### PR TITLE
[codex] align Symphony workitem orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@
 **Fizzy Symphony** is a Python scaffold for planning card-based automation on top
 of [Fizzy](https://github.com/fizzy-project/fizzy). The scaffold treats **Fizzy
 as the tracker and board system**, normalizes cards into a canonical `FizzyCard`
-shape, and keeps all adapter behavior dry-run only for now.
+shape, and keeps tracker mutations dry-run-first while the durable queue layer
+is delegated to `robocorp-adapters-custom`.
+
+The design follows the original OpenAI Symphony model: an existing tracker board
+is the human source of truth, one issue/card is claimed at a time, Codex works in
+an isolated workspace, and proof is reported back to the same issue/card. The
+main divergence is implementation plumbing: this project can use Robocorp
+workitems as the durable claimed/running/result queue instead of keeping that
+state only inside a long-running daemon.
 
 It provides:
 
@@ -17,7 +25,8 @@ It provides:
 |---|---|
 | **Models** | Pure Python dataclasses (`FizzyCard`, `Agent`, `CardAdapter`, `Board`, `FizzyConfig`) |
 | **Adapter** | A dry-run `FizzyCLIAdapter` that builds real Fizzy CLI commands without executing them |
-| **CLI** | `fizzy-symphony` entry points for dry-run list/claim/comment/move flows and a demo plan |
+| **CLI** | `fizzy-symphony` entry points for board bootstrap, setup checks, dry-run list/claim/comment/move flows, and a demo plan |
+| **Workitems** | Robocorp-compatible queue payloads, adapter env helpers, and producer/worker/reporter helpers |
 
 ## Main Mapping
 
@@ -28,11 +37,14 @@ It provides:
 | Project | Fizzy board |
 | State | Fizzy list/column |
 | Comment | Fizzy card comment/update |
-| Worker | Codex app-server session |
+| Orchestrator state | Robocorp workitem reservation/release/output state |
+| Worker | Codex command/app-server session |
 | Workflow contract | WORKFLOW.md |
 | Workspace | Per-card branch/worktree |
 
 > **Status:** Pre-alpha scaffold — no real Fizzy or Codex execution yet.
+> The durable orchestration direction is now Robocorp workitems/RCC: Fizzy stays
+> the board, workitems provide queue leasing/release, and Codex is the worker.
 
 ---
 
@@ -41,6 +53,18 @@ It provides:
 ```bash
 # Install in editable mode (requires Python ≥ 3.9)
 pip install -e ".[dev]"
+
+# Optional: install Robocorp workitems adapter support
+pip install -e ".[workitems]"
+
+# Check how this checkout maps to the upstream Symphony model
+fizzy-symphony doctor --board work-ai-board
+
+# Print dry-run commands for preparing an existing Fizzy board
+fizzy-symphony init-board --board work-ai-board
+
+# Print default env JSON for robocorp-adapters-custom
+fizzy-symphony workitems-env
 
 # Print the dry-run Fizzy command for listing a board
 fizzy-symphony list --board work-ai-board --dry-run
@@ -68,6 +92,36 @@ pip install -e ".[dev]"
 ---
 
 ## CLI Commands
+
+### `fizzy-symphony doctor`
+
+Prints a deterministic setup checklist and maps upstream OpenAI Symphony
+concepts onto this Fizzy/RCC implementation.
+
+```bash
+fizzy-symphony doctor --board work-ai-board
+```
+
+### `fizzy-symphony init-board`
+
+Prints dry-run commands for preparing an existing Fizzy board with the
+recommended Symphony-style columns. It does not create a hidden system board by
+default.
+
+```bash
+fizzy-symphony init-board --board work-ai-board
+# fizzy column list --board work-ai-board --agent --quiet
+# fizzy column create --board work-ai-board --name 'Ready for Agents' --agent --quiet
+```
+
+### `fizzy-symphony workitems-env`
+
+Prints the default environment contract for the published
+`robocorp-adapters-custom` package.
+
+```bash
+fizzy-symphony workitems-env
+```
 
 ### `fizzy-symphony list`
 
@@ -136,7 +190,11 @@ fizzy-symphony/
 │       ├── cli.py                  # CLI entry point
 │       ├── commands.py             # Compatibility wrappers over the adapter
 │       ├── models.py               # FizzyCard, Agent, CardAdapter, Board, FizzyConfig
-│       └── tracker.py              # Tracker adapter contract
+│       ├── robocorp_adapter.py     # Published adapter package loader/env contract
+│       ├── symphony.py             # OpenAI Symphony concept mapping and board bootstrap
+│       ├── tracker.py              # Tracker adapter contract
+│       ├── workitem_pipeline.py    # Fizzy/workitems/Codex pipeline helpers
+│       └── workitem_queue.py       # Robocorp-compatible work item payload/queue seam
 ├── tests/
 │   ├── test_adapters_fizzy_cli.py
 │   ├── test_cli.py
@@ -166,6 +224,8 @@ python -m pytest
 - `WORKFLOW.example.md` shows a board/workspace/agent configuration and a worker prompt body.
 - `prompts/program-lead.md` guides the lead agent on board coordination and state transitions.
 - `prompts/worker-agent.md` guides a worker to claim exactly one card, stay within allowed paths, and report proof of work.
+- `docs/openai-symphony-alignment.md` explains how this maps to the upstream OpenAI Symphony model.
+- `docs/rcc-workitems.md` describes the RCC/workitems refactor path.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -6,6 +6,20 @@ Fizzy Symphony is a dry-run-first scaffold for orchestrating coding agents
 against a Fizzy board. Its job is to normalize tracker data, define safe state
 transitions, and produce the exact Fizzy CLI commands that later phases may run.
 
+The architecture follows OpenAI Symphony's tracker-first model: the existing
+tracker board remains the human source of truth, one issue/card maps to one
+agent task, and worker proof is written back to the original issue/card. This
+project diverges by using Robocorp workitems as durable queue plumbing for
+claimed/running/result state instead of treating one daemon process as the only
+owner of orchestration state.
+
+Boundary:
+
+- `fizzy-symphony` owns board semantics, workflow state, Codex runner policy,
+  workspace policy, and reporter output.
+- `robocorp-adapters-custom` owns reserve/release/fail/output queue mechanics.
+- Fizzy owns the visible board, cards, comments, and columns.
+
 ## Core Domain Model
 
 - `FizzyCard`: canonical normalized tracker card.
@@ -14,6 +28,9 @@ transitions, and produce the exact Fizzy CLI commands that later phases may run.
 - `Board`: ordered collection of cards for a Fizzy board.
 - `TrackerAdapter`: contract for reading cards and writing comments/state updates.
 - `FizzyCLIAdapter`: dry-run adapter that builds Fizzy CLI commands.
+- `SymphonyColumn`: recommended tracker column for the upstream-inspired flow.
+- `RobocorpWorkitemConfig`: environment contract for the published adapter
+  package.
 
 ## Normalized Fizzy Card Shape
 
@@ -67,6 +84,19 @@ already under active execution:
 - `Synthesize & Verify`
 - `Ready to Ship`
 
+## Recommended Board Columns
+
+Fizzy Symphony expects an existing board by default. `fizzy-symphony init-board`
+prints dry-run commands to add any missing recommended columns:
+
+- `Shaping`
+- `Ready for Agents`
+- `In Flight`
+- `Needs Input`
+- `Synthesize & Verify`
+- `Ready to Ship`
+- `Done`
+
 ## Terminal States
 
 Terminal states indicate no more automated work should occur:
@@ -104,6 +134,8 @@ passes, and preserve the card as the source of truth for scope and status.
 - Phase 0 is dry-run only; no subprocess execution is allowed.
 - No direct HTTP or API behavior is allowed in the scaffold.
 - No daemon/background loop behavior is allowed yet.
+- The system must not create a hidden board by default; it configures or checks
+  an existing Fizzy board unless the user explicitly opts into creation later.
 - Fizzy CLI mutations must target the visible card `number`, not only the internal `id`.
 - Workers claim exactly one card at a time.
 - Workers may edit only approved paths for the claimed card.

--- a/docs/openai-symphony-alignment.md
+++ b/docs/openai-symphony-alignment.md
@@ -1,0 +1,83 @@
+# OpenAI Symphony Alignment
+
+## TL;DR
+
+Fizzy Symphony follows the original OpenAI Symphony product model, not the exact
+runtime implementation.
+
+```text
+OpenAI Symphony:
+Linear issue -> orchestrator state -> Codex workspace/session -> Linear update
+
+Fizzy Symphony:
+Fizzy card -> Robocorp workitem state -> Codex workspace/command -> Fizzy update
+```
+
+The visible tracker remains the source of truth in both systems. The durable
+queue layer is the deliberate divergence.
+
+## Concept Mapping
+
+| OpenAI Symphony | Fizzy Symphony | Why |
+| --- | --- | --- |
+| Linear project | Existing Fizzy board | Keep work visible to humans in the tracker. |
+| Linear issue | Fizzy card | One unit of agent work. |
+| Linear status | Fizzy column | Human-readable workflow state. |
+| Orchestrator state | Robocorp workitem state | Durable reserve/release/fail/output semantics. |
+| Codex app-server session | Codex worker command/session | One isolated worker per card. |
+| Issue comment | Fizzy comment | Proof of work goes back to the original card. |
+| `WORKFLOW.md` | `WORKFLOW.md` / `WORKFLOW.example.md` | Repo-owned workflow contract. |
+
+## Board Ownership
+
+Fizzy Symphony does not create a hidden board by default. It expects an existing
+Fizzy board and can print a bootstrap plan for recommended columns:
+
+```bash
+fizzy-symphony init-board --board <board-id>
+```
+
+Recommended columns:
+
+- `Shaping`
+- `Ready for Agents`
+- `In Flight`
+- `Needs Input`
+- `Synthesize & Verify`
+- `Ready to Ship`
+- `Done`
+
+## Package Boundary
+
+`robocorp-adapters-custom` should stay boring and durable:
+
+- select backend from environment
+- seed input items
+- reserve input items
+- create output items
+- release items as done or failed
+- store files/attachments
+- recover orphaned reserved items
+
+`fizzy-symphony` should own orchestration:
+
+- Fizzy board/column semantics
+- OpenAI Symphony concept mapping
+- `WORKFLOW.md` policy
+- per-card workspace policy
+- Codex runner configuration
+- producer/worker/reporter CLI UX
+- proof/report formatting
+
+## Local Happy Path
+
+```bash
+pip install -e ".[dev,workitems]"
+fizzy-symphony doctor --board <board-id>
+fizzy-symphony init-board --board <board-id>
+fizzy-symphony workitems-env
+```
+
+Then use the producer/worker/reporter helpers with a Robocorp-compatible adapter.
+The workitem queue is invisible plumbing; the Fizzy card remains where humans
+read scope, comments, state, and proof.

--- a/docs/rcc-workitems.md
+++ b/docs/rcc-workitems.md
@@ -1,0 +1,81 @@
+# RCC Workitems Architecture
+
+Fizzy Symphony should not own durable queue mechanics. Robocorp workitems and
+Josh's `robocorp_adapters_custom` already provide the right execution substrate:
+reserve, release, output chaining, backend switching, and orphan recovery.
+
+This keeps the project aligned with OpenAI Symphony without copying its daemon
+implementation directly. Upstream Symphony keeps claimed/running/retry state in
+the orchestrator process; this project can persist that same state in Robocorp
+workitems so RCC tasks, local workers, and future services can share it safely.
+
+## Target Shape
+
+- Fizzy remains the board and source of truth.
+- `robocorp.workitems` becomes the durable queue API.
+- `robocorp_adapters_custom` supplies SQLite, Redis, DocumentDB, or Yorko Control
+  Room storage.
+- Codex runs inside a worker task and reports proof through work item outputs.
+- A reporter task consumes worker outputs and updates Fizzy comments/states.
+- `fizzy-symphony` owns all Symphony-specific semantics: board columns,
+  `WORKFLOW.md`, per-card workspaces, runner policy, and report formatting.
+
+## Pipeline
+
+```text
+Fizzy board
+  -> FizzyWorkItemProducer
+  -> input queue
+  -> CodexWorkItemWorker
+  -> result queue
+  -> FizzyWorkItemReporter
+  -> Fizzy comment/state update
+```
+
+## Local Dev Backend
+
+Use SQLite first:
+
+```json
+{
+  "RC_WORKITEM_ADAPTER": "robocorp_adapters_custom._sqlite.SQLiteAdapter",
+  "RC_WORKITEM_QUEUE_NAME": "fizzy_codex_input",
+  "RC_WORKITEM_OUTPUT_QUEUE_NAME": "fizzy_codex_results",
+  "RC_WORKITEM_DB_PATH": "./output/fizzy-symphony-workitems.db",
+  "RC_WORKITEM_FILES_DIR": "./output/workitem-files"
+}
+```
+
+## Current Code
+
+- `fizzy_symphony.workitem_queue.WorkItemQueue` wraps Robocorp-compatible
+  adapters without hard-coding a backend.
+- `FizzyWorkItemPayload` defines the card/workflow/runner payload contract.
+- `FizzyWorkItemProducer` turns tracker candidate cards into queue items.
+- `CodexWorkItemWorker` reserves one item and delegates work to an injected
+  runner.
+- `FizzyWorkItemReporter` consumes one result and calls the tracker comment/state
+  contract.
+
+## Adapter Augmentation
+
+Tracked upstream in:
+
+https://github.com/joshyorko/robocorp_adapters_custom/issues/8
+
+Main missing pieces are duplicate prevention/idempotency, queue metrics, and
+clean examples for the three-stage Fizzy/Codex flow.
+
+## Boundary Decision
+
+The adapter package may keep Fizzy examples, but the application brain belongs
+in this repository:
+
+- Adapter package: backend selection, queue persistence, reserve/release/fail,
+  outputs, files, and orphan recovery.
+- Fizzy Symphony: Fizzy CLI tracker integration, OpenAI Symphony mapping,
+  producer/worker/reporter policy, and CLI user experience.
+
+That split keeps the cool RCC/workitems backend while preserving the simple
+upstream mental model: tracker issue/card in, isolated Codex work out, proof
+back on the same tracker issue/card.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,9 +1,11 @@
 # Roadmap
 
 - [x] Phase 0: spec/scaffold
-- [ ] Phase 1: CLI-backed Fizzy adapter
-- [ ] Phase 2: dispatch loop
-- [ ] Phase 3: workspace manager
+- [x] Phase 0.5: Robocorp workitems queue seam
+- [x] Phase 0.6: OpenAI Symphony alignment and board bootstrap docs
+- [ ] Phase 1: Real CLI-backed Fizzy tracker adapter
+- [ ] Phase 2: Fizzy producer -> workitems queue CLI command
+- [ ] Phase 3: Codex workitem worker and RCC task wrappers
 - [ ] Phase 4: Codex app-server runner
-- [ ] Phase 5: dashboard/observability
+- [ ] Phase 5: reporter/observability back to Fizzy
 - [ ] Phase 6: hardened safety model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
+workitems = [
+    "robocorp-workitems>=1.4.7; python_version >= '3.10'",
+    "robocorp-adapters-custom>=0.1.4; python_version >= '3.10'",
+]
 dev = [
     "pytest>=7.4",
     "pytest-cov>=4.1",

--- a/src/fizzy_symphony/__init__.py
+++ b/src/fizzy_symphony/__init__.py
@@ -16,7 +16,11 @@ from .commands import (
     build_workflow_plan,
 )
 from .models import Agent, Board, CardAdapter, FizzyCard, FizzyConfig, Workflow
+from .robocorp_adapter import RobocorpWorkitemConfig
+from .symphony import SymphonyColumn, SymphonyMapping
 from .tracker import TrackerAdapter
+from .workitem_pipeline import CodexWorkItemWorker, FizzyWorkItemProducer, FizzyWorkItemReporter
+from .workitem_queue import FizzyWorkItemPayload, ReservedWorkItem, WorkItemQueue, WorkItemState
 
 __all__ = [
     "Agent",
@@ -25,7 +29,17 @@ __all__ = [
     "FizzyCard",
     "FizzyConfig",
     "FizzyCLIAdapter",
+    "FizzyWorkItemPayload",
+    "FizzyWorkItemProducer",
+    "FizzyWorkItemReporter",
+    "RobocorpWorkitemConfig",
+    "CodexWorkItemWorker",
+    "ReservedWorkItem",
+    "SymphonyColumn",
+    "SymphonyMapping",
     "TrackerAdapter",
+    "WorkItemQueue",
+    "WorkItemState",
     "Workflow",
     "build_board_plan",
     "build_card_claim_command",

--- a/src/fizzy_symphony/adapters/fizzy_cli.py
+++ b/src/fizzy_symphony/adapters/fizzy_cli.py
@@ -24,6 +24,34 @@ class FizzyCLIAdapter:
         """Build the recommended health check command."""
         return " ".join([quote(self.config.fizzy_bin), "doctor"])
 
+    def build_column_list_command(self, board: Optional[str] = None) -> str:
+        """Build the Fizzy CLI command used to list board columns."""
+        parts: List[str] = [quote(self.config.fizzy_bin), "column", "list"]
+        parts.extend(self._board_flag_parts(board))
+        parts.extend(self._agent_quiet_parts())
+        parts.extend(self.config.extra_flags)
+        return " ".join(parts)
+
+    def build_column_create_command(self, board: str, name: str) -> str:
+        """Build the Fizzy CLI command used to create a board column."""
+        self._ensure_dry_run()
+        if not board:
+            raise ValueError("board must not be empty.")
+        if not name:
+            raise ValueError("name must not be empty.")
+        parts: List[str] = [
+            quote(self.config.fizzy_bin),
+            "column",
+            "create",
+            "--board",
+            quote(board),
+            "--name",
+            quote(name),
+        ]
+        parts.extend(self._agent_quiet_parts())
+        parts.extend(self.config.extra_flags)
+        return " ".join(parts)
+
     def build_list_command(self, board: Optional[str] = None) -> str:
         """Build the Fizzy CLI command used to list board cards."""
         parts: List[str] = [quote(self.config.fizzy_bin), "card", "list"]

--- a/src/fizzy_symphony/cli.py
+++ b/src/fizzy_symphony/cli.py
@@ -10,6 +10,12 @@ from . import __version__
 from .adapters.fizzy_cli import FizzyCLIAdapter
 from .commands import build_board_plan, format_plan_as_text
 from .models import Agent, Board, CardAdapter, FizzyConfig
+from .robocorp_adapter import (
+    RobocorpWorkitemConfig,
+    adapter_package_available,
+    format_workitem_env,
+)
+from .symphony import format_init_board_plan, format_mapping_table
 
 
 def _build_demo_board() -> Board:
@@ -79,6 +85,45 @@ def _cmd_plan(args: argparse.Namespace) -> int:
     plan = build_board_plan(board, config)
     print(format_plan_as_text(plan))
     print("(dry-run mode — no commands were executed)")
+    return 0
+
+
+def _cmd_doctor(args: argparse.Namespace) -> int:
+    """Print a deterministic readiness checklist for the local integration."""
+    config = _config_from_args(args)
+    adapter_status = "available" if adapter_package_available() else "missing"
+    board = args.board or "FIZZY_BOARD / .fizzy.yaml"
+
+    print("Fizzy Symphony Doctor")
+    print("")
+    print(f"Fizzy CLI check : {FizzyCLIAdapter(config=config).build_doctor_command()}")
+    print(f"Board context   : {board}")
+    print(f"Adapter package : robocorp-adapters-custom ({adapter_status})")
+    print("Adapter role    : durable queue plumbing only")
+    print("Orchestrator    : fizzy-symphony owns Symphony semantics")
+    print("")
+    print(format_mapping_table())
+    return 0
+
+
+def _cmd_init_board(args: argparse.Namespace) -> int:
+    """Print dry-run commands for preparing an existing Fizzy board."""
+    print(format_init_board_plan(args.board, fizzy_bin=args.fizzy_bin))
+    print("")
+    print("(dry-run mode — create only the columns that are missing)")
+    return 0
+
+
+def _cmd_workitems_env(args: argparse.Namespace) -> int:
+    """Print default environment variables for the published adapter package."""
+    config = RobocorpWorkitemConfig(
+        adapter=args.adapter,
+        queue_name=args.queue_name,
+        output_queue_name=args.output_queue_name,
+        db_path=args.db_path,
+        files_dir=args.files_dir,
+    )
+    print(format_workitem_env(config))
     return 0
 
 
@@ -156,6 +201,53 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Reserved per-card timeout in seconds for future execution support (default: 300).",
     )
 
+    doctor_p = sub.add_parser(
+        "doctor",
+        help="Print setup checks and the upstream Symphony mapping.",
+    )
+    _add_common_command_options(doctor_p)
+    doctor_p.add_argument(
+        "--board",
+        metavar="BOARD_ID",
+        help="Fizzy board ID to validate conceptually; otherwise use FIZZY_BOARD/.fizzy.yaml.",
+    )
+
+    init_p = sub.add_parser(
+        "init-board",
+        help="Print dry-run commands for preparing an existing Fizzy board.",
+    )
+    _add_common_command_options(init_p, include_board=True)
+
+    env_p = sub.add_parser(
+        "workitems-env",
+        help="Print default robocorp-adapters-custom environment variables.",
+    )
+    env_p.add_argument(
+        "--adapter",
+        default=RobocorpWorkitemConfig.adapter,
+        help="Fully qualified adapter class path.",
+    )
+    env_p.add_argument(
+        "--queue-name",
+        default=RobocorpWorkitemConfig.queue_name,
+        help="Input queue name used by producer/worker.",
+    )
+    env_p.add_argument(
+        "--output-queue-name",
+        default=RobocorpWorkitemConfig.output_queue_name,
+        help="Output queue name used by worker/reporter.",
+    )
+    env_p.add_argument(
+        "--db-path",
+        default=RobocorpWorkitemConfig.db_path,
+        help="SQLite database path for local development.",
+    )
+    env_p.add_argument(
+        "--files-dir",
+        default=RobocorpWorkitemConfig.files_dir,
+        help="Attachment directory for local development.",
+    )
+
     list_p = sub.add_parser("list", help="Print the Fizzy CLI command for listing cards on a board.")
     _add_common_command_options(list_p, include_board=True)
 
@@ -184,6 +276,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     dispatch = {
         "version": _cmd_version,
         "plan": _cmd_plan,
+        "doctor": _cmd_doctor,
+        "init-board": _cmd_init_board,
+        "workitems-env": _cmd_workitems_env,
         "list": _cmd_list,
         "claim": _cmd_claim,
         "comment": _cmd_comment,

--- a/src/fizzy_symphony/robocorp_adapter.py
+++ b/src/fizzy_symphony/robocorp_adapter.py
@@ -1,0 +1,67 @@
+"""Published robocorp-adapters-custom integration helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Dict
+
+
+@dataclass(frozen=True)
+class RobocorpWorkitemConfig:
+    """Environment contract for the published custom workitem adapters."""
+
+    adapter: str = "robocorp_adapters_custom._sqlite.SQLiteAdapter"
+    queue_name: str = "fizzy_codex_input"
+    output_queue_name: str = "fizzy_codex_results"
+    db_path: str = "./output/fizzy-symphony-workitems.db"
+    files_dir: str = "./output/workitem-files"
+
+    def as_env(self) -> Dict[str, str]:
+        """Return environment variables consumed by robocorp-adapters-custom."""
+        return {
+            "RC_WORKITEM_ADAPTER": self.adapter,
+            "RC_WORKITEM_QUEUE_NAME": self.queue_name,
+            "RC_WORKITEM_OUTPUT_QUEUE_NAME": self.output_queue_name,
+            "RC_WORKITEM_DB_PATH": self.db_path,
+            "RC_WORKITEM_FILES_DIR": self.files_dir,
+        }
+
+
+def format_workitem_env(config: RobocorpWorkitemConfig) -> str:
+    """Render the default adapter environment as JSON for copy/paste or RCC env files."""
+    return json.dumps(config.as_env(), indent=2, sort_keys=True)
+
+
+def adapter_package_available() -> bool:
+    """Return whether the optional published adapter package can be imported."""
+    try:
+        import_module("robocorp_adapters_custom.workitems_integration")
+    except ImportError:
+        return False
+    return True
+
+
+def initialize_adapter_from_environment() -> Any:
+    """Initialize the active adapter using robocorp-adapters-custom.
+
+    The adapter package owns durable queue plumbing. Fizzy Symphony owns the
+    Symphony-style orchestration semantics around it.
+    """
+    try:
+        integration = import_module("robocorp_adapters_custom.workitems_integration")
+    except ImportError as exc:
+        raise RuntimeError(
+            "Install workitem support first: pip install -e '.[workitems]' "
+            "or pip install robocorp-adapters-custom."
+        ) from exc
+
+    try:
+        initialize_adapter = integration.initialize_adapter
+    except AttributeError as exc:
+        raise RuntimeError(
+            "robocorp-adapters-custom does not expose initialize_adapter()."
+        ) from exc
+
+    return initialize_adapter()

--- a/src/fizzy_symphony/symphony.py
+++ b/src/fizzy_symphony/symphony.py
@@ -1,0 +1,154 @@
+"""OpenAI Symphony alignment primitives.
+
+This module keeps the public mental model close to upstream Symphony while
+letting Fizzy Symphony use Fizzy and Robocorp workitems underneath.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from shlex import quote
+from typing import List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class SymphonyColumn:
+    """Recommended Fizzy column for a Symphony-style board."""
+
+    name: str
+    role: str
+    upstream_state: Optional[str]
+    description: str
+
+
+@dataclass(frozen=True)
+class SymphonyMapping:
+    """Concept mapping between upstream Symphony and this implementation."""
+
+    upstream: str
+    fizzy_symphony: str
+    note: str
+
+
+RECOMMENDED_COLUMNS: Tuple[SymphonyColumn, ...] = (
+    SymphonyColumn(
+        name="Shaping",
+        role="Backlog/refinement",
+        upstream_state="Backlog",
+        description="Human-scoped work that is not ready for an agent yet.",
+    ),
+    SymphonyColumn(
+        name="Ready for Agents",
+        role="Agent intake",
+        upstream_state="Todo",
+        description="Cards eligible for producer enqueueing.",
+    ),
+    SymphonyColumn(
+        name="In Flight",
+        role="Claimed/running",
+        upstream_state="In Progress",
+        description="Cards currently owned by an automated worker.",
+    ),
+    SymphonyColumn(
+        name="Needs Input",
+        role="Blocked handoff",
+        upstream_state="Blocked",
+        description="Worker needs human clarification before continuing.",
+    ),
+    SymphonyColumn(
+        name="Synthesize & Verify",
+        role="Human review",
+        upstream_state="Human Review",
+        description="Completed worker output awaiting review or integration.",
+    ),
+    SymphonyColumn(
+        name="Ready to Ship",
+        role="Integration",
+        upstream_state="Ready",
+        description="Verified work that can be merged or released.",
+    ),
+    SymphonyColumn(
+        name="Done",
+        role="Terminal",
+        upstream_state="Done",
+        description="No more automated work should occur.",
+    ),
+)
+
+
+UPSTREAM_MAPPING: Tuple[SymphonyMapping, ...] = (
+    SymphonyMapping(
+        upstream="Linear project",
+        fizzy_symphony="Fizzy board",
+        note="Existing tracker workspace; not created automatically by default.",
+    ),
+    SymphonyMapping(
+        upstream="Linear issue",
+        fizzy_symphony="Fizzy card",
+        note="The visible card remains the human source of truth.",
+    ),
+    SymphonyMapping(
+        upstream="Orchestrator state",
+        fizzy_symphony="Robocorp workitem state",
+        note="Reserve/release/fail/output chaining lives in the adapter backend.",
+    ),
+    SymphonyMapping(
+        upstream="Codex app-server session",
+        fizzy_symphony="Codex worker command",
+        note="Workers consume one queued card payload at a time.",
+    ),
+    SymphonyMapping(
+        upstream="Issue comment/status update",
+        fizzy_symphony="Fizzy comment/column update",
+        note="Reporter publishes proof back to the original card.",
+    ),
+    SymphonyMapping(
+        upstream="WORKFLOW.md",
+        fizzy_symphony="WORKFLOW.md / WORKFLOW.example.md",
+        note="Repository-owned workflow contract should drive worker behavior.",
+    ),
+)
+
+
+def recommended_columns() -> List[SymphonyColumn]:
+    """Return a copy of the recommended board columns."""
+    return list(RECOMMENDED_COLUMNS)
+
+
+def upstream_mapping() -> List[SymphonyMapping]:
+    """Return a copy of the upstream-to-Fizzy mapping."""
+    return list(UPSTREAM_MAPPING)
+
+
+def format_init_board_plan(board_id: str, *, fizzy_bin: str = "fizzy") -> str:
+    """Render dry-run commands for preparing an existing Fizzy board."""
+    if not board_id:
+        raise ValueError("board_id is required")
+
+    lines = [
+        "Fizzy Symphony board bootstrap plan",
+        "",
+        "This follows upstream Symphony: configure an existing tracker board; do not",
+        "create a hidden system board by default.",
+        "",
+        f"Board: {board_id}",
+        "",
+        "Check existing columns first:",
+        f"{quote(fizzy_bin)} column list --board {quote(board_id)} --agent --quiet",
+        "",
+        "Create any missing columns:",
+    ]
+    for column in RECOMMENDED_COLUMNS:
+        lines.append(
+            f"{quote(fizzy_bin)} column create --board {quote(board_id)} "
+            f"--name {quote(column.name)} --agent --quiet"
+        )
+    return "\n".join(lines)
+
+
+def format_mapping_table() -> str:
+    """Render a compact text table explaining how this follows Symphony."""
+    lines = ["OpenAI Symphony mapping", ""]
+    for mapping in UPSTREAM_MAPPING:
+        lines.append(f"- {mapping.upstream} -> {mapping.fizzy_symphony}: {mapping.note}")
+    return "\n".join(lines)

--- a/src/fizzy_symphony/workitem_pipeline.py
+++ b/src/fizzy_symphony/workitem_pipeline.py
@@ -1,0 +1,120 @@
+"""Fizzy -> Workitems -> Codex -> Fizzy pipeline helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Protocol
+
+from .models import FizzyCard
+from .tracker import TrackerAdapter
+from .workitem_queue import FizzyWorkItemPayload, JSONDict, WorkItemQueue
+
+
+class WorkItemRunner(Protocol):
+    def __call__(self, payload: FizzyWorkItemPayload) -> JSONDict: ...
+
+
+@dataclass(frozen=True)
+class WorkerResult:
+    item_id: str
+    output_id: Optional[str]
+    succeeded: bool
+
+
+@dataclass(frozen=True)
+class ReporterResult:
+    item_id: str
+    reported: bool
+
+
+@dataclass
+class FizzyWorkItemProducer:
+    """Enqueue eligible Fizzy cards as durable work items."""
+
+    tracker: TrackerAdapter
+    queue: WorkItemQueue
+    board_id: Optional[str]
+    prompt_template: str = ""
+    allowed_paths: List[str] | None = None
+    handoff_column: str = "Synthesize & Verify"
+    runner_command: str = "codex exec --json"
+
+    def produce(self) -> List[str]:
+        item_ids: List[str] = []
+        for card in self.tracker.fetch_candidate_cards():
+            payload = self._payload_for(card)
+            item_ids.append(self.queue.enqueue_input(payload))
+        return item_ids
+
+    def _payload_for(self, card: FizzyCard) -> FizzyWorkItemPayload:
+        return FizzyWorkItemPayload.from_card(
+            card,
+            board_id=self.board_id,
+            prompt_template=self.prompt_template,
+            allowed_paths=list(self.allowed_paths or []),
+            handoff_column=self.handoff_column,
+            runner_command=self.runner_command,
+        )
+
+
+@dataclass
+class CodexWorkItemWorker:
+    """Reserve one work item and pass it to a configured Codex runner."""
+
+    queue: WorkItemQueue
+    runner: WorkItemRunner
+    failure_code: str = "CODEX_WORKER_FAILED"
+
+    def work_one(self) -> WorkerResult:
+        item = self.queue.reserve()
+        payload = FizzyWorkItemPayload.from_dict(item.payload)
+        try:
+            runner_result = self.runner(payload)
+        except Exception as exc:
+            self.queue.fail(item.id, message=str(exc), code=self.failure_code)
+            return WorkerResult(item_id=item.id, output_id=None, succeeded=False)
+
+        output_payload = self._output_payload(payload, runner_result)
+        output_id = self.queue.complete(item.id, output_payload)
+        return WorkerResult(item_id=item.id, output_id=output_id, succeeded=True)
+
+    @staticmethod
+    def _output_payload(payload: FizzyWorkItemPayload, result: JSONDict) -> JSONDict:
+        return {
+            "source": payload.source,
+            "card_id": payload.card.get("id"),
+            "card_number": payload.card.get("number"),
+            "comment": result.get("comment", ""),
+            "handoff_state": result.get(
+                "handoff_state",
+                payload.workflow.get("handoff_column", "Synthesize & Verify"),
+            ),
+            "runner": payload.runner,
+            "result": dict(result),
+        }
+
+
+@dataclass
+class FizzyWorkItemReporter:
+    """Report one completed work item result back to the tracker."""
+
+    queue: WorkItemQueue
+    tracker: TrackerAdapter
+    failure_code: str = "FIZZY_REPORTER_FAILED"
+
+    def report_one(self) -> ReporterResult:
+        item = self.queue.reserve()
+        try:
+            payload = item.payload
+            card_id = str(payload["card_id"])
+            comment = str(payload.get("comment") or "Codex work item completed.")
+            handoff_state = str(payload.get("handoff_state") or "Synthesize & Verify")
+
+            self.tracker.create_comment(card_id, comment)
+            self.tracker.update_card_state(card_id, handoff_state)
+            self.queue.complete(item.id, {"reported": True, "card_id": card_id})
+        except Exception as exc:
+            self.queue.fail(item.id, message=str(exc), code=self.failure_code)
+            return ReporterResult(item_id=item.id, reported=False)
+
+        return ReporterResult(item_id=item.id, reported=True)

--- a/src/fizzy_symphony/workitem_queue.py
+++ b/src/fizzy_symphony/workitem_queue.py
@@ -1,0 +1,145 @@
+"""Robocorp work item queue integration primitives."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional, Protocol
+
+from .models import FizzyCard
+
+
+JSONDict = Dict[str, Any]
+
+
+class WorkItemState(str, Enum):
+    """Release states compatible with robocorp.workitems adapters."""
+
+    DONE = "COMPLETED"
+    FAILED = "FAILED"
+
+
+class WorkItemAdapter(Protocol):
+    """Subset of robocorp.workitems BaseAdapter used by Fizzy Symphony."""
+
+    def reserve_input(self) -> str: ...
+
+    def release_input(
+        self,
+        item_id: str,
+        state: WorkItemState,
+        exception: Optional[JSONDict] = None,
+    ) -> None: ...
+
+    def create_output(self, parent_id: str, payload: Optional[JSONDict] = None) -> str: ...
+
+    def load_payload(self, item_id: str) -> JSONDict: ...
+
+    def save_payload(self, item_id: str, payload: JSONDict) -> None: ...
+
+
+@dataclass(frozen=True)
+class ReservedWorkItem:
+    """Reserved work item payload from an adapter."""
+
+    id: str
+    payload: JSONDict
+
+
+@dataclass(frozen=True)
+class FizzyWorkItemPayload:
+    """Stable payload contract for turning Fizzy cards into work items."""
+
+    source: str
+    card: JSONDict
+    workflow: JSONDict
+    runner: JSONDict
+
+    @classmethod
+    def from_card(
+        cls,
+        card: FizzyCard,
+        *,
+        board_id: Optional[str],
+        prompt_template: str = "",
+        allowed_paths: Optional[List[str]] = None,
+        handoff_column: str = "Synthesize & Verify",
+        runner_command: str = "codex exec --json",
+    ) -> "FizzyWorkItemPayload":
+        card_data = asdict(card)
+        card_data["board_id"] = board_id
+        return cls(
+            source="fizzy",
+            card=card_data,
+            workflow={
+                "prompt_template": prompt_template,
+                "allowed_paths": list(allowed_paths or []),
+                "handoff_column": handoff_column,
+            },
+            runner={
+                "kind": "codex",
+                "command": runner_command,
+            },
+        )
+
+    @classmethod
+    def from_dict(cls, payload: JSONDict) -> "FizzyWorkItemPayload":
+        source = payload.get("source")
+        if source != "fizzy":
+            raise ValueError(f"unsupported work item source: {source!r}")
+        return cls(
+            source=source,
+            card=dict(payload.get("card") or {}),
+            workflow=dict(payload.get("workflow") or {}),
+            runner=dict(payload.get("runner") or {}),
+        )
+
+    def to_dict(self) -> JSONDict:
+        return {
+            "source": self.source,
+            "card": dict(self.card),
+            "workflow": dict(self.workflow),
+            "runner": dict(self.runner),
+        }
+
+
+class WorkItemQueue:
+    """Thin wrapper over a Robocorp-compatible work item adapter.
+
+    This keeps durable queue mechanics in the workitems layer while Fizzy
+    Symphony owns only the card payload contract and orchestration semantics.
+    """
+
+    def __init__(self, adapter: WorkItemAdapter) -> None:
+        self.adapter = adapter
+
+    def enqueue_input(self, payload: FizzyWorkItemPayload) -> str:
+        seed_input = getattr(self.adapter, "seed_input", None)
+        if not callable(seed_input):
+            raise RuntimeError(
+                "Adapter must provide seed_input(payload=...) to enqueue root Fizzy work items."
+            )
+        return str(seed_input(payload=payload.to_dict()))
+
+    def reserve(self) -> ReservedWorkItem:
+        item_id = self.adapter.reserve_input()
+        payload = self.adapter.load_payload(item_id)
+        if not isinstance(payload, dict):
+            raise ValueError("Work item payload must be a JSON object.")
+        return ReservedWorkItem(id=item_id, payload=payload)
+
+    def complete(self, item_id: str, result_payload: JSONDict) -> str:
+        output_id = self.adapter.create_output(item_id, payload=result_payload)
+        self.adapter.release_input(item_id, WorkItemState.DONE, exception=None)
+        return output_id
+
+    def fail(self, item_id: str, *, message: str, code: Optional[str] = None) -> None:
+        self.adapter.release_input(
+            item_id,
+            WorkItemState.FAILED,
+            exception={
+                "type": "APPLICATION",
+                "code": code,
+                "message": message,
+            },
+        )

--- a/tests/test_adapters_fizzy_cli.py
+++ b/tests/test_adapters_fizzy_cli.py
@@ -17,6 +17,19 @@ def test_build_list_command_uses_explicit_board():
     assert cmd == "fizzy card list --board work-ai-board --agent --markdown"
 
 
+def test_build_column_commands_use_existing_board():
+    adapter = _make_adapter()
+
+    assert (
+        adapter.build_column_list_command("board-1")
+        == "fizzy column list --board board-1 --agent --quiet"
+    )
+    assert (
+        adapter.build_column_create_command("board-1", "Ready for Agents")
+        == "fizzy column create --board board-1 --name 'Ready for Agents' --agent --quiet"
+    )
+
+
 def test_build_claim_command_uses_card_number_and_board():
     cmd = _make_adapter().build_claim_command(42, "work-ai-board")
     assert cmd == "fizzy card claim 42 --board work-ai-board --agent --quiet"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import json
+
 from fizzy_symphony.cli import main
 
 
@@ -20,6 +22,37 @@ def test_plan_command_prints_board_plan(capsys):
     assert "fizzy doctor" in captured.out
     assert "fizzy card claim 42 --board work-ai-board" in captured.out
     assert "(dry-run mode — no commands were executed)" in captured.out
+
+
+def test_doctor_command_prints_symphony_mapping(capsys):
+    exit_code = main(["doctor", "--board", "board-1"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Fizzy Symphony Doctor" in captured.out
+    assert "fizzy doctor" in captured.out
+    assert "Linear issue -> Fizzy card" in captured.out
+    assert "robocorp-adapters-custom" in captured.out
+
+
+def test_init_board_prints_existing_board_bootstrap_plan(capsys):
+    exit_code = main(["init-board", "--board", "board-1"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "configure an existing tracker board" in captured.out
+    assert "fizzy column list --board board-1 --agent --quiet" in captured.out
+    assert "fizzy column create --board board-1 --name 'Ready for Agents'" in captured.out
+
+
+def test_workitems_env_prints_adapter_environment(capsys):
+    exit_code = main(["workitems-env"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    data = json.loads(captured.out)
+    assert data["RC_WORKITEM_ADAPTER"] == "robocorp_adapters_custom._sqlite.SQLiteAdapter"
+    assert data["RC_WORKITEM_QUEUE_NAME"] == "fizzy_codex_input"
 
 
 def test_list_command_prints_dry_run_fizzy_command(capsys):

--- a/tests/test_robocorp_adapter.py
+++ b/tests/test_robocorp_adapter.py
@@ -1,0 +1,38 @@
+import sys
+import types
+
+import pytest
+
+from fizzy_symphony.robocorp_adapter import (
+    RobocorpWorkitemConfig,
+    format_workitem_env,
+    initialize_adapter_from_environment,
+)
+
+
+def test_workitem_config_formats_published_adapter_env():
+    config = RobocorpWorkitemConfig()
+    env_text = format_workitem_env(config)
+
+    assert '"RC_WORKITEM_ADAPTER": "robocorp_adapters_custom._sqlite.SQLiteAdapter"' in env_text
+    assert '"RC_WORKITEM_QUEUE_NAME": "fizzy_codex_input"' in env_text
+
+
+def test_initialize_adapter_from_environment_uses_published_package(monkeypatch):
+    package = types.ModuleType("robocorp_adapters_custom")
+    integration = types.ModuleType("robocorp_adapters_custom.workitems_integration")
+    adapter = object()
+    integration.initialize_adapter = lambda: adapter
+
+    monkeypatch.setitem(sys.modules, "robocorp_adapters_custom", package)
+    monkeypatch.setitem(sys.modules, "robocorp_adapters_custom.workitems_integration", integration)
+
+    assert initialize_adapter_from_environment() is adapter
+
+
+def test_initialize_adapter_from_environment_reports_missing_dependency(monkeypatch):
+    monkeypatch.setitem(sys.modules, "robocorp_adapters_custom", None)
+    monkeypatch.setitem(sys.modules, "robocorp_adapters_custom.workitems_integration", None)
+
+    with pytest.raises(RuntimeError, match="Install workitem support"):
+        initialize_adapter_from_environment()

--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -1,0 +1,36 @@
+from fizzy_symphony.symphony import (
+    format_init_board_plan,
+    format_mapping_table,
+    recommended_columns,
+    upstream_mapping,
+)
+
+
+def test_recommended_columns_follow_symphony_lifecycle():
+    names = [column.name for column in recommended_columns()]
+
+    assert names == [
+        "Shaping",
+        "Ready for Agents",
+        "In Flight",
+        "Needs Input",
+        "Synthesize & Verify",
+        "Ready to Ship",
+        "Done",
+    ]
+
+
+def test_format_init_board_plan_uses_existing_board():
+    plan = format_init_board_plan("board-1")
+
+    assert "configure an existing tracker board" in plan
+    assert "fizzy column list --board board-1 --agent --quiet" in plan
+    assert "fizzy column create --board board-1 --name 'Synthesize & Verify'" in plan
+
+
+def test_format_mapping_table_explains_upstream_alignment():
+    mapping = format_mapping_table()
+
+    assert "Linear issue -> Fizzy card" in mapping
+    assert "Orchestrator state -> Robocorp workitem state" in mapping
+    assert len(upstream_mapping()) >= 5

--- a/tests/test_workitem_pipeline.py
+++ b/tests/test_workitem_pipeline.py
@@ -1,0 +1,182 @@
+from fizzy_symphony.models import FizzyCard
+from fizzy_symphony.workitem_pipeline import (
+    CodexWorkItemWorker,
+    FizzyWorkItemProducer,
+    FizzyWorkItemReporter,
+)
+from fizzy_symphony.workitem_queue import WorkItemQueue, WorkItemState
+
+
+class FakeAdapter:
+    def __init__(self):
+        self.items = {}
+        self.outputs = {}
+        self.releases = []
+        self.next_id = 1
+
+    def seed_input(self, payload=None, parent_id="", files=None):  # noqa: ARG002
+        item_id = f"item-{self.next_id}"
+        self.next_id += 1
+        self.items[item_id] = payload or {}
+        return item_id
+
+    def reserve_input(self):
+        return next(iter(self.items))
+
+    def load_payload(self, item_id):
+        return self.items[item_id]
+
+    def release_input(self, item_id, state, exception=None):
+        self.releases.append((item_id, state, exception))
+        self.items.pop(item_id, None)
+
+    def create_output(self, parent_id, payload=None):
+        output_id = f"output-{len(self.outputs) + 1}"
+        self.outputs[output_id] = payload or {}
+        return output_id
+
+    def save_payload(self, item_id, payload):
+        self.items[item_id] = payload
+
+
+class FakeTracker:
+    def __init__(self, cards=None):
+        self.cards = cards or []
+        self.comments = []
+        self.states = []
+
+    def fetch_candidate_cards(self):
+        return self.cards
+
+    def fetch_cards_by_states(self, states):  # noqa: ARG002
+        return []
+
+    def fetch_card_states_by_ids(self, card_ids):  # noqa: ARG002
+        return {}
+
+    def create_comment(self, card_id, body):
+        self.comments.append((card_id, body))
+
+    def update_card_state(self, card_id, state_name):
+        self.states.append((card_id, state_name))
+
+
+def _card(number=579):
+    return FizzyCard(
+        id=f"card-{number}",
+        number=number,
+        identifier=str(number),
+        title=f"Card {number}",
+        state="Ready for Agents",
+    )
+
+
+def test_producer_enqueues_candidate_cards_as_workitems():
+    adapter = FakeAdapter()
+    producer = FizzyWorkItemProducer(
+        tracker=FakeTracker([_card(1), _card(2)]),
+        queue=WorkItemQueue(adapter),
+        board_id="board-1",
+        prompt_template="Work {{ card.title }}",
+    )
+
+    item_ids = producer.produce()
+
+    assert item_ids == ["item-1", "item-2"]
+    assert adapter.items["item-1"]["card"]["number"] == 1
+    assert adapter.items["item-1"]["workflow"]["prompt_template"] == "Work {{ card.title }}"
+
+
+def test_worker_completes_reserved_item_with_runner_result():
+    adapter = FakeAdapter()
+    producer = FizzyWorkItemProducer(
+        tracker=FakeTracker([_card(579)]),
+        queue=WorkItemQueue(adapter),
+        board_id="board-1",
+        prompt_template="Work {{ card.title }}",
+    )
+    producer.produce()
+
+    def runner(payload):
+        return {"success": True, "comment": f"Done {payload.card['number']}"}
+
+    result = CodexWorkItemWorker(queue=WorkItemQueue(adapter), runner=runner).work_one()
+
+    assert result.output_id == "output-1"
+    assert adapter.outputs["output-1"]["card_id"] == "card-579"
+    assert adapter.outputs["output-1"]["comment"] == "Done 579"
+    assert adapter.releases == [("item-1", WorkItemState.DONE, None)]
+
+
+def test_worker_failure_releases_item_as_application_failure():
+    adapter = FakeAdapter()
+    FizzyWorkItemProducer(
+        tracker=FakeTracker([_card(579)]),
+        queue=WorkItemQueue(adapter),
+        board_id="board-1",
+    ).produce()
+
+    def runner(payload):  # noqa: ARG001
+        raise RuntimeError("codex exploded")
+
+    result = CodexWorkItemWorker(queue=WorkItemQueue(adapter), runner=runner).work_one()
+
+    assert result.output_id is None
+    assert adapter.releases == [
+        (
+            "item-1",
+            WorkItemState.FAILED,
+            {"type": "APPLICATION", "code": "CODEX_WORKER_FAILED", "message": "codex exploded"},
+        )
+    ]
+
+
+def test_reporter_posts_comment_and_updates_state_from_result_item():
+    adapter = FakeAdapter()
+    adapter.seed_input(
+        payload={
+            "card_id": "card-579",
+            "card_number": 579,
+            "comment": "Proof attached",
+            "handoff_state": "Synthesize & Verify",
+        }
+    )
+    tracker = FakeTracker()
+
+    result = FizzyWorkItemReporter(queue=WorkItemQueue(adapter), tracker=tracker).report_one()
+
+    assert result.reported is True
+    assert tracker.comments == [("card-579", "Proof attached")]
+    assert tracker.states == [("card-579", "Synthesize & Verify")]
+    assert adapter.releases == [("item-1", WorkItemState.DONE, None)]
+
+
+def test_reporter_failure_releases_result_item_as_failed():
+    class BrokenTracker(FakeTracker):
+        def create_comment(self, card_id, body):  # noqa: ARG002
+            raise RuntimeError("fizzy write failed")
+
+    adapter = FakeAdapter()
+    adapter.seed_input(
+        payload={
+            "card_id": "card-579",
+            "card_number": 579,
+            "comment": "Proof attached",
+            "handoff_state": "Synthesize & Verify",
+        }
+    )
+
+    result = FizzyWorkItemReporter(queue=WorkItemQueue(adapter), tracker=BrokenTracker()).report_one()
+
+    assert result.reported is False
+    assert adapter.releases == [
+        (
+            "item-1",
+            WorkItemState.FAILED,
+            {
+                "type": "APPLICATION",
+                "code": "FIZZY_REPORTER_FAILED",
+                "message": "fizzy write failed",
+            },
+        )
+    ]

--- a/tests/test_workitem_queue.py
+++ b/tests/test_workitem_queue.py
@@ -1,0 +1,129 @@
+import pytest
+
+from fizzy_symphony.models import FizzyCard
+from fizzy_symphony.workitem_queue import (
+    FizzyWorkItemPayload,
+    WorkItemQueue,
+    WorkItemState,
+)
+
+
+class FakeAdapter:
+    def __init__(self):
+        self.items = {}
+        self.outputs = []
+        self.releases = []
+        self.next_id = 1
+
+    def seed_input(self, payload=None, parent_id="", files=None):  # noqa: ARG002
+        item_id = f"item-{self.next_id}"
+        self.next_id += 1
+        self.items[item_id] = payload or {}
+        return item_id
+
+    def reserve_input(self):
+        return next(iter(self.items))
+
+    def load_payload(self, item_id):
+        return self.items[item_id]
+
+    def release_input(self, item_id, state, exception=None):
+        self.releases.append((item_id, state, exception))
+
+    def create_output(self, parent_id, payload=None):
+        output_id = f"output-{len(self.outputs) + 1}"
+        self.outputs.append((output_id, parent_id, payload or {}))
+        return output_id
+
+    def save_payload(self, item_id, payload):
+        self.items[item_id] = payload
+
+    def list_files(self, item_id):  # noqa: ARG002
+        return []
+
+    def get_file(self, item_id, name):  # noqa: ARG002
+        return b""
+
+    def add_file(self, item_id, name, content):  # noqa: ARG002
+        return None
+
+    def remove_file(self, item_id, name):  # noqa: ARG002
+        return None
+
+
+def _card() -> FizzyCard:
+    return FizzyCard(
+        id="03abc",
+        number=579,
+        identifier="579",
+        title="Fix login",
+        description="Broken auth",
+        state="Ready for Agents",
+        url="https://fizzy.test/cards/579",
+        labels=["bug"],
+        branch_name="fizzy/579-fix-login",
+        column_id="ready-for-agents",
+    )
+
+
+def test_payload_round_trips_fizzy_card_context():
+    payload = FizzyWorkItemPayload.from_card(
+        _card(),
+        board_id="board-1",
+        prompt_template="Work {{ issue.title }}",
+        allowed_paths=["src/", "tests/"],
+        handoff_column="synthesize-and-verify",
+        runner_command="codex exec --json",
+    )
+
+    data = payload.to_dict()
+    restored = FizzyWorkItemPayload.from_dict(data)
+
+    assert data["source"] == "fizzy"
+    assert data["card"]["number"] == 579
+    assert restored.card["title"] == "Fix login"
+    assert restored.workflow["allowed_paths"] == ["src/", "tests/"]
+    assert restored.runner["command"] == "codex exec --json"
+
+
+def test_queue_can_seed_reserve_complete_and_emit_output():
+    adapter = FakeAdapter()
+    queue = WorkItemQueue(adapter)
+    payload = FizzyWorkItemPayload.from_card(_card(), board_id="board-1")
+
+    item_id = queue.enqueue_input(payload)
+    reserved = queue.reserve()
+    output_id = queue.complete(reserved.id, {"status": "ok", "card_number": 579})
+
+    assert item_id == "item-1"
+    assert reserved.id == "item-1"
+    assert reserved.payload["card"]["number"] == 579
+    assert output_id == "output-1"
+    assert adapter.outputs == [("output-1", "item-1", {"status": "ok", "card_number": 579})]
+    assert adapter.releases == [("item-1", WorkItemState.DONE, None)]
+
+
+def test_queue_failure_uses_application_exception_payload():
+    adapter = FakeAdapter()
+    queue = WorkItemQueue(adapter)
+    item_id = queue.enqueue_input(FizzyWorkItemPayload.from_card(_card(), board_id="board-1"))
+
+    queue.fail(item_id, message="codex failed", code="CODEX_FAILED")
+
+    assert adapter.releases == [
+        (
+            "item-1",
+            WorkItemState.FAILED,
+            {"type": "APPLICATION", "code": "CODEX_FAILED", "message": "codex failed"},
+        )
+    ]
+
+
+def test_enqueue_requires_seed_input_support():
+    class MinimalAdapter(FakeAdapter):
+        seed_input = None
+
+    queue = WorkItemQueue(MinimalAdapter())
+
+    with pytest.raises(RuntimeError, match="seed_input"):
+        queue.enqueue_input(FizzyWorkItemPayload.from_card(_card(), board_id="board-1"))


### PR DESCRIPTION
## Summary

Aligns fizzy-symphony with the upstream OpenAI Symphony mental model while keeping the published robocorp-adapters-custom package as durable workitem plumbing.

Changes include:
- Add OpenAI Symphony mapping and recommended Fizzy board bootstrap helpers.
- Add CLI commands: doctor, init-board, and workitems-env.
- Add Robocorp adapter env/loader helpers for robocorp-adapters-custom.
- Add workitem queue/pipeline primitives for producer, Codex worker, and reporter flow.
- Harden reporter failure handling so failed tracker writeback releases the reserved result item as FAILED.
- Update README, SPEC, roadmap, and RCC workitems docs.

## Why

The earlier direction was technically useful but blurry: some Fizzy/Codex orchestration logic had started living in the adapter package. This PR makes the boundary explicit: adapters provide queue mechanics; fizzy-symphony owns the Symphony orchestration semantics and user experience.

## Validation

- env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest -q
- python -m compileall src
- git diff --check
- env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev --extra workitems python -c "from fizzy_symphony.robocorp_adapter import adapter_package_available; print(adapter_package_available())"
- env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev fizzy-symphony doctor --board work-ai-board
- env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev fizzy-symphony init-board --board work-ai-board
- env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev fizzy-symphony workitems-env

Fizzy tracking card: https://fizzy.joshyorko.com/1/cards/220