### PR TITLE
Study fizzy-popper and define durable-mode roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Overview
 
 **Fizzy Symphony** is a Python scaffold for planning card-based automation on top
-of [Fizzy](https://github.com/fizzy-project/fizzy). The scaffold treats **Fizzy
+of [Fizzy](https://github.com/basecamp/fizzy-cli). The scaffold treats **Fizzy
 as the tracker and board system**, normalizes cards into a canonical `FizzyCard`
 shape, and keeps tracker mutations dry-run-first while the durable queue layer
 is delegated to `robocorp-adapters-custom`.
@@ -19,14 +19,38 @@ main divergence is implementation plumbing: this project can use Robocorp
 workitems as the durable claimed/running/result queue instead of keeping that
 state only inside a long-running daemon.
 
+The closest Fizzy-native prior art is
+[`basecamp/fizzy-popper`](https://github.com/basecamp/fizzy-popper). This repo
+borrows its golden-ticket board pattern, but keeps a separate Python/RCC lane for
+larger asynchronous execution.
+
 It provides:
 
 | Layer | Description |
 |---|---|
-| **Models** | Pure Python dataclasses (`FizzyCard`, `Agent`, `CardAdapter`, `Board`, `FizzyConfig`) |
+| **Models** | Pure Python dataclasses (`FizzyCard`, `GoldenTicket`, `Agent`, `CardAdapter`, `Board`, `FizzyConfig`) |
 | **Adapter** | A dry-run `FizzyCLIAdapter` for command preview/debugging plus a future `FizzyOpenAPIAdapter` stub for real tracker reads/writes |
 | **CLI** | `fizzy-symphony` entry points for board bootstrap, setup checks, dry-run list/claim/comment/move flows, and a demo plan |
 | **Workitems** | Robocorp-compatible queue payloads, adapter env helpers, and producer/worker/reporter helpers |
+
+## Operating Modes
+
+Simple mode should stay as clean as `fizzy-popper`:
+
+```text
+Fizzy board -> polling -> Codex -> comment/move card
+```
+
+Durable mode is the reason for this Python/RCC variant:
+
+```text
+Fizzy board -> producer -> workitem lease -> RCC/Codex worker -> reporter -> Fizzy
+```
+
+Fizzy stores the work truth: card content, comments, tags, visible lanes, and
+proof. Workitems store execution custody: leases, retries, worker outputs,
+artifacts, and reporter handoff. If durable mode does not provide real
+multi-worker or crash-recovery value, operators should prefer `fizzy-popper`.
 
 ## Main Mapping
 
@@ -35,7 +59,7 @@ It provides:
 | Issue tracker | Fizzy |
 | Issue | Fizzy card |
 | Project | Fizzy board |
-| State | Fizzy list/column |
+| State | Fizzy system lane or custom column |
 | Comment | Fizzy card comment/update |
 | Orchestrator state | Robocorp workitem reservation/release/output state |
 | Worker | Codex command/app-server session |
@@ -108,8 +132,9 @@ fizzy-symphony doctor --board work-ai-board
 ### `fizzy-symphony init-board`
 
 Prints dry-run commands for preparing an existing Fizzy board with the
-recommended Symphony-style columns. It does not create a hidden system board by
-default.
+recommended Symphony-style custom columns. It does not create a hidden system
+board by default, and it treats `Maybe?`, `Not Now`, and `Done` as built-in
+Fizzy system lanes rather than custom columns to create.
 
 ```bash
 fizzy-symphony init-board --board work-ai-board
@@ -250,6 +275,9 @@ python -m pytest
 - `prompts/program-lead.md` guides the lead agent on board coordination and state transitions.
 - `prompts/worker-agent.md` guides a worker to claim exactly one card, stay within allowed paths, and report proof of work.
 - `docs/openai-symphony-alignment.md` explains how this maps to the upstream OpenAI Symphony model.
+- `docs/prior-art-fizzy-popper.md` compares this repo with Basecamp's Fizzy-native implementation.
+- `docs/feature-parity-roadmap.md` tracks simple-mode and durable-mode parity work.
+- `docs/codex-runner-strategy.md` explains why Codex SDK/app-server is the preferred worker harness.
 - `docs/rcc-workitems.md` describes the RCC/workitems refactor path.
 
 ## Adapter Strategy
@@ -264,6 +292,17 @@ python -m pytest
   layer. Fizzy is still the human-visible tracker layer.
 - Assignment is optional for MVP claim previews; a dedicated Codex/Fizzy
   Symphony user can be added later without blocking the orchestration loop.
+
+## Runner Strategy
+
+The current scaffold does not run Codex yet. When runtime execution lands, the
+preferred worker path should be the official Codex SDK/app-server so
+`fizzy-symphony` can control local Codex agents programmatically. Raw
+non-interactive `codex` CLI commands should be a fallback, not the only story.
+
+This project should not build its own coding-agent harness. For "let Codex work
+a repo card," use Codex as the harness and keep `fizzy-symphony` focused on
+Fizzy routing, durable work custody, and report-back.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -13,6 +13,11 @@ project diverges by using Robocorp workitems as durable queue plumbing for
 claimed/running/result state instead of treating one daemon process as the only
 owner of orchestration state.
 
+This repository uses `basecamp/fizzy-popper` as prior art for the simple
+board-native loop, but it is only worth keeping if it also supports a durable
+distributed mode for many workers, many Codex accounts/runtimes, and
+crash-safe handoffs.
+
 Boundary:
 
 - `fizzy-symphony` owns board semantics, workflow state, Codex runner policy,
@@ -23,6 +28,8 @@ Boundary:
 ## Core Domain Model
 
 - `FizzyCard`: canonical normalized tracker card.
+- `GoldenTicket`: board-native routing contract parsed from a Fizzy card tagged
+  `#agent-instructions`.
 - `Agent`: worker execution persona and limits.
 - `CardAdapter`: compatibility wrapper used by the demo planning scaffold.
 - `Board`: ordered collection of cards for a Fizzy board.
@@ -55,6 +62,32 @@ The canonical `FizzyCard` fields are:
 `number` is the visible card number and is the identifier used by Fizzy CLI card
 commands. `id` remains the internal stable tracker identifier.
 
+## Golden Ticket Shape
+
+A golden ticket is a Fizzy card tagged `#agent-instructions` that lives in the
+column it configures. It is inspired by `fizzy-popper`, but this scaffold treats
+it as routing policy only; it does not execute the card by itself.
+
+The `GoldenTicket` fields are:
+
+- `card_id`
+- `card_number`
+- `column_id`
+- `column_name`
+- `prompt`
+- `steps`
+- `backend`
+- `completion_policy`
+
+Supported backend tags start with `#codex`. Future tags may include `#claude`,
+`#opencode`, `#anthropic`, and `#openai`.
+
+Supported completion policies:
+
+- no completion tag: post a comment only
+- `#close-on-complete`: post a comment, then close the card
+- `#move-to-<column-name>`: post a comment, then move to the named custom column
+
 ## Tracker Adapter Contract
 
 A tracker adapter must provide these operations:
@@ -84,7 +117,8 @@ using the card branch name when present and a deterministic fallback when not.
 ## Active States
 
 Active states are the states in which a card is eligible for worker activity or
-already under active execution:
+already under active execution. These are custom workflow columns, not Fizzy's
+immutable system lanes:
 
 - `Ready for Agents`
 - `In Flight`
@@ -95,7 +129,7 @@ already under active execution:
 ## Recommended Board Columns
 
 Fizzy Symphony expects an existing board by default. `fizzy-symphony init-board`
-prints dry-run commands to add any missing recommended columns:
+prints dry-run commands to add any missing recommended custom columns:
 
 - `Shaping`
 - `Ready for Agents`
@@ -103,7 +137,14 @@ prints dry-run commands to add any missing recommended columns:
 - `Needs Input`
 - `Synthesize & Verify`
 - `Ready to Ship`
-- `Done`
+
+Fizzy's built-in system lanes are always represented separately:
+
+- `Maybe?` / pseudo column `maybe` / API stream or triage view
+- `Not Now` / pseudo column `not-now` / API `not_now`
+- `Done` / pseudo column `done` / API `closed`
+
+Do not create, delete, or treat those system lanes as custom columns.
 
 ## Terminal States
 
@@ -111,6 +152,29 @@ Terminal states indicate no more automated work should occur:
 
 - `Done`
 - `Not Now`
+
+## Codex Runner Strategy
+
+The early scaffold previews Codex work with dry-run command strings only. Future
+runtime work should use OpenAI's Codex harness rather than building a custom
+coding-agent harness here.
+
+Preferred runner:
+
+- `CodexSdkRunner`: controls local Codex agents through the official Codex
+  SDK/app-server.
+
+Fallback runner:
+
+- `CodexCliRunner`: uses non-interactive `codex` CLI execution when the SDK path
+  is unavailable or too immature for the current environment.
+
+Non-goal:
+
+- Do not build a custom shell/apply-patch/tool harness with the OpenAI Agents
+  SDK. The intended worker is Codex itself acting as a coding agent over a
+  repository. Direct OpenAI model calls may still be useful for narrow helper
+  tasks, but they are not the main card-execution runtime.
 
 ## Handoff States
 
@@ -149,5 +213,7 @@ passes, and preserve the card as the source of truth for scope and status.
 - Workers claim exactly one card at a time.
 - Claim is modeled as a composite orchestration operation, not a required native
   Fizzy `card claim` command.
+- Workitems may hold execution custody, but Fizzy remains the source of truth
+  for human workflow state.
 - Workers may edit only approved paths for the claimed card.
 - Card comments and state updates must reflect actual proof of work.

--- a/docs/codex-runner-strategy.md
+++ b/docs/codex-runner-strategy.md
@@ -1,0 +1,97 @@
+# Codex Runner Strategy
+
+`fizzy-symphony` should use Codex as the coding-agent harness. It should not
+rebuild Codex with the OpenAI Agents SDK.
+
+## Official SDK Shape
+
+OpenAI documents a Codex SDK for programmatic control of local Codex agents:
+
+- TypeScript package: `@openai/codex-sdk`
+- Python SDK: experimental, controls the local Codex app-server over JSON-RPC,
+  requires Python 3.10+, and currently expects a local checkout of the
+  open-source Codex repo
+- Non-interactive `codex exec --json` remains a useful fallback because it emits
+  structured JSONL events, but the SDK gives a cleaner thread/resume/run API.
+
+That means the cleanest first implementation is not a hard runtime dependency
+in this Python package. The cleanest first step is a runner boundary that can
+call Codex through the SDK when available.
+
+## Recommended Integration
+
+Add a runner contract before adding a concrete SDK dependency:
+
+```text
+CodexRunRequest
+  card_number
+  workspace
+  prompt
+  model
+  approval_policy
+  timeout_seconds
+  metadata
+
+CodexRunResult
+  final_response
+  success
+  thread_id
+  artifacts
+  validation_summary
+  raw_metadata
+```
+
+Then implement runners in this order:
+
+1. `CodexSdkRunner` spike using the official SDK/app-server.
+2. `CodexCliRunner` fallback for non-interactive `codex` CLI execution.
+3. Optional TypeScript sidecar if the TypeScript SDK stays more stable than the
+   experimental Python SDK.
+
+The workitem worker should depend on the runner contract, not the concrete SDK.
+Do not add a default dependency on either SDK until a local spike proves the
+auth, app-server, and packaging path works in Josh's Bluefin/devcontainer setup.
+
+## How This Fits Durable Mode
+
+The workitem queue owns execution custody:
+
+- reserve one card payload;
+- start or resume a Codex thread for that card;
+- write `thread_id` and runtime metadata to the result payload;
+- release the item only after the worker has produced a result item.
+
+The reporter owns Fizzy writeback:
+
+- post the final response or proof summary;
+- move/close according to the golden-ticket completion policy;
+- retry writeback without rerunning Codex.
+
+This lets the system scale to multiple workers while still using Codex's own
+agent harness.
+
+## Multiple Codex Accounts
+
+Multiple Codex accounts are an operations problem, not a board-model problem.
+Durable mode can support them by assigning workers to capacity pools:
+
+- separate containers or OS users;
+- separate `CODEX_HOME` / config homes;
+- queue names or worker labels per account;
+- per-account concurrency limits.
+
+Do not mix credential state inside one worker process.
+
+## Authentication Notes
+
+Codex supports ChatGPT sign-in for subscription access and API-key sign-in for
+usage-based access. Durable mode should treat auth as worker-local runtime
+state, not as Fizzy board state. For CI-style or fleet workers, prefer explicit
+worker profiles/containers so account limits and credentials are observable.
+
+## Agents SDK Decision
+
+The OpenAI Agents SDK is useful when an application owns tools, handoffs,
+approvals, and agent state. That is not the desired shape here. This repo should
+own board routing and durable queue custody, then delegate coding execution to
+Codex through the Codex SDK/app-server.

--- a/docs/feature-parity-roadmap.md
+++ b/docs/feature-parity-roadmap.md
@@ -1,0 +1,126 @@
+# Feature Parity Roadmap
+
+This roadmap uses `fizzy-popper` as prior art without turning
+`fizzy-symphony` into a TypeScript daemon clone.
+
+## Product Shape
+
+`fizzy-symphony` should support two operating modes.
+
+Simple mode:
+
+```text
+Fizzy board -> polling -> Codex -> comment/move card
+```
+
+Durable mode:
+
+```text
+Fizzy board -> producer -> Robocorp workitem queue -> Codex/RCC worker -> reporter -> Fizzy
+```
+
+Simple mode keeps the project understandable. Durable mode is the differentiator
+for larger boards, multiple worker processes, multiple Codex accounts, and
+crash/retry handling.
+
+## Fizzy Board Semantics
+
+Fizzy has built-in system lanes:
+
+| Lane | Pseudo ID | API kind | Meaning |
+| --- | --- | --- | --- |
+| `Maybe?` | `maybe` | `triage` / `stream` | Active cards without a custom column |
+| `Not Now` | `not-now` | `not_now` | Postponed cards |
+| `Done` | `done` | `closed` | Closed cards |
+
+These are not custom columns to create or delete. Custom workflow columns should
+be discovered by ID and can be configured by golden tickets.
+
+## Phase A: Tracker Adapter Correctness
+
+- Treat visible card `number` as the CLI command identifier.
+- Treat internal card `id` as the reconciliation/deduplication identifier.
+- Move cards by custom column ID or by explicit pseudo-lane operation:
+  `untriage`, `postpone`, or `close`.
+- Preserve dry-run CLI command generation until real execution is explicitly
+  enabled.
+
+## Phase B: Golden-Ticket Discovery and Parsing
+
+- Parse `#agent-instructions` cards into a `GoldenTicket` model.
+- Include `card_id`, `card_number`, `column_id`, `column_name`, `prompt`,
+  `steps`, `backend`, and `completion_policy`.
+- Start with `#codex` as the supported backend tag.
+- Support completion policies: comment-only, close, and move-to-column.
+- Do not execute runtime behavior in this phase.
+
+## Phase C: Producer Creates Workitems
+
+- Poll candidate cards from configured boards.
+- Skip golden-ticket cards, closed cards, postponed cards, and cards already
+  leased.
+- Enqueue one durable workitem per eligible card.
+- Store enough payload to reproduce the run intent without making workitems the
+  human source of truth.
+
+## Phase D: Codex Worker Consumes Workitems
+
+- Reserve one workitem at a time.
+- Create or reuse an isolated workspace per card.
+- Build the prompt from workflow contract, golden ticket, card, steps, and
+  comments.
+- Run Codex through an injected runner first. Prefer the official Codex SDK as
+  the future runtime path, with non-interactive CLI execution as a fallback.
+- Emit a result workitem with proof and metadata.
+
+Runner options:
+
+- `CodexSdkRunner`: controls local Codex agents through the Codex SDK/app-server.
+- `CodexCliRunner`: shells out to `codex` only for compatibility.
+
+Do not build a custom coding-agent harness here. The desired worker is Codex,
+not an in-house clone of Codex using the Agents SDK.
+
+## Phase E: Reporter Moves Cards
+
+- Consume result workitems.
+- Post proof back to the original Fizzy card.
+- Apply the golden-ticket completion policy.
+- Retry reporter failures without rerunning the worker.
+- Confirm final card state after mutation.
+
+## Phase F: Polling Reconciler
+
+- Refresh golden tickets.
+- Reconcile running workitems against current card state.
+- Release or fail leases for cards that moved to `Done`, `Not Now`, or a
+  non-agent column.
+- Recover orphaned reserved items after worker crashes.
+
+## Phase G: Optional Webhooks
+
+- Add webhook ingestion after polling works.
+- Use webhooks to accelerate reconciliation, not replace it.
+- Deduplicate events, then fall back to polling for correctness.
+
+## Phase H: Optional Direct OpenAPI Adapter
+
+- Implement a real API adapter from `basecamp/fizzy-sdk/openapi.json` when the
+  CLI adapter is no longer enough.
+- Keep the CLI adapter useful for dry-run/operator workflows.
+- Do not invent a fake Python SDK surface.
+
+## Distributed Scale Story
+
+The durable mode should eventually support:
+
+- multiple worker machines;
+- multiple Codex accounts or credential pools;
+- queue-level capacity limits;
+- per-column or per-backend concurrency;
+- retry/backoff by failure type;
+- artifact storage outside Fizzy comments;
+- reporter-only retries;
+- metrics for queued, leased, succeeded, failed, and stale work.
+
+This is the reason to keep `fizzy-symphony` alive beside `fizzy-popper`.

--- a/docs/prior-art-fizzy-popper.md
+++ b/docs/prior-art-fizzy-popper.md
@@ -1,0 +1,136 @@
+# Prior Art: fizzy-popper
+
+## Summary
+
+Basecamp's `fizzy-popper` is the clearest Fizzy-native implementation of the
+OpenAI Symphony idea: a Fizzy board becomes an agent dispatch surface. A card
+tagged `#agent-instructions` sits in a column as a golden ticket, work cards
+enter that column, a long-running Node/TypeScript service launches an agent,
+posts a result, and optionally moves or closes the card.
+
+As of April 26, 2026, `fizzy-popper` is small and intentionally direct:
+
+- Node/TypeScript daemon.
+- Polling plus optional webhook ingestion.
+- In-memory active-agent supervisor.
+- Board-native golden-ticket configuration.
+- Multiple backend tags, including Claude, Codex, OpenCode, Anthropic, OpenAI,
+  and a command backend.
+- No persistent execution database.
+
+That is a strong simple-mode design. It should shape this repository.
+
+## What It Does Better Today
+
+`fizzy-popper` has a better immediate product loop:
+
+1. Configure a board with golden tickets.
+2. Start one watcher.
+3. Move cards into agent-enabled columns.
+4. Watch comments and card movement happen.
+
+It also has a mature-feeling service shape for local/personal use: setup
+wizard, status endpoint, webhook receiver, polling reconciler, backend
+detection, prompt assembly, and supervisor lifecycle are all in one repo.
+
+If `fizzy-symphony` cannot preserve a clean simple mode, operators should use
+or fork `fizzy-popper` instead.
+
+## Where fizzy-symphony Differs
+
+`fizzy-symphony` should not try to be a worse TypeScript daemon. Its useful
+lane is Python/RCC durable execution:
+
+```text
+Fizzy card -> producer -> workitem lease -> RCC/Codex worker -> result item -> reporter -> Fizzy card
+```
+
+Fizzy remains the source of truth for the work:
+
+- card title and description
+- comments and proof
+- tags and golden-ticket routing
+- visible board position
+- `Maybe?`, `Not Now`, and `Done` system lanes
+
+Robocorp workitems should only store execution custody:
+
+- which worker leased this run
+- when the lease started
+- retry attempt count
+- input/output payload snapshots
+- result waiting for report-back
+- local artifact/file handles
+- failure state when a worker crashes before posting proof
+
+That distinction matters. It keeps Fizzy human-readable while letting execution
+scale beyond one local daemon process.
+
+## Why Durable Mode Can Be Stickier
+
+For one person or a small board, `fizzy-popper` is likely enough.
+
+For a large board with many agents, multiple Codex accounts, RCC containers, or
+several worker machines, `fizzy-symphony` can provide a stronger operating
+model:
+
+- Multiple producers/workers/reporters can run independently.
+- Workers can crash without losing custody state.
+- A queue backend can enforce one lease per card.
+- Different queues can represent different capacity pools or Codex accounts.
+- Reporter failures can be retried without rerunning the worker.
+- Artifacts can live with the execution envelope instead of being stuffed into
+  Fizzy comments.
+- Backpressure and metrics can come from the queue instead of the board alone.
+
+This is the real value proposition. Without that distributed-execution story,
+the project should collapse back toward `fizzy-popper`.
+
+## Concepts To Borrow
+
+- Golden tickets: `#agent-instructions` cards configure the column they occupy.
+- Backend tags: start with `#codex`; leave room for `#claude`, `#opencode`,
+  `#anthropic`, and `#openai`.
+- Completion tags: default comment-only, `#close-on-complete`, and
+  `#move-to-<column-name>`.
+- Prompt assembly: service instructions, golden-ticket prompt, golden-ticket
+  steps, card content, card steps, and discussion thread.
+- Polling as the baseline reconciler, webhooks as a later accelerator.
+- One active execution per card.
+
+## Concepts Not To Copy Yet
+
+- Full daemon/webhook server.
+- All backends.
+- Direct TypeScript SDK dependence.
+- In-memory-only supervisor as the only execution state.
+- Making the board mutate directly from every worker process.
+
+## Codex Runner Implication
+
+`fizzy-popper` shells out to supported agent backends. `fizzy-symphony` should
+not assume raw CLI subprocesses are the final Codex story. The official Codex
+SDK/app-server is a better long-term fit for durable mode because the
+orchestrator can keep structured run/thread identity while workitems keep the
+lease and retry envelope.
+
+This repo should not build a custom coding-agent harness. Codex is the harness;
+`fizzy-symphony` supplies board routing, durable execution custody, and
+report-back.
+
+## Stop Conditions
+
+Stop investing in `fizzy-symphony` and prefer `fizzy-popper` if:
+
+- simple mode becomes harder to explain than `fizzy-popper`;
+- Robocorp/RCC cannot stay optional;
+- durable mode does not demonstrate crash recovery, retry, or multi-worker
+  coordination;
+- the repo starts storing human workflow truth outside Fizzy.
+
+Continue investing if:
+
+- simple mode remains Popper-like;
+- durable mode proves useful for many workers or many Codex accounts;
+- Fizzy remains the visible source of truth;
+- workitems remain boring execution plumbing.

--- a/docs/rcc-workitems.md
+++ b/docs/rcc-workitems.md
@@ -5,9 +5,9 @@ Josh's `robocorp_adapters_custom` already provide the right execution substrate:
 reserve, release, output chaining, backend switching, and orphan recovery.
 
 This keeps the project aligned with OpenAI Symphony without copying its daemon
-implementation directly. Upstream Symphony keeps claimed/running/retry state in
-the orchestrator process; this project can persist that same state in Robocorp
-workitems so RCC tasks, local workers, and future services can share it safely.
+implementation directly. Fizzy still stores the work truth. Robocorp workitems
+store execution custody: leases, retries, outputs, artifacts, and report-back
+handoffs that should survive process death.
 
 ## Target Shape
 
@@ -16,6 +16,8 @@ workitems so RCC tasks, local workers, and future services can share it safely.
 - `robocorp_adapters_custom` supplies SQLite, Redis, DocumentDB, or Yorko Control
   Room storage.
 - Codex runs inside a worker task and reports proof through work item outputs.
+- The worker should eventually prefer the Codex SDK/app-server over raw shelling
+  out, with CLI execution kept as a fallback.
 - A reporter task consumes worker outputs and updates Fizzy comments/states.
 - `fizzy-symphony` owns all Symphony-specific semantics: board columns,
   `WORKFLOW.md`, per-card workspaces, runner policy, and report formatting.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,9 +3,11 @@
 - [x] Phase 0: spec/scaffold
 - [x] Phase 0.5: Robocorp workitems queue seam
 - [x] Phase 0.6: OpenAI Symphony alignment and board bootstrap docs
+- [x] Phase 0.7: fizzy-popper prior-art roadmap and GoldenTicket model stub
 - [ ] Phase 1: Real CLI-backed Fizzy tracker adapter
-- [ ] Phase 2: Fizzy producer -> workitems queue CLI command
-- [ ] Phase 3: Codex workitem worker and RCC task wrappers
-- [ ] Phase 4: Codex app-server runner
+- [ ] Phase 2: Golden-ticket discovery from Fizzy cards
+- [ ] Phase 3: Fizzy producer -> workitems queue CLI command
+- [ ] Phase 4: Codex SDK/app-server workitem runner and RCC task wrappers
 - [ ] Phase 5: reporter/observability back to Fizzy
-- [ ] Phase 6: hardened safety model
+- [ ] Phase 6: polling reconciler and orphan recovery
+- [ ] Phase 7: hardened safety model

--- a/src/fizzy_symphony/__init__.py
+++ b/src/fizzy_symphony/__init__.py
@@ -16,9 +16,18 @@ from .commands import (
     build_doctor_command,
     build_workflow_plan,
 )
-from .models import Agent, Board, CardAdapter, FizzyCard, FizzyConfig, Workflow
+from .models import (
+    Agent,
+    Board,
+    CardAdapter,
+    FizzyCard,
+    FizzyConfig,
+    GoldenTicket,
+    Workflow,
+    parse_golden_ticket_card,
+)
 from .robocorp_adapter import RobocorpWorkitemConfig
-from .symphony import SymphonyColumn, SymphonyMapping
+from .symphony import FizzySystemLane, SymphonyColumn, SymphonyMapping, fizzy_system_lanes
 from .tracker import TrackerAdapter
 from .workitem_pipeline import CodexWorkItemWorker, FizzyWorkItemProducer, FizzyWorkItemReporter
 from .workitem_queue import FizzyWorkItemPayload, ReservedWorkItem, WorkItemQueue, WorkItemState
@@ -34,7 +43,9 @@ __all__ = [
     "FizzyWorkItemPayload",
     "FizzyWorkItemProducer",
     "FizzyWorkItemReporter",
+    "FizzySystemLane",
     "RobocorpWorkitemConfig",
+    "GoldenTicket",
     "CodexWorkItemWorker",
     "ReservedWorkItem",
     "SymphonyColumn",
@@ -53,4 +64,6 @@ __all__ = [
     "build_comment_create_command",
     "build_doctor_command",
     "build_workflow_plan",
+    "fizzy_system_lanes",
+    "parse_golden_ticket_card",
 ]

--- a/src/fizzy_symphony/models.py
+++ b/src/fizzy_symphony/models.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional
+from typing import Any, List, Mapping, Optional, Sequence
 
 
 class CardStatus(str, Enum):
@@ -38,6 +38,117 @@ class AgentCapability(str, Enum):
     TESTING = "testing"
     DOCUMENTATION = "documentation"
     REFACTORING = "refactoring"
+
+
+BACKEND_TAGS = ("codex", "claude", "opencode", "anthropic", "openai")
+AGENT_INSTRUCTIONS_TAG = "agent-instructions"
+DEFAULT_AGENT_BACKEND = "codex"
+DEFAULT_COMPLETION_POLICY = "comment"
+
+
+@dataclass(frozen=True)
+class GoldenTicket:
+    """Board-native routing contract parsed from a Fizzy instruction card.
+
+    A golden ticket is a Fizzy card tagged ``#agent-instructions`` that lives in
+    the column it configures. Fizzy remains the source of truth for the card;
+    this model only captures the routing policy the orchestrator needs.
+    """
+
+    card_id: str
+    card_number: int
+    column_id: str
+    column_name: str
+    prompt: str = ""
+    steps: List[str] = field(default_factory=list)
+    backend: str = DEFAULT_AGENT_BACKEND
+    completion_policy: str = DEFAULT_COMPLETION_POLICY
+
+    def __post_init__(self) -> None:
+        if not self.card_id:
+            raise ValueError("GoldenTicket.card_id must not be empty.")
+        if self.card_number < 1:
+            raise ValueError("GoldenTicket.card_number must be >= 1.")
+        if not self.column_id:
+            raise ValueError("GoldenTicket.column_id must not be empty.")
+        if not self.column_name:
+            raise ValueError("GoldenTicket.column_name must not be empty.")
+        if not self.backend:
+            raise ValueError("GoldenTicket.backend must not be empty.")
+        if not self.completion_policy:
+            raise ValueError("GoldenTicket.completion_policy must not be empty.")
+
+
+def parse_golden_ticket_card(
+    card: Mapping[str, Any],
+    *,
+    default_backend: str = DEFAULT_AGENT_BACKEND,
+) -> Optional[GoldenTicket]:
+    """Parse a Fizzy card-shaped mapping into a :class:`GoldenTicket`.
+
+    This is a deliberately small spec stub. It accepts the card shape returned
+    by the CLI/API enough to define semantics, but it does not perform network
+    calls or mutate Fizzy.
+    """
+    tags = [_normalize_tag(tag) for tag in card.get("tags", [])]
+    if AGENT_INSTRUCTIONS_TAG not in tags:
+        return None
+
+    column = card.get("column")
+    if not isinstance(column, Mapping):
+        return None
+
+    column_id = str(column.get("id") or "")
+    column_name = str(column.get("name") or "")
+    if not column_id or not column_name:
+        return None
+
+    return GoldenTicket(
+        card_id=str(card.get("id") or ""),
+        card_number=int(card.get("number") or 0),
+        column_id=column_id,
+        column_name=column_name,
+        prompt=str(card.get("description") or ""),
+        steps=_parse_step_contents(card.get("steps", [])),
+        backend=_resolve_backend(tags, default_backend=default_backend),
+        completion_policy=_resolve_completion_policy(tags),
+    )
+
+
+def _normalize_tag(tag: object) -> str:
+    return str(tag).strip().lower().lstrip("#")
+
+
+def _resolve_backend(tags: Sequence[str], *, default_backend: str) -> str:
+    for tag in tags:
+        if tag in BACKEND_TAGS:
+            return tag
+    return default_backend
+
+
+def _resolve_completion_policy(tags: Sequence[str]) -> str:
+    for tag in tags:
+        if tag == "close-on-complete":
+            return "close"
+        if tag.startswith("move-to-"):
+            column_name = tag.removeprefix("move-to-").replace("-", " ")
+            return f"move:{column_name}"
+    return DEFAULT_COMPLETION_POLICY
+
+
+def _parse_step_contents(raw_steps: object) -> List[str]:
+    if not isinstance(raw_steps, list):
+        return []
+
+    steps: List[str] = []
+    for step in raw_steps:
+        if isinstance(step, Mapping):
+            content = str(step.get("content") or "").strip()
+        else:
+            content = str(step).strip()
+        if content:
+            steps.append(content)
+    return steps
 
 
 @dataclass

--- a/src/fizzy_symphony/symphony.py
+++ b/src/fizzy_symphony/symphony.py
@@ -22,12 +22,48 @@ class SymphonyColumn:
 
 
 @dataclass(frozen=True)
+class FizzySystemLane:
+    """Built-in Fizzy lane that is not created as a custom board column."""
+
+    name: str
+    pseudo_id: str
+    kind: str
+    role: str
+    description: str
+
+
+@dataclass(frozen=True)
 class SymphonyMapping:
     """Concept mapping between upstream Symphony and this implementation."""
 
     upstream: str
     fizzy_symphony: str
     note: str
+
+
+FIZZY_SYSTEM_LANES: Tuple[FizzySystemLane, ...] = (
+    FizzySystemLane(
+        name="Maybe?",
+        pseudo_id="maybe",
+        kind="triage",
+        role="Default intake",
+        description="Active cards with no custom column assignment.",
+    ),
+    FizzySystemLane(
+        name="Not Now",
+        pseudo_id="not-now",
+        kind="not_now",
+        role="Postponed",
+        description="Cards postponed out of active automation.",
+    ),
+    FizzySystemLane(
+        name="Done",
+        pseudo_id="done",
+        kind="closed",
+        role="Terminal",
+        description="Closed cards; no more automated work should occur.",
+    ),
+)
 
 
 RECOMMENDED_COLUMNS: Tuple[SymphonyColumn, ...] = (
@@ -66,12 +102,6 @@ RECOMMENDED_COLUMNS: Tuple[SymphonyColumn, ...] = (
         role="Integration",
         upstream_state="Ready",
         description="Verified work that can be merged or released.",
-    ),
-    SymphonyColumn(
-        name="Done",
-        role="Terminal",
-        upstream_state="Done",
-        description="No more automated work should occur.",
     ),
 )
 
@@ -115,6 +145,11 @@ def recommended_columns() -> List[SymphonyColumn]:
     return list(RECOMMENDED_COLUMNS)
 
 
+def fizzy_system_lanes() -> List[FizzySystemLane]:
+    """Return Fizzy's built-in pseudo lanes used by the orchestration model."""
+    return list(FIZZY_SYSTEM_LANES)
+
+
 def upstream_mapping() -> List[SymphonyMapping]:
     """Return a copy of the upstream-to-Fizzy mapping."""
     return list(UPSTREAM_MAPPING)
@@ -133,11 +168,19 @@ def format_init_board_plan(board_id: str, *, fizzy_bin: str = "fizzy") -> str:
         "",
         f"Board: {board_id}",
         "",
-        "Check existing columns first:",
-        f"{quote(fizzy_bin)} column list --board {quote(board_id)} --agent --quiet",
-        "",
-        "Create any missing columns:",
+        "Fizzy system lanes already exist and are not custom columns:",
     ]
+    for lane in FIZZY_SYSTEM_LANES:
+        lines.append(f"- {lane.name} ({lane.pseudo_id}, {lane.kind})")
+    lines.extend(
+        [
+            "",
+            "Check existing custom columns first:",
+            f"{quote(fizzy_bin)} column list --board {quote(board_id)} --agent --quiet",
+            "",
+            "Create any missing custom workflow columns:",
+        ]
+    )
     for column in RECOMMENDED_COLUMNS:
         lines.append(
             f"{quote(fizzy_bin)} column create --board {quote(board_id)} "

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,6 +12,8 @@ from fizzy_symphony.models import (
     CardStatus,
     FizzyCard,
     FizzyConfig,
+    GoldenTicket,
+    parse_golden_ticket_card,
 )
 
 
@@ -44,6 +46,78 @@ class TestFizzyCard:
 
         with pytest.raises(ValueError, match="FizzyCard.state"):
             FizzyCard(id="card_123", number=42, identifier="abc", title="x", state="")
+
+
+class TestGoldenTicket:
+    _DEFAULT = object()
+
+    def _make_card(self, *, tags=None, column=_DEFAULT, steps=None):
+        resolved_column = (
+            {"id": "col_ready", "name": "Ready for Agents"}
+            if column is self._DEFAULT
+            else column
+        )
+        return {
+            "id": "card_gt",
+            "number": 12,
+            "title": "Codex Agent",
+            "description": "Work the card and leave proof.",
+            "tags": tags or ["agent-instructions", "codex", "move-to-ready-to-ship"],
+            "column": resolved_column,
+            "steps": steps or [
+                {"content": "Read the card"},
+                {"content": "Run validation"},
+            ],
+        }
+
+    def test_golden_ticket_requires_identity_and_column(self):
+        with pytest.raises(ValueError, match="GoldenTicket.card_id"):
+            GoldenTicket(card_id="", card_number=1, column_id="col", column_name="Ready")
+
+        with pytest.raises(ValueError, match="GoldenTicket.card_number"):
+            GoldenTicket(card_id="card", card_number=0, column_id="col", column_name="Ready")
+
+        with pytest.raises(ValueError, match="GoldenTicket.column_id"):
+            GoldenTicket(card_id="card", card_number=1, column_id="", column_name="Ready")
+
+    def test_parse_golden_ticket_card_maps_prompt_steps_backend_and_completion(self):
+        ticket = parse_golden_ticket_card(self._make_card())
+
+        assert ticket == GoldenTicket(
+            card_id="card_gt",
+            card_number=12,
+            column_id="col_ready",
+            column_name="Ready for Agents",
+            prompt="Work the card and leave proof.",
+            steps=["Read the card", "Run validation"],
+            backend="codex",
+            completion_policy="move:ready to ship",
+        )
+
+    def test_parse_golden_ticket_card_defaults_to_comment_and_configured_backend(self):
+        ticket = parse_golden_ticket_card(
+            self._make_card(tags=["#agent-instructions"]),
+            default_backend="claude",
+        )
+
+        assert ticket is not None
+        assert ticket.backend == "claude"
+        assert ticket.completion_policy == "comment"
+
+    def test_parse_golden_ticket_card_supports_close_on_complete(self):
+        ticket = parse_golden_ticket_card(
+            self._make_card(tags=["agent-instructions", "close-on-complete"])
+        )
+
+        assert ticket is not None
+        assert ticket.completion_policy == "close"
+
+    def test_parse_golden_ticket_card_ignores_non_instruction_cards(self):
+        assert parse_golden_ticket_card(self._make_card(tags=["codex"])) is None
+
+    def test_parse_golden_ticket_card_requires_real_column(self):
+        assert parse_golden_ticket_card(self._make_card(column=None)) is None
+        assert parse_golden_ticket_card(self._make_card(column={})) is None
 
 
 class TestAgent:

--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -1,4 +1,5 @@
 from fizzy_symphony.symphony import (
+    fizzy_system_lanes,
     format_init_board_plan,
     format_mapping_table,
     recommended_columns,
@@ -16,16 +17,26 @@ def test_recommended_columns_follow_symphony_lifecycle():
         "Needs Input",
         "Synthesize & Verify",
         "Ready to Ship",
-        "Done",
     ]
+
+
+def test_fizzy_system_lanes_are_immutable_board_lanes():
+    lanes = {lane.pseudo_id: lane for lane in fizzy_system_lanes()}
+
+    assert lanes["maybe"].kind == "triage"
+    assert lanes["not-now"].kind == "not_now"
+    assert lanes["done"].kind == "closed"
 
 
 def test_format_init_board_plan_uses_existing_board():
     plan = format_init_board_plan("board-1")
 
     assert "configure an existing tracker board" in plan
+    assert "Fizzy system lanes already exist" in plan
+    assert "- Done (done, closed)" in plan
     assert "fizzy column list --board board-1 --agent --quiet" in plan
     assert "fizzy column create --board board-1 --name 'Synthesize & Verify'" in plan
+    assert "fizzy column create --board board-1 --name Done" not in plan
 
 
 def test_format_mapping_table_explains_upstream_alignment():


### PR DESCRIPTION
## Summary
- Study `basecamp/fizzy-popper` as the simple-mode reference and document where this repo should borrow its board-native golden-ticket model.
- Define the durable-mode value proposition: Fizzy remains the work source of truth while workitems hold execution custody for leases, retries, outputs, reporter handoff, and crash recovery.
- Document the Codex SDK/app-server runner strategy so Codex is the harness, with raw CLI execution only as a fallback.
- Add a small `GoldenTicket` parser/model stub plus immutable Fizzy system-lane representation for `Maybe?`, `Not Now`, and `Done`.

## Direction
This keeps `fizzy-symphony` alive only where it can beat `fizzy-popper`: distributed Python/RCC execution with multiple workers, multiple Codex accounts/runtimes, queue-level custody, and retryable report-back. If we cannot prove that lane, the roadmap says to collapse back toward Popper.

Follow-up implementation spike: #12

## Verification
- `.venv/bin/python -m compileall src`
- `.venv/bin/python -m pytest`
- `git diff --check`

Closes #10.
