### PR TITLE
feat: finish SDK-backed RCC smoke path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "fizzy-symphony",
+  "image": "ghcr.io/joshyorko/ror:latest",
+  "workspaceFolder": "/workspaces/fizzy-symphony",
+  "containerEnv": {
+    "FIZZY_API_URL": "${localEnv:FIZZY_API_URL}",
+    "FIZZY_BOARD": "${localEnv:FIZZY_BOARD}",
+    "FIZZY_PROFILE": "${localEnv:FIZZY_PROFILE}",
+    "FIZZY_TOKEN": "${localEnv:FIZZY_TOKEN}",
+    "OPENAI_API_KEY": "${localEnv:OPENAI_API_KEY}"
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/fizzy,target=/home/vscode/.config/fizzy,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.robocorp,target=/home/vscode/.robocorp,type=bind,consistency=cached"
+  ],
+  "postCreateCommand": "python -m pip install -e '.[dev,workitems,codex-sdk]'",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ python test-projects/workai-smoke/bootstrap_board.py --live --create-board
 - `docs/feature-parity-roadmap.md` tracks simple-mode and durable-mode parity work.
 - `docs/codex-runner-strategy.md` explains why Codex SDK/app-server is the preferred worker harness.
 - `docs/production-smoke-agent.md` defines the SDK-backed release smoke gate.
+- `docs/live-operator-guide.md` walks from devcontainer setup to a live Fizzy card run.
 - `docs/rcc-workitems.md` describes the RCC/workitems refactor path.
 - `robots/workitems/` contains the RCC SQLite smoke robot.
 - `test-projects/workai-smoke/` contains the disposable Fizzy board fixture and fake project.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ multi-worker or crash-recovery value, operators should prefer `fizzy-popper`.
 | Workflow contract | WORKFLOW.md |
 | Workspace | Per-card branch/worktree |
 
-> **Status:** Pre-alpha scaffold — no real Fizzy or Codex execution yet.
-> The durable orchestration direction is now Robocorp workitems/RCC: Fizzy stays
-> the board, workitems provide queue leasing/release, and Codex is the worker.
+> **Status:** Pre-alpha, but the runner and RCC smoke paths now execute.
+> Tracker-facing CLI flows remain dry-run-first unless explicitly guarded as
+> live smoke commands.
 
 ---
 
@@ -94,10 +94,10 @@ fizzy-symphony workitems-env
 fizzy-symphony list --board work-ai-board --dry-run
 
 # Claim a card in dry-run mode
-fizzy-symphony claim 42 --board work-ai-board --dry-run
+fizzy-symphony claim 42 --board work-ai-board --in-flight-column col_in_flight --dry-run
 
 # Preview a composite claim with an explicit in-flight column/comment
-fizzy-symphony claim 42 --in-flight-column in-flight --comment-body "Claimed by fizzy-symphony worker." --dry-run
+fizzy-symphony claim 42 --in-flight-column col_in_flight --comment-body "Claimed by fizzy-symphony worker." --dry-run
 
 # Comment on a card in dry-run mode
 fizzy-symphony comment 42 --body "Validated the change." --dry-run
@@ -172,18 +172,18 @@ Fizzy CLI operation, so the preview is:
 - add a claim comment
 
 ```bash
-fizzy-symphony claim 42 --board work-ai-board --dry-run
+fizzy-symphony claim 42 --board work-ai-board --in-flight-column col_in_flight --dry-run
 # fizzy card show 42 --agent --markdown
-# fizzy card column 42 --column 'In Flight' --agent --quiet
+# fizzy card column 42 --column col_in_flight --agent --quiet
 # fizzy comment create --card 42 --body 'Claimed by fizzy-symphony worker.' --agent --quiet
 
-fizzy-symphony claim 42 --self-assign --dry-run
+fizzy-symphony claim 42 --self-assign --in-flight-column col_in_flight --dry-run
 # fizzy card show 42 --agent --markdown
 # fizzy card self-assign 42 --agent --quiet
-# fizzy card column 42 --column 'In Flight' --agent --quiet
+# fizzy card column 42 --column col_in_flight --agent --quiet
 # fizzy comment create --card 42 --body 'Claimed by fizzy-symphony worker.' --agent --quiet
 
-fizzy-symphony claim 42 --assignee-id user-123 --in-flight-column ready --comment-body "Claimed by fizzy-symphony worker." --dry-run
+fizzy-symphony claim 42 --assignee-id user-123 --in-flight-column col_ready --comment-body "Claimed by fizzy-symphony worker." --dry-run
 # fizzy card show 42 --agent --markdown
 # fizzy card assign 42 --user user-123 --agent --quiet
 # fizzy card column 42 --column ready --agent --quiet
@@ -201,12 +201,31 @@ fizzy-symphony comment 42 --body "Proof of work attached." --dry-run
 
 ### `fizzy-symphony move`
 
-Prints the Fizzy CLI command that would move a card to a new column.
+Prints the Fizzy CLI command that would move a card to a custom column or Fizzy
+system lane. Custom columns should be targeted by real column ID. The system
+lanes are immutable pseudo lanes: `maybe`, `not-now`, and `done`.
 
 ```bash
 fizzy-symphony move 42 --column ready-to-ship --dry-run
 # fizzy card column 42 --column ready-to-ship --agent --quiet
+
+fizzy-symphony move 42 --column maybe --dry-run
+# fizzy card untriage 42 --agent --quiet
+
+fizzy-symphony move 42 --column not-now --dry-run
+# fizzy card postpone 42 --agent --quiet
+
+fizzy-symphony move 42 --column done --dry-run
+# fizzy card close 42 --agent --quiet
+
+fizzy-symphony move 42 --column "Ready for Agents" \
+  --custom-column "col_ready=Ready for Agents" --dry-run
+# fizzy card column 42 --column col_ready --agent --quiet
 ```
+
+Name-based custom-column resolution is only a convenience for mapped columns.
+Duplicate custom column names are rejected; use column IDs when a board has
+ambiguous display names.
 
 ### `fizzy-symphony plan`
 
@@ -314,8 +333,9 @@ python test-projects/workai-smoke/bootstrap_board.py --live --create-board
 ## Runner Strategy
 
 The runner boundary now lives in `fizzy_symphony.runners`. `CodexCliRunner`
-is the safe subprocess fallback, `CodexWorkItemRunner` adapts it to durable
-workitems, and the preferred future path remains the official Codex SDK/app-server.
+is the safe subprocess fallback, `CodexSdkRunner` uses the official Codex
+app-server protocol when the local runtime is available, and
+`CodexWorkItemRunner` adapts the runner contract to durable workitems.
 
 This project should not build its own coding-agent harness. For "let Codex work
 a repo card," use Codex as the harness and keep `fizzy-symphony` focused on

--- a/SPEC.md
+++ b/SPEC.md
@@ -37,6 +37,9 @@ Boundary:
 - `FizzyCLIAdapter`: dry-run adapter that builds Fizzy CLI commands for preview/debugging.
 - `FizzyOpenAPIAdapter`: future real adapter to be implemented from `basecamp/fizzy-sdk/openapi.json`.
 - `SymphonyColumn`: recommended tracker column for the upstream-inspired flow.
+- `FizzyCustomColumn`: known custom board column with a real Fizzy `column_id`.
+- `FizzyLaneTarget`: resolved move target, either `custom_column`, `triage`,
+  `not_now`, or `closed`.
 - `RobocorpWorkitemConfig`: environment contract for the published adapter
   package.
 
@@ -87,6 +90,10 @@ Supported completion policies:
 - no completion tag: post a comment only
 - `#close-on-complete`: post a comment, then close the card
 - `#move-to-<column-name>`: post a comment, then move to the named custom column
+
+Name-based custom-column resolution is valid only after mapping real Fizzy
+column IDs. Duplicate display names are ambiguous and must be resolved by
+column ID.
 
 ## Tracker Adapter Contract
 
@@ -146,6 +153,13 @@ Fizzy's built-in system lanes are always represented separately:
 
 Do not create, delete, or treat those system lanes as custom columns.
 
+Move planning branches by lane kind:
+
+- custom column: `fizzy card column CARD --column COLUMN_ID`
+- `maybe` / `triage`: `fizzy card untriage CARD`
+- `not-now` / `not_now`: `fizzy card postpone CARD`
+- `done` / `closed`: `fizzy card close CARD`
+
 ## Terminal States
 
 Terminal states indicate no more automated work should occur:
@@ -203,9 +217,11 @@ passes, and preserve the card as the source of truth for scope and status.
 
 ## Safety Invariants
 
-- Phase 0 is dry-run only; no subprocess execution is allowed.
-- No direct HTTP or API behavior is allowed in the scaffold beyond the explicit
-  future OpenAPI stub.
+- Tracker mutation previews are dry-run by default.
+- Runner and RCC smoke paths may execute subprocesses only through explicit
+  runner/robot entry points.
+- No direct Fizzy HTTP or API behavior is allowed in the scaffold beyond the
+  explicit future OpenAPI stub.
 - No daemon/background loop behavior is allowed yet.
 - The system must not create a hidden board by default; it configures or checks
   an existing Fizzy board unless the user explicitly opts into creation later.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ The scaffold treats **Fizzy as the tracker/board layer**. Tracker items are
 normalized into `FizzyCard` objects, while `CardAdapter` remains a compatibility
 wrapper for the existing demo board plan.
 
-Phase 0 keeps the system dry-run only. The CLI adapter mirrors real Fizzy CLI
+Tracker mutation remains dry-run-first. The CLI adapter mirrors real Fizzy CLI
 commands for preview/debugging, but it never executes subprocesses:
 
 - `fizzy card list`
@@ -55,8 +55,10 @@ steps above, not a required native `fizzy card claim` command.
 ## Key Design Decisions
 
 ### 1. Dry-Run-First
-All functionality is dry-run only. `FizzyCLIAdapter` raises if configured for
-non-dry-run use so Phase 0 cannot accidentally execute real tracker mutations.
+Tracker-facing CLI functionality is dry-run only. `FizzyCLIAdapter` raises if
+configured for non-dry-run use so preview flows cannot accidentally execute real
+tracker mutations. Runner and RCC smoke entry points are separate guarded
+execution paths.
 
 ### 2. Canonical Card Shape
 `FizzyCard` is the normalized tracker model. It keeps both the internal `id` and

--- a/docs/codex-runner-strategy.md
+++ b/docs/codex-runner-strategy.md
@@ -9,8 +9,8 @@ OpenAI documents a Codex SDK for programmatic control of local Codex agents:
 
 - TypeScript package: `@openai/codex-sdk`
 - Python SDK: experimental, controls the local Codex app-server over JSON-RPC,
-  requires Python 3.10+, and currently expects a local checkout of the
-  open-source Codex repo
+  requires Python 3.10+, and is installed here from the official OpenAI
+  `sdk/python` subdirectory until the packaging story is stable.
 - Non-interactive `codex exec --json` remains a useful fallback because it emits
   structured JSONL events, but the SDK gives a cleaner thread/resume/run API.
 
@@ -41,22 +41,26 @@ CodexRunResult
   raw_metadata
 ```
 
-Then implement runners in this order:
+Runner implementation order:
 
-1. `CodexSdkRunner` spike using the official SDK/app-server.
-2. `CodexCliRunner` fallback for non-interactive `codex` CLI execution.
+1. `CodexSdkRunner` uses the official Codex app-server JSON-RPC protocol.
+2. `CodexCliRunner` remains the fallback for non-interactive `codex` CLI execution.
 3. Optional TypeScript sidecar if the TypeScript SDK stays more stable than the
    experimental Python SDK.
 
 The workitem worker should depend on the runner contract, not the concrete SDK.
-Do not add a default dependency on either SDK until a local spike proves the
-auth, app-server, and packaging path works in Josh's Bluefin/devcontainer setup.
+Do not add a default dependency on either SDK until the auth, app-server, and
+packaging path is proven in Josh's Bluefin/devcontainer setup.
 
 Current implementation status: the repo now has a payload-agnostic runner
-boundary in `fizzy_symphony.runners`. `CodexCliRunner` is the safe fallback for
-local subprocess execution, `CodexWorkItemRunner` adapts that boundary to the
-durable workitem worker, and the SDK path intentionally fails clearly until the
-optional Codex SDK/app-server spike is implemented.
+boundary in `fizzy_symphony.runners`. `CodexSdkRunner` prefers the official
+`codex_app_server` Python SDK when installed, starts a one-turn Codex app-server
+thread in an isolated `cwd`, captures final answer/proof text and thread/turn
+metadata, and returns a clean failed `CodexRunResult` when the local Codex
+runtime or auth is unavailable. If the Python SDK import is unavailable, it can
+fall back to the same app-server JSON-RPC protocol directly. `CodexCliRunner`
+remains the safe subprocess fallback, and `CodexWorkItemRunner` adapts the
+runner contract to the durable workitem worker.
 
 ## How This Fits Durable Mode
 

--- a/docs/live-operator-guide.md
+++ b/docs/live-operator-guide.md
@@ -1,0 +1,122 @@
+# Live Operator Guide
+
+Use this when you want to run Fizzy Symphony from a clean checkout against a
+real Fizzy board and a real Codex CLI login.
+
+## 1. Open the Devcontainer
+
+This repo includes a devcontainer using `ghcr.io/joshyorko/ror:latest`.
+
+Open the repo in the container, then verify the Python package installed:
+
+```bash
+fizzy-symphony version
+python -m pytest -q
+```
+
+The devcontainer forwards `FIZZY_TOKEN`, `FIZZY_API_URL`, `FIZZY_PROFILE`,
+`FIZZY_BOARD`, and `OPENAI_API_KEY` from the host when those variables exist. It
+also mounts `.codex`, `.config/fizzy`, and `.robocorp` so Codex/Fizzy/RCC state
+can be reused.
+
+## 2. Authenticate Codex and Fizzy
+
+RCC does not need auth for this project. It only builds and runs the local robot
+environment.
+
+Codex CLI auth must exist in the same environment that runs the robot:
+
+```bash
+codex login
+codex login status
+```
+
+API-key auth is also supported by the CLI:
+
+```bash
+printenv OPENAI_API_KEY | codex login --with-api-key
+codex login status
+```
+
+Fizzy auth is separate:
+
+```bash
+fizzy setup
+# or:
+fizzy auth login "$FIZZY_TOKEN" --profile 1
+
+fizzy auth status
+fizzy doctor
+fizzy board list
+```
+
+## 3. Verify RCC Locally
+
+```bash
+rcc --version
+rcc ht vars -r robots/workitems/robot.yaml --json
+rcc run -r robots/workitems/robot.yaml -t Doctor --silent
+rcc run -r robots/workitems/robot.yaml -t SmokeSQLiteWorkitemFlow \
+  -e robots/workitems/devdata/env-sqlite.json --silent
+```
+
+## 4. Run One Live Card From Your Own Prompt
+
+Create or choose a Fizzy board and card. Get the board id, card number, and the
+real custom column id for your handoff column:
+
+```bash
+fizzy column list --board <board id> --agent --quiet
+fizzy card show <card number> --agent --quiet
+```
+
+Then run one card through SQLite workitems and Codex SDK:
+
+```bash
+export FIZZY_SYMPHONY_BOARD_ID=<board id>
+export FIZZY_SYMPHONY_CARD_NUMBER=<card number>
+export FIZZY_SYMPHONY_WORKSPACE=/absolute/path/to/project
+export FIZZY_SYMPHONY_PROMPT="$(cat prompt.md)"
+export FIZZY_SYMPHONY_HANDOFF_COLUMN_ID=<Synthesize & Verify column id>
+export FIZZY_SYMPHONY_LIVE_FIZZY=1
+
+rcc run -r robots/workitems/robot.yaml -t PromptCardSmoke --silent
+```
+
+The robot verifies the board/card, runs Codex with the official Python SDK,
+writes through `workspace-write` sandbox mode, creates a workitem output, posts a
+Fizzy comment, and moves the card to the handoff column.
+
+## 5. Run the Disposable Dashboard Smoke
+
+For a bigger visual board test:
+
+```bash
+python test-projects/workai-smoke/bootstrap_board.py --live --create-board
+```
+
+Copy the printed `smoke_env` values, then run:
+
+```bash
+export WORKAI_SMOKE_BOARD_ID=<printed board id>
+export WORKAI_SMOKE_CARD_NUMBERS=<printed fixture-to-live mapping>
+export WORKAI_SMOKE_GOLDEN_CARD_NUMBER=<printed golden card number>
+export WORKAI_SMOKE_HANDOFF_COLUMN_ID=<printed handoff column id>
+export WORKAI_SMOKE_LIVE_FIZZY=1
+
+rcc run -r robots/workitems/robot.yaml -t WorkAIProductionSmoke --silent
+```
+
+When finished, delete only the disposable board:
+
+```bash
+fizzy board delete <printed board id>
+```
+
+## Useful Defaults
+
+- Codex model: `gpt-5.4-mini`
+- Codex approval policy: `never`
+- Codex sandbox: `workspace-write`
+- RCC adapter: SQLite via `robocorp-adapters-custom`
+- Fizzy system lanes are built in: `Maybe?`, `Not Now`, and `Done`

--- a/docs/production-smoke-agent.md
+++ b/docs/production-smoke-agent.md
@@ -24,6 +24,10 @@ Before the full smoke starts, the agent must prove:
 - Fizzy auth passes `fizzy doctor`.
 - A disposable Fizzy board exists with a real golden ticket, not only tags.
 
+The smoke refuses to treat `CodexCliRunner` as SDK proof. If the SDK runner is
+missing, returns no thread/run identity, or reports CLI fallback metadata, the
+full smoke stops before queueing work.
+
 If any item fails, the smoke is blocked and should report the missing gate.
 
 ## Test Project
@@ -44,18 +48,66 @@ coordination are the thing under test.
 ## Required Smoke Flow
 
 1. Create or reuse a disposable Fizzy board from the WorkAI fixture.
-2. Confirm the golden ticket is actually golden via `fizzy card show`.
-3. Discover golden-ticket instructions from the board.
-4. Enqueue eligible task cards into SQLite workitems.
-5. Reserve one task at a time through RCC.
-6. Run Codex through the SDK runner in the sample project workspace.
-7. Create real sample-project artifacts: source changes, docs, and tests.
-8. Run the sample project test suite.
-9. Emit workitem result metadata including SDK thread/run identity.
-10. Report proof back to the matching Fizzy card.
-11. Move completed cards according to the golden-ticket completion policy.
-12. Produce a final smoke summary with board URL, card numbers, artifacts, SDK
+2. Mark the instruction card with `fizzy card golden <number>`.
+3. Confirm the golden ticket is actually golden via `fizzy card show`.
+4. Keep the cleanup command explicit: `fizzy board delete <board id>`.
+5. Discover golden-ticket instructions from the board.
+6. Enqueue eligible task cards into SQLite workitems.
+7. Reserve one task at a time through RCC.
+8. Run Codex through the SDK runner in the sample project workspace.
+9. Create real sample-project artifacts: source changes, docs, and tests.
+10. Run the sample project test suite.
+11. Emit workitem result metadata including SDK thread/run identity.
+12. Report proof back to the matching Fizzy card.
+13. Move completed cards according to the golden-ticket completion policy.
+14. Produce a final smoke summary with board URL, card numbers, artifacts, SDK
     metadata, RCC output path, and test output.
+
+## Disposable Board Commands
+
+Preview the setup without mutating Fizzy:
+
+```bash
+python test-projects/workai-smoke/bootstrap_board.py
+```
+
+Create a new disposable board and print the created card numbers:
+
+```bash
+python test-projects/workai-smoke/bootstrap_board.py --live --create-board
+```
+
+Reuse an existing disposable board:
+
+```bash
+python test-projects/workai-smoke/bootstrap_board.py --live --board-id <board id>
+```
+
+The bootstrap summary includes `cleanup_command`; run it only for the disposable
+smoke board after preserving any evidence Josh wants to inspect.
+
+## RCC Entry Point
+
+The production smoke robot is intentionally guarded:
+
+```bash
+WORKAI_SMOKE_BOARD_ID=<disposable board id> \
+  rcc run -r robots/workitems/robot.yaml -t WorkAIProductionSmoke
+```
+
+Set `WORKAI_SMOKE_LIVE_FIZZY=1` only when report-back comments and column moves
+should be posted to the disposable board. Live mode also requires
+`WORKAI_SMOKE_HANDOFF_COLUMN_ID=<Synthesize & Verify column id>` so the move
+targets a real custom column ID, `WORKAI_SMOKE_GOLDEN_CARD_NUMBER=<number>` so
+the harness verifies the actual golden ticket, and
+`WORKAI_SMOKE_CARD_NUMBERS=1=<live>,2=<live>,...` so fixture cards are mapped to
+the real disposable-board cards before any report-back happens. The robot uses
+`WORKAI_SMOKE_CODEX_MODEL=gpt-5.4-mini` and
+`WORKAI_SMOKE_CODEX_APPROVAL_POLICY=never` by default; override those only when
+you intentionally want a different Codex runtime profile.
+
+Without those variables, the harness creates local workitem/test artifacts and
+emits the Fizzy commands it would run.
 
 ## Non-Goals
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ workitems = [
     "robocorp-workitems>=1.4.7; python_version >= '3.10'",
     "robocorp-adapters-custom>=0.1.4; python_version >= '3.10'",
 ]
+codex-sdk = [
+    "codex-app-server-sdk @ git+https://github.com/openai/codex.git@87bc72408c5ef08f8d21f2cdd00c55451c3be33f#subdirectory=sdk/python; python_version >= '3.10'",
+]
 dev = [
     "pytest>=7.4",
     "pytest-cov>=4.1",

--- a/robots/workitems/conda.yaml
+++ b/robots/workitems/conda.yaml
@@ -3,7 +3,12 @@ channels:
 
 dependencies:
   - python=3.12.11
-  - uv=0.9.28
+  - nodejs=24
+  - pytest=9.0.2
+  - uv=0.11.7
   - pip:
-      - robocorp>=3.0
-      - robocorp-adapters-custom>=0.1.4
+      # Official OpenAI Python SDK for codex app-server; PyPI currently has a
+      # conflicting third-party artifact under this project name.
+      - "codex-app-server-sdk @ git+https://github.com/openai/codex.git@87bc72408c5ef08f8d21f2cdd00c55451c3be33f#subdirectory=sdk/python"
+      - robocorp==3.1.1 # https://pypi.org/project/robocorp
+      - robocorp-adapters-custom==0.1.5 # https://pypi.org/project/robocorp-adapters-custom

--- a/robots/workitems/robot.yaml
+++ b/robots/workitems/robot.yaml
@@ -3,6 +3,7 @@
 #   rcc run -r robots/workitems/robot.yaml -t Doctor
 #   rcc run -r robots/workitems/robot.yaml -t WorkitemsEnv
 #   rcc run -r robots/workitems/robot.yaml -t SmokeSQLiteWorkitemFlow -e robots/workitems/devdata/env-sqlite.json
+#   WORKAI_SMOKE_BOARD_ID=<disposable board id> rcc run -r robots/workitems/robot.yaml -t WorkAIProductionSmoke
 
 tasks:
   Doctor:
@@ -13,6 +14,9 @@ tasks:
 
   SmokeSQLiteWorkitemFlow:
     shell: python -m robocorp.tasks run tasks.py -t SmokeSQLiteWorkitemFlow
+
+  WorkAIProductionSmoke:
+    shell: python -m robocorp.tasks run tasks.py -t WorkAIProductionSmoke
 
 environmentConfigs:
   - conda.yaml

--- a/robots/workitems/robot.yaml
+++ b/robots/workitems/robot.yaml
@@ -4,6 +4,7 @@
 #   rcc run -r robots/workitems/robot.yaml -t WorkitemsEnv
 #   rcc run -r robots/workitems/robot.yaml -t SmokeSQLiteWorkitemFlow -e robots/workitems/devdata/env-sqlite.json
 #   WORKAI_SMOKE_BOARD_ID=<disposable board id> rcc run -r robots/workitems/robot.yaml -t WorkAIProductionSmoke
+#   FIZZY_SYMPHONY_BOARD_ID=<board id> FIZZY_SYMPHONY_CARD_NUMBER=<number> FIZZY_SYMPHONY_WORKSPACE=$PWD FIZZY_SYMPHONY_PROMPT='...' rcc run -r robots/workitems/robot.yaml -t PromptCardSmoke
 
 tasks:
   Doctor:
@@ -17,6 +18,9 @@ tasks:
 
   WorkAIProductionSmoke:
     shell: python -m robocorp.tasks run tasks.py -t WorkAIProductionSmoke
+
+  PromptCardSmoke:
+    shell: python -m robocorp.tasks run tasks.py -t PromptCardSmoke
 
 environmentConfigs:
   - conda.yaml

--- a/robots/workitems/tasks.py
+++ b/robots/workitems/tasks.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
+import shlex
+import subprocess
 import sys
 import types
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 try:
     from robocorp.tasks import get_output_dir, task
@@ -34,8 +37,23 @@ from fizzy_symphony.robocorp_adapter import (
     format_workitem_env,
     initialize_adapter_from_environment,
 )
+from fizzy_symphony.runners import (
+    CodexCliRunner,
+    CodexRunRequest,
+    CodexWorkItemRunner,
+    create_codex_runner,
+)
 from fizzy_symphony.workitem_pipeline import CodexWorkItemWorker
 from fizzy_symphony.workitem_queue import FizzyWorkItemPayload, JSONDict, WorkItemQueue
+
+
+WORKAI_SMOKE_ROOT = REPO_ROOT / "test-projects" / "workai-smoke"
+WORKAI_FIXTURE_PATH = WORKAI_SMOKE_ROOT / "board.fixture.json"
+WORKAI_SAMPLE_PROJECT = WORKAI_SMOKE_ROOT / "sample_project"
+
+
+class FullSmokeBlocked(RuntimeError):
+    """Raised when a production smoke preflight is intentionally not satisfied."""
 
 
 class InMemoryWorkItemAdapter:
@@ -177,7 +195,9 @@ def run_smoke_sqlite_workitem_flow(
 ) -> JSONDict:
     artifacts_dir = resolve_output_dir(output_dir)
     selected_adapter, adapter_kind = (
-        (adapter, "provided") if adapter is not None else make_smoke_adapter(artifacts_dir, prefer_real=prefer_real_adapter)
+        (adapter, "provided")
+        if adapter is not None
+        else make_smoke_adapter(artifacts_dir, prefer_real=prefer_real_adapter)
     )
     queue = WorkItemQueue(selected_adapter)
 
@@ -211,6 +231,531 @@ def run_smoke_sqlite_workitem_flow(
     return proof
 
 
+def load_workai_fixture(path: Path = WORKAI_FIXTURE_PATH) -> JSONDict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_workai_production_smoke(
+    *,
+    board_id: Optional[str],
+    output_dir: Optional[Path] = None,
+    sample_project_dir: Path = WORKAI_SAMPLE_PROJECT,
+    fixture_path: Path = WORKAI_FIXTURE_PATH,
+    adapter=None,
+    runner=None,
+    prefer_real_adapter: bool = True,
+    live_fizzy: bool = False,
+    handoff_column_id: Optional[str] = None,
+    live_card_numbers: Optional[Dict[int, int]] = None,
+    golden_card_number: Optional[int] = None,
+    codex_model: Optional[str] = "gpt-5.4-mini",
+    codex_approval_policy: Optional[str] = "never",
+    codex_sandbox_mode: Optional[str] = "workspace-write",
+) -> JSONDict:
+    """Run the WorkAI fixture through SDK-backed workitems and sample tests.
+
+    The default path is intentionally blocked until the public SDK runner exists.
+    Tests can inject an SDK-shaped runner to exercise the full harness without
+    live Fizzy mutations.
+    """
+
+    artifacts_dir = resolve_output_dir(output_dir)
+    sample_project_dir = Path(sample_project_dir)
+    fixture = load_workai_fixture(fixture_path)
+    board_id = _require_disposable_board_id(board_id)
+    sdk_runner, sdk_preflight = _require_sdk_runner(
+        runner,
+        workspace=sample_project_dir,
+        codex_model=codex_model,
+        codex_approval_policy=codex_approval_policy,
+        codex_sandbox_mode=codex_sandbox_mode,
+    )
+    selected_adapter, adapter_kind = _make_required_workai_adapter(
+        artifacts_dir,
+        adapter=adapter,
+        prefer_real_adapter=prefer_real_adapter,
+    )
+    queue = WorkItemQueue(selected_adapter)
+    setup_commands = _workai_setup_commands(fixture, board_id=board_id)
+    fizzy_preflight = _run_fizzy_preflight(
+        board_id=board_id,
+        fixture=fixture,
+        live=live_fizzy,
+        live_card_numbers=live_card_numbers,
+        golden_card_number=golden_card_number,
+    )
+
+    cards = []
+    for card in fixture.get("task_cards", []):
+        payload = _workai_payload_for_card(
+            card,
+            board_id=board_id,
+            workspace=sample_project_dir,
+            codex_model=codex_model,
+            codex_approval_policy=codex_approval_policy,
+            codex_sandbox_mode=codex_sandbox_mode,
+        )
+        input_id = queue.enqueue_input(payload)
+        worker_result = CodexWorkItemWorker(
+            queue=queue,
+            runner=CodexWorkItemRunner(sdk_runner),
+        ).work_one()
+        output_payload = _load_output_payload(selected_adapter, worker_result.output_id)
+        fixture_card_number = int(card["number"])
+        live_card_number = _resolve_report_card_number(
+            fixture_card_number,
+            live=live_fizzy,
+            live_card_numbers=live_card_numbers,
+        )
+        report_back = _report_card_result(
+            output_payload,
+            card_number=live_card_number,
+            live=live_fizzy,
+            handoff_column_id=handoff_column_id,
+        )
+        sdk = _sdk_metadata(output_payload.get("result", {}))
+        cards.append(
+            {
+                "card_number": fixture_card_number,
+                "live_card_number": live_card_number if live_fizzy else None,
+                "title": card["title"],
+                "input_id": input_id,
+                "worker": {
+                    "item_id": worker_result.item_id,
+                    "output_id": worker_result.output_id,
+                    "succeeded": worker_result.succeeded,
+                },
+                "sdk": sdk,
+                "artifacts": output_payload.get("result", {}).get("artifacts", {}),
+                "report_back": report_back,
+            }
+        )
+
+    sample_tests = _run_sample_project_tests(sample_project_dir, artifacts_dir)
+    all_cards_succeeded = all(card["worker"]["succeeded"] for card in cards)
+    status = "PASS" if sample_tests["returncode"] == 0 and all_cards_succeeded else "FAIL"
+    summary: JSONDict = {
+        "status": status,
+        "board": {
+            "id": board_id,
+            "url": _board_url(board_id),
+            "mutated_fizzy": live_fizzy,
+            "setup_commands": setup_commands,
+            "cleanup_command": f"fizzy board delete {shlex.quote(board_id)}",
+            "golden_ticket": fixture.get("golden_tickets", [{}])[0].get("title"),
+            "golden_proof_command": "fizzy card show <golden card number>",
+        },
+        "preflight": {
+            "fizzy": fizzy_preflight,
+            "sqlite_workitems": {
+                "adapter": adapter_kind,
+                "required": prefer_real_adapter,
+            },
+            "sdk": sdk_preflight,
+        },
+        "cards": cards,
+        "sample_project_tests": sample_tests,
+        "artifacts": {},
+    }
+    summary_path = artifacts_dir / "workai-production-smoke-summary.json"
+    summary["artifacts"]["summary_path"] = str(summary_path)
+    summary["artifacts"]["pytest_output_path"] = sample_tests["output_path"]
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    return summary
+
+
+def _require_disposable_board_id(board_id: Optional[str]) -> str:
+    if not board_id:
+        raise FullSmokeBlocked(
+            "Full WorkAI smoke requires an explicit disposable board id. "
+            "Create or choose the disposable board intentionally before running."
+        )
+    return board_id
+
+
+def _require_sdk_runner(
+    runner,
+    *,
+    workspace: Path,
+    codex_model: Optional[str],
+    codex_approval_policy: Optional[str],
+    codex_sandbox_mode: Optional[str],
+):
+    if runner is None:
+        try:
+            runner = create_codex_runner("sdk")
+        except Exception as exc:  # noqa: BLE001 - preserve the runner's reason.
+            raise FullSmokeBlocked(f"Codex SDK runner is unavailable: {exc}") from exc
+
+    runner_kind = str(getattr(runner, "runner_kind", "")).lower()
+    if isinstance(runner, CodexCliRunner) or runner_kind in {"cli", "codex_cli"}:
+        raise FullSmokeBlocked("Full WorkAI smoke must use CodexSdkRunner, not CodexCliRunner.")
+
+    try:
+        result = runner(
+            CodexRunRequest(
+                prompt="Reply exactly: WORKAI_SDK_PREFLIGHT_OK",
+                workspace=str(workspace),
+                model=codex_model,
+                approval_policy=codex_approval_policy,
+                sandbox_mode=codex_sandbox_mode,
+                timeout_seconds=60,
+                metadata={"preflight": True, "smoke": "workai"},
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 - placeholder SDK runner raises RuntimeError.
+        raise FullSmokeBlocked(f"Codex SDK runner failed preflight: {exc}") from exc
+
+    if not result.success:
+        detail = result.stderr or result.validation_summary or result.final_response
+        raise FullSmokeBlocked(
+            f"Codex SDK runner preflight returned an unsuccessful result: {detail}"
+        )
+    if not result.final_response:
+        raise FullSmokeBlocked("Codex SDK runner preflight did not return final response text.")
+
+    sdk = _sdk_metadata(result.to_workitem_result())
+    if sdk["runner"] == "codex_cli":
+        raise FullSmokeBlocked("Codex CLI fallback cannot validate SDK-backed production smoke.")
+    if not sdk["thread_id"] or not sdk["run_id"] or not sdk["raw_metadata"]:
+        raise FullSmokeBlocked(
+            "Codex SDK runner preflight must include thread id, run id, and raw metadata."
+        )
+    return runner, sdk
+
+
+def _make_required_workai_adapter(
+    output_dir: Path,
+    *,
+    adapter=None,
+    prefer_real_adapter: bool,
+):
+    if adapter is not None:
+        return adapter, "provided"
+    if not prefer_real_adapter:
+        return make_smoke_adapter(output_dir, prefer_real=False)
+    if not adapter_package_available():
+        raise FullSmokeBlocked("SQLite workitem adapter package is unavailable.")
+    ensure_safe_sqlite_env(output_dir)
+    install_adapter_config_shim()
+    try:
+        return initialize_adapter_from_environment(), "robocorp-adapters-custom"
+    except Exception as exc:  # noqa: BLE001 - expose adapter initialization blocker.
+        raise FullSmokeBlocked(f"SQLite workitem adapter could not initialize: {exc}") from exc
+
+
+def _workai_payload_for_card(
+    card: JSONDict,
+    *,
+    board_id: str,
+    workspace: Path,
+    codex_model: Optional[str],
+    codex_approval_policy: Optional[str],
+    codex_sandbox_mode: Optional[str],
+) -> FizzyWorkItemPayload:
+    number = int(card["number"])
+    fizzy_card = FizzyCard(
+        id=f"workai-smoke-{number}",
+        number=number,
+        identifier=f"WORKAI-{number}",
+        title=str(card["title"]),
+        description=str(card["description"]),
+        state=str(card.get("target_column") or "Ready for Agents"),
+        labels=["workai-smoke", "codex-sdk"],
+    )
+    card_data = {
+        **fizzy_card.__dict__,
+        "board_id": board_id,
+        "expected_artifact": card.get("expected_artifact"),
+    }
+    return FizzyWorkItemPayload(
+        source="fizzy",
+        card=card_data,
+        workflow={
+            "prompt_template": _workai_prompt(card),
+            "allowed_paths": ["test-projects/workai-smoke/sample_project"],
+            "handoff_column": "Synthesize & Verify",
+            "workspace": str(workspace),
+        },
+        runner={
+            "kind": "codex_sdk",
+            "workspace": str(workspace),
+            "model": codex_model,
+            "approval_policy": codex_approval_policy,
+            "sandbox_mode": codex_sandbox_mode,
+            "timeout_seconds": 600,
+        },
+    )
+
+
+def _workai_prompt(card: JSONDict) -> str:
+    return (
+        "You are running the disposable WorkAI production smoke fixture.\n"
+        f"Card {card['number']}: {card['title']}\n"
+        f"Task: {card['description']}\n"
+        f"Expected artifact: {card['expected_artifact']}\n"
+        "Edit only the sample project, run its tests when useful, and return concise proof."
+    )
+
+
+def _load_output_payload(adapter, output_id: Optional[str]) -> JSONDict:
+    if output_id is None:
+        return {}
+    try:
+        return adapter.load_payload(output_id)
+    except Exception:
+        outputs = getattr(adapter, "outputs", {})
+        return dict(outputs.get(output_id, {}))
+
+
+def _sdk_metadata(result: JSONDict) -> JSONDict:
+    raw_metadata = dict(result.get("raw_metadata") or {})
+    thread_id = result.get("thread_id") or raw_metadata.get("thread_id")
+    run_id = raw_metadata.get("run_id") or raw_metadata.get("response_id") or raw_metadata.get("id")
+    runner = (
+        raw_metadata.get("runner")
+        or raw_metadata.get("runner_kind")
+        or raw_metadata.get("kind")
+    )
+    return {
+        "runner": runner,
+        "thread_id": thread_id,
+        "run_id": run_id,
+        "raw_metadata": raw_metadata,
+    }
+
+
+def _run_sample_project_tests(sample_project_dir: Path, output_dir: Path) -> JSONDict:
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(sample_project_dir)
+        if not existing
+        else f"{sample_project_dir}{os.pathsep}{existing}"
+    )
+    command = [sys.executable, "-m", "pytest", "tests"]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=sample_project_dir,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=120,
+            check=False,
+        )
+        returncode = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+    except subprocess.TimeoutExpired as exc:
+        returncode = -1
+        stdout = _coerce_process_output(exc.stdout)
+        stderr = _coerce_process_output(exc.stderr)
+        stderr = f"{stderr}\nTimed out after 120 seconds.".strip()
+    output_path = output_dir / "workai-sample-pytest.txt"
+    output_path.write_text(
+        stdout + ("\n--- stderr ---\n" + stderr if stderr else ""),
+        encoding="utf-8",
+    )
+    return {
+        "command": command,
+        "cwd": str(sample_project_dir),
+        "returncode": returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "output_path": str(output_path),
+    }
+
+
+def _report_card_result(
+    output_payload: JSONDict,
+    *,
+    card_number: int,
+    live: bool,
+    handoff_column_id: Optional[str],
+) -> JSONDict:
+    result = output_payload.get("result", {})
+    sdk = _sdk_metadata(result)
+    final_response = str(
+        result.get("final_response") or output_payload.get("comment") or "completed"
+    )
+    comment = (
+        "SDK smoke proof: "
+        f"{final_response[:180]} "
+        f"(thread={sdk['thread_id']}, run={sdk['run_id']})"
+    )
+    target_column = handoff_column_id or "<Synthesize & Verify column id>"
+    commands = [
+        _join_command(["fizzy", "comment", "create", "--card", str(card_number), "--body", comment]),
+        _join_command(
+            ["fizzy", "card", "column", str(card_number), "--column", target_column]
+        ),
+    ]
+    if live:
+        if not handoff_column_id:
+            raise FullSmokeBlocked(
+                "Live WorkAI smoke requires WORKAI_SMOKE_HANDOFF_COLUMN_ID for Synthesize & Verify."
+            )
+        subprocess.run(
+            ["fizzy", "comment", "create", "--card", str(card_number), "--body", comment],
+            check=True,
+        )
+        subprocess.run(
+            ["fizzy", "card", "column", str(card_number), "--column", handoff_column_id],
+            check=True,
+        )
+    return {
+        "mode": "live" if live else "dry-run",
+        "comment": comment,
+        "commands": commands,
+    }
+
+
+def _resolve_report_card_number(
+    fixture_card_number: int,
+    *,
+    live: bool,
+    live_card_numbers: Optional[Dict[int, int]],
+) -> int:
+    if not live:
+        return fixture_card_number
+    if not live_card_numbers or fixture_card_number not in live_card_numbers:
+        raise FullSmokeBlocked(
+            f"Live WorkAI smoke requires WORKAI_SMOKE_CARD_NUMBERS to map fixture card {fixture_card_number}."
+        )
+    return int(live_card_numbers[fixture_card_number])
+
+
+def _run_fizzy_preflight(
+    *,
+    board_id: str,
+    fixture: JSONDict,
+    live: bool,
+    live_card_numbers: Optional[Dict[int, int]],
+    golden_card_number: Optional[int],
+) -> JSONDict:
+    if not live:
+        return {
+            "mode": "dry-run",
+            "doctor_command": "fizzy doctor",
+            "golden_check": "fizzy card show <golden card number>",
+        }
+    if not golden_card_number:
+        raise FullSmokeBlocked("Live WorkAI smoke requires WORKAI_SMOKE_GOLDEN_CARD_NUMBER.")
+    if not live_card_numbers:
+        raise FullSmokeBlocked("Live WorkAI smoke requires WORKAI_SMOKE_CARD_NUMBERS.")
+    completed = subprocess.run(["fizzy", "doctor"], text=True, capture_output=True, check=False)
+    if completed.returncode != 0:
+        raise FullSmokeBlocked(f"fizzy doctor failed: {completed.stderr or completed.stdout}")
+
+    board = _run_json(["fizzy", "board", "show", board_id, "--agent", "--quiet"])
+    if str(board.get("id") or "") != board_id:
+        raise FullSmokeBlocked(f"Disposable board {board_id} could not be verified.")
+
+    golden = _run_json(["fizzy", "card", "show", str(golden_card_number), "--agent", "--quiet"])
+    _verify_live_card_on_board(golden, board_id=board_id, expected_golden=True)
+
+    for card in fixture.get("task_cards", []):
+        fixture_number = int(card["number"])
+        live_number = live_card_numbers.get(fixture_number)
+        if live_number is None:
+            raise FullSmokeBlocked(
+                f"WORKAI_SMOKE_CARD_NUMBERS is missing fixture card {fixture_number}."
+            )
+        live_card = _run_json(["fizzy", "card", "show", str(live_number), "--agent", "--quiet"])
+        _verify_live_card_on_board(live_card, board_id=board_id, expected_golden=False)
+
+    return {
+        "mode": "live",
+        "doctor_command": "fizzy doctor",
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "board_id": board_id,
+        "golden_card_number": golden_card_number,
+        "verified_card_numbers": dict(sorted(live_card_numbers.items())),
+    }
+
+
+def _run_json(command: List[str]) -> JSONDict:
+    completed = subprocess.run(command, text=True, capture_output=True, check=False)
+    if completed.returncode != 0:
+        raise FullSmokeBlocked(completed.stderr or completed.stdout or f"Command failed: {command}")
+    try:
+        data = json.loads(completed.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise FullSmokeBlocked(f"Command did not return JSON: {command}") from exc
+    if isinstance(data, Mapping) and isinstance(data.get("data"), Mapping):
+        return dict(data["data"])
+    if isinstance(data, Mapping):
+        return dict(data)
+    return {}
+
+
+def _verify_live_card_on_board(card: JSONDict, *, board_id: str, expected_golden: bool) -> None:
+    card_board = card.get("board")
+    actual_board_id = card_board.get("id") if isinstance(card_board, Mapping) else None
+    if actual_board_id != board_id:
+        raise FullSmokeBlocked(
+            f"Card {card.get('number')} belongs to board {actual_board_id}, not disposable board {board_id}."
+        )
+    if bool(card.get("golden")) != expected_golden:
+        expected = "golden" if expected_golden else "not golden"
+        raise FullSmokeBlocked(f"Card {card.get('number')} is not verified as {expected}.")
+
+
+def _workai_setup_commands(fixture: JSONDict, *, board_id: str) -> List[str]:
+    bootstrap = _load_workai_bootstrap_module()
+    commands = list(bootstrap.build_dry_run_commands(fixture, board_id=board_id))
+    commands.append(f"fizzy board delete {shlex.quote(board_id)}")
+    return commands
+
+
+def _load_workai_bootstrap_module():
+    path = WORKAI_SMOKE_ROOT / "bootstrap_board.py"
+    spec = importlib.util.spec_from_file_location("workai_smoke_bootstrap_runtime", path)
+    module = importlib.util.module_from_spec(spec)
+    if spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    spec.loader.exec_module(module)
+    return module
+
+
+def _board_url(board_id: str) -> str:
+    return f"fizzy://board/{board_id}"
+
+
+def _join_command(parts: List[str]) -> str:
+    return " ".join(shlex.quote(part) for part in parts)
+
+
+def _coerce_process_output(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return str(value)
+
+
+def _parse_card_number_mapping(raw: Optional[str]) -> Optional[Dict[int, int]]:
+    if not raw:
+        return None
+    mapping: Dict[int, int] = {}
+    for pair in raw.split(","):
+        if not pair.strip():
+            continue
+        if "=" not in pair:
+            raise FullSmokeBlocked("WORKAI_SMOKE_CARD_NUMBERS must use fixture=live pairs.")
+        fixture_number, live_number = pair.split("=", 1)
+        mapping[int(fixture_number.strip())] = int(live_number.strip())
+    return mapping
+
+
+def _parse_optional_int(raw: Optional[str]) -> Optional[int]:
+    if raw is None or raw == "":
+        return None
+    return int(raw)
+
+
 @task
 def Doctor() -> None:
     output_dir = resolve_output_dir()
@@ -231,4 +776,19 @@ def WorkitemsEnv() -> None:
 @task
 def SmokeSQLiteWorkitemFlow() -> None:
     proof = run_smoke_sqlite_workitem_flow()
+    print(json.dumps(proof, indent=2, sort_keys=True))
+
+
+@task
+def WorkAIProductionSmoke() -> None:
+    proof = run_workai_production_smoke(
+        board_id=os.getenv("WORKAI_SMOKE_BOARD_ID"),
+        live_fizzy=os.getenv("WORKAI_SMOKE_LIVE_FIZZY") == "1",
+        handoff_column_id=os.getenv("WORKAI_SMOKE_HANDOFF_COLUMN_ID"),
+        live_card_numbers=_parse_card_number_mapping(os.getenv("WORKAI_SMOKE_CARD_NUMBERS")),
+        golden_card_number=_parse_optional_int(os.getenv("WORKAI_SMOKE_GOLDEN_CARD_NUMBER")),
+        codex_model=os.getenv("WORKAI_SMOKE_CODEX_MODEL") or "gpt-5.4-mini",
+        codex_approval_policy=os.getenv("WORKAI_SMOKE_CODEX_APPROVAL_POLICY") or "never",
+        codex_sandbox_mode=os.getenv("WORKAI_SMOKE_CODEX_SANDBOX") or "workspace-write",
+    )
     print(json.dumps(proof, indent=2, sort_keys=True))

--- a/robots/workitems/tasks.py
+++ b/robots/workitems/tasks.py
@@ -364,12 +364,122 @@ def run_workai_production_smoke(
     return summary
 
 
+def run_prompt_card_smoke(
+    *,
+    board_id: Optional[str],
+    card_number: Optional[int],
+    prompt: Optional[str],
+    workspace: Optional[Path],
+    output_dir: Optional[Path] = None,
+    adapter=None,
+    runner=None,
+    prefer_real_adapter: bool = True,
+    live_fizzy: bool = False,
+    handoff_column_id: Optional[str] = None,
+    codex_model: Optional[str] = "gpt-5.4-mini",
+    codex_approval_policy: Optional[str] = "never",
+    codex_sandbox_mode: Optional[str] = "workspace-write",
+) -> JSONDict:
+    """Run one explicit prompt/card through SQLite workitems and Codex SDK."""
+
+    board_id = _require_board_id(
+        board_id,
+        "Prompt card smoke requires FIZZY_SYMPHONY_BOARD_ID.",
+    )
+    if not card_number:
+        raise FullSmokeBlocked("Prompt card smoke requires FIZZY_SYMPHONY_CARD_NUMBER.")
+    if not prompt:
+        raise FullSmokeBlocked("Prompt card smoke requires FIZZY_SYMPHONY_PROMPT.")
+    if workspace is None:
+        raise FullSmokeBlocked("Prompt card smoke requires FIZZY_SYMPHONY_WORKSPACE.")
+
+    artifacts_dir = resolve_output_dir(output_dir)
+    workspace = Path(workspace).resolve()
+    if not workspace.is_dir():
+        raise FullSmokeBlocked(f"Prompt card workspace does not exist: {workspace}")
+
+    sdk_runner, sdk_preflight = _require_sdk_runner(
+        runner,
+        workspace=workspace,
+        codex_model=codex_model,
+        codex_approval_policy=codex_approval_policy,
+        codex_sandbox_mode=codex_sandbox_mode,
+    )
+    selected_adapter, adapter_kind = _make_required_workai_adapter(
+        artifacts_dir,
+        adapter=adapter,
+        prefer_real_adapter=prefer_real_adapter,
+    )
+    fizzy_preflight = _run_prompt_card_fizzy_preflight(
+        board_id=board_id,
+        card_number=card_number,
+        live=live_fizzy,
+    )
+
+    payload = _prompt_card_payload(
+        board_id=board_id,
+        card_number=card_number,
+        prompt=prompt,
+        workspace=workspace,
+        live_card=fizzy_preflight.get("card") if live_fizzy else None,
+        codex_model=codex_model,
+        codex_approval_policy=codex_approval_policy,
+        codex_sandbox_mode=codex_sandbox_mode,
+    )
+    queue = WorkItemQueue(selected_adapter)
+    input_id = queue.enqueue_input(payload)
+    worker_result = CodexWorkItemWorker(
+        queue=queue,
+        runner=CodexWorkItemRunner(sdk_runner),
+    ).work_one()
+    output_payload = _load_output_payload(selected_adapter, worker_result.output_id)
+    report_back = _report_card_result(
+        output_payload,
+        card_number=card_number,
+        live=live_fizzy,
+        handoff_column_id=handoff_column_id,
+    )
+    summary: JSONDict = {
+        "status": "PASS" if worker_result.succeeded else "FAIL",
+        "board": {
+            "id": board_id,
+            "url": _board_url(board_id),
+            "mutated_fizzy": live_fizzy,
+        },
+        "card_number": card_number,
+        "workspace": str(workspace),
+        "preflight": {
+            "fizzy": fizzy_preflight,
+            "sqlite_workitems": {"adapter": adapter_kind, "required": prefer_real_adapter},
+            "sdk": sdk_preflight,
+        },
+        "worker": {
+            "input_id": input_id,
+            "item_id": worker_result.item_id,
+            "output_id": worker_result.output_id,
+            "succeeded": worker_result.succeeded,
+        },
+        "sdk": _sdk_metadata(output_payload.get("result", {})),
+        "report_back": report_back,
+        "artifacts": {},
+    }
+    summary_path = artifacts_dir / "prompt-card-smoke-summary.json"
+    summary["artifacts"]["summary_path"] = str(summary_path)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    return summary
+
+
 def _require_disposable_board_id(board_id: Optional[str]) -> str:
+    return _require_board_id(
+        board_id,
+        "Full WorkAI smoke requires an explicit disposable board id. "
+        "Create or choose the disposable board intentionally before running.",
+    )
+
+
+def _require_board_id(board_id: Optional[str], message: str) -> str:
     if not board_id:
-        raise FullSmokeBlocked(
-            "Full WorkAI smoke requires an explicit disposable board id. "
-            "Create or choose the disposable board intentionally before running."
-        )
+        raise FullSmokeBlocked(message)
     return board_id
 
 
@@ -484,6 +594,53 @@ def _workai_payload_for_card(
             "approval_policy": codex_approval_policy,
             "sandbox_mode": codex_sandbox_mode,
             "timeout_seconds": 600,
+        },
+    )
+
+
+def _prompt_card_payload(
+    *,
+    board_id: str,
+    card_number: int,
+    prompt: str,
+    workspace: Path,
+    live_card: Optional[JSONDict],
+    codex_model: Optional[str],
+    codex_approval_policy: Optional[str],
+    codex_sandbox_mode: Optional[str],
+) -> FizzyWorkItemPayload:
+    title = "Prompt card"
+    description = prompt
+    if live_card:
+        title = str(live_card.get("title") or title)
+        description = str(live_card.get("description") or prompt)
+    column = live_card.get("column") if live_card else None
+    fizzy_card = FizzyCard(
+        id=str(live_card.get("id") if live_card else f"prompt-card-{card_number}"),
+        number=card_number,
+        identifier=f"FIZZY-{card_number}",
+        title=title,
+        description=description,
+        state=str(column.get("name") if isinstance(column, Mapping) else "Ready for Agents"),
+        labels=["prompt-card", "codex-sdk"],
+    )
+    card_data = {**fizzy_card.__dict__, "board_id": board_id}
+    return FizzyWorkItemPayload(
+        source="fizzy",
+        card=card_data,
+        workflow={
+            "prompt_template": prompt,
+            "allowed_paths": [str(workspace)],
+            "handoff_column": "Synthesize & Verify",
+            "workspace": str(workspace),
+        },
+        runner={
+            "kind": "codex_sdk",
+            "workspace": str(workspace),
+            "model": codex_model,
+            "approval_policy": codex_approval_policy,
+            "sandbox_mode": codex_sandbox_mode,
+            "timeout_seconds": 900,
         },
     )
 
@@ -676,6 +833,35 @@ def _run_fizzy_preflight(
     }
 
 
+def _run_prompt_card_fizzy_preflight(
+    *,
+    board_id: str,
+    card_number: int,
+    live: bool,
+) -> JSONDict:
+    if not live:
+        return {
+            "mode": "dry-run",
+            "board_check": f"fizzy board show {board_id} --agent --quiet",
+            "card_check": f"fizzy card show {card_number} --agent --quiet",
+        }
+    completed = subprocess.run(["fizzy", "doctor"], text=True, capture_output=True, check=False)
+    if completed.returncode != 0:
+        raise FullSmokeBlocked(f"fizzy doctor failed: {completed.stderr or completed.stdout}")
+    board = _run_json(["fizzy", "board", "show", board_id, "--agent", "--quiet"])
+    if str(board.get("id") or "") != board_id:
+        raise FullSmokeBlocked(f"Board {board_id} could not be verified.")
+    card = _run_json(["fizzy", "card", "show", str(card_number), "--agent", "--quiet"])
+    _verify_live_card_on_board(card, board_id=board_id, expected_golden=False)
+    return {
+        "mode": "live",
+        "doctor_command": "fizzy doctor",
+        "board_id": board_id,
+        "card_number": card_number,
+        "card": card,
+    }
+
+
 def _run_json(command: List[str]) -> JSONDict:
     completed = subprocess.run(command, text=True, capture_output=True, check=False)
     if completed.returncode != 0:
@@ -756,6 +942,12 @@ def _parse_optional_int(raw: Optional[str]) -> Optional[int]:
     return int(raw)
 
 
+def _parse_optional_path(raw: Optional[str]) -> Optional[Path]:
+    if raw is None or raw == "":
+        return None
+    return Path(raw)
+
+
 @task
 def Doctor() -> None:
     output_dir = resolve_output_dir()
@@ -790,5 +982,21 @@ def WorkAIProductionSmoke() -> None:
         codex_model=os.getenv("WORKAI_SMOKE_CODEX_MODEL") or "gpt-5.4-mini",
         codex_approval_policy=os.getenv("WORKAI_SMOKE_CODEX_APPROVAL_POLICY") or "never",
         codex_sandbox_mode=os.getenv("WORKAI_SMOKE_CODEX_SANDBOX") or "workspace-write",
+    )
+    print(json.dumps(proof, indent=2, sort_keys=True))
+
+
+@task
+def PromptCardSmoke() -> None:
+    proof = run_prompt_card_smoke(
+        board_id=os.getenv("FIZZY_SYMPHONY_BOARD_ID"),
+        card_number=_parse_optional_int(os.getenv("FIZZY_SYMPHONY_CARD_NUMBER")),
+        prompt=os.getenv("FIZZY_SYMPHONY_PROMPT"),
+        workspace=_parse_optional_path(os.getenv("FIZZY_SYMPHONY_WORKSPACE")),
+        live_fizzy=os.getenv("FIZZY_SYMPHONY_LIVE_FIZZY") == "1",
+        handoff_column_id=os.getenv("FIZZY_SYMPHONY_HANDOFF_COLUMN_ID"),
+        codex_model=os.getenv("FIZZY_SYMPHONY_CODEX_MODEL") or "gpt-5.4-mini",
+        codex_approval_policy=os.getenv("FIZZY_SYMPHONY_CODEX_APPROVAL_POLICY") or "never",
+        codex_sandbox_mode=os.getenv("FIZZY_SYMPHONY_CODEX_SANDBOX") or "workspace-write",
     )
     print(json.dumps(proof, indent=2, sort_keys=True))

--- a/src/fizzy_symphony/__init__.py
+++ b/src/fizzy_symphony/__init__.py
@@ -37,7 +37,15 @@ from .runners import (
     Runner,
     create_codex_runner,
 )
-from .symphony import FizzySystemLane, SymphonyColumn, SymphonyMapping, fizzy_system_lanes
+from .symphony import (
+    FizzyCustomColumn,
+    FizzyLaneTarget,
+    FizzySystemLane,
+    SymphonyColumn,
+    SymphonyMapping,
+    fizzy_system_lanes,
+    resolve_fizzy_lane,
+)
 from .tracker import TrackerAdapter
 from .workitem_pipeline import CodexWorkItemWorker, FizzyWorkItemProducer, FizzyWorkItemReporter
 from .workitem_queue import FizzyWorkItemPayload, ReservedWorkItem, WorkItemQueue, WorkItemState
@@ -49,6 +57,8 @@ __all__ = [
     "FizzyCard",
     "FizzyConfig",
     "FizzyCLIAdapter",
+    "FizzyCustomColumn",
+    "FizzyLaneTarget",
     "FizzyOpenAPIAdapter",
     "FizzyWorkItemPayload",
     "FizzyWorkItemProducer",
@@ -84,4 +94,5 @@ __all__ = [
     "create_codex_runner",
     "fizzy_system_lanes",
     "parse_golden_ticket_card",
+    "resolve_fizzy_lane",
 ]

--- a/src/fizzy_symphony/adapters/fizzy_cli.py
+++ b/src/fizzy_symphony/adapters/fizzy_cli.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 from shlex import quote
-from typing import List, Optional
+from typing import Any, List, Mapping, Optional, Sequence, Union
 
 from ..models import FizzyConfig
+from ..symphony import FizzyCustomColumn, FizzyLaneTarget, resolve_fizzy_lane
 
 
 @dataclass(frozen=True)
@@ -92,12 +93,46 @@ class FizzyCLIAdapter:
         parts.extend(self.config.extra_flags)
         return " ".join(parts)
 
-    def build_move_command(self, card_number: int, column_id: str) -> str:
-        """Build the Fizzy CLI command used to move a card to a column.
+    def build_move_command(
+        self,
+        card_number: int,
+        target: str,
+        *,
+        custom_columns: Sequence[Union[FizzyCustomColumn, Mapping[str, Any]]] = (),
+    ) -> str:
+        """Build the Fizzy CLI command used to move a card to a lane.
 
-        Compatibility wrapper over :meth:`build_move_to_column_command`.
+        Custom lanes resolve to ``fizzy card column`` with a real column ID.
+        Fizzy system lanes resolve to their dedicated card operation.
         """
-        return self.build_move_to_column_command(card_number, column_id)
+        return self.build_move_to_lane_command(
+            card_number,
+            resolve_fizzy_lane(target, custom_columns=custom_columns),
+        )
+
+    def build_move_to_lane_command(self, card_number: int, lane: FizzyLaneTarget) -> str:
+        """Build the Fizzy CLI command used to move a card to a resolved lane."""
+        if lane.kind == "custom_column":
+            return self.build_move_to_column_command(card_number, lane.column_id or "")
+        if lane.kind == "triage":
+            return self.build_untriage_card_command(card_number)
+        if lane.kind == "not_now":
+            return self.build_postpone_card_command(card_number)
+        if lane.kind == "closed":
+            return self.build_close_card_command(card_number)
+        raise ValueError(f"Unsupported Fizzy lane kind: {lane.kind}")
+
+    def build_untriage_card_command(self, card_number: int) -> str:
+        """Build the Fizzy CLI command used to return a card to Maybe?/triage."""
+        return self._build_card_system_lane_command("untriage", card_number)
+
+    def build_postpone_card_command(self, card_number: int) -> str:
+        """Build the Fizzy CLI command used to move a card to Not Now."""
+        return self._build_card_system_lane_command("postpone", card_number)
+
+    def build_close_card_command(self, card_number: int) -> str:
+        """Build the Fizzy CLI command used to move a card to Done."""
+        return self._build_card_system_lane_command("close", card_number)
 
     def build_create_comment_command(self, card_number: int, body: str) -> str:
         """Build the Fizzy CLI command used to comment on a card."""
@@ -205,6 +240,14 @@ class FizzyCLIAdapter:
     def _ensure_dry_run(self) -> None:
         if not self.config.dry_run:
             raise ValueError("FizzyCLIAdapter is dry-run only in this scaffold.")
+
+    def _build_card_system_lane_command(self, operation: str, card_number: int) -> str:
+        self._ensure_dry_run()
+        self._validate_card_number(card_number)
+        parts: List[str] = [quote(self.config.fizzy_bin), "card", operation, str(card_number)]
+        parts.extend(self._agent_quiet_parts())
+        parts.extend(self.config.extra_flags)
+        return " ".join(parts)
 
     @staticmethod
     def _agent_markdown_parts() -> List[str]:

--- a/src/fizzy_symphony/cli.py
+++ b/src/fizzy_symphony/cli.py
@@ -15,10 +15,9 @@ from .robocorp_adapter import (
     adapter_package_available,
     format_workitem_env,
 )
-from .symphony import format_init_board_plan, format_mapping_table
+from .symphony import FizzyCustomColumn, format_init_board_plan, format_mapping_table
 
 DEFAULT_CLAIM_COMMENT_BODY = "Claimed by fizzy-symphony worker."
-DEFAULT_IN_FLIGHT_COLUMN_ID = "In Flight"
 
 
 def _build_demo_board() -> Board:
@@ -29,7 +28,7 @@ def _build_demo_board() -> Board:
         number=42,
         title="Capture the board request and draft a scoped implementation prompt.",
         agent=agent,
-        column_id="ready-for-agents",
+        column_id="col_ready_for_agents",
         labels=["board", "planning"],
         comment_body="Captured the request in dry-run mode and prepared the adapter prompt.",
     )
@@ -37,7 +36,7 @@ def _build_demo_board() -> Board:
         number=57,
         title="Map the tracker card into the Fizzy card adapter model.",
         agent=agent,
-        column_id="synthesize-and-verify",
+        column_id="col_synthesize_and_verify",
         labels=["adapter", "modeling"],
         comment_body="Mapped the tracker card into the canonical Fizzy card fields.",
     )
@@ -45,7 +44,7 @@ def _build_demo_board() -> Board:
         number=61,
         title="Review the dry-run board plan output and update docs/tests.",
         agent=agent,
-        column_id="ready-to-ship",
+        column_id="col_ready_to_ship",
         labels=["docs", "tests"],
         comment_body="Validated the dry-run CLI contract and documented the setup guidance.",
     )
@@ -156,7 +155,27 @@ def _cmd_comment(args: argparse.Namespace) -> int:
 
 def _cmd_move(args: argparse.Namespace) -> int:
     adapter = FizzyCLIAdapter(config=_config_from_args(args))
-    return _print_dry_run_commands([adapter.build_move_command(args.card_number, args.column)])
+    try:
+        custom_columns = _parse_custom_columns(args.custom_column)
+        command = adapter.build_move_command(
+            args.card_number,
+            args.column,
+            custom_columns=custom_columns,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return _print_dry_run_commands([command])
+
+
+def _parse_custom_columns(values: Optional[Sequence[str]]) -> List[FizzyCustomColumn]:
+    columns: List[FizzyCustomColumn] = []
+    for value in values or []:
+        if "=" not in value:
+            raise ValueError("--custom-column must use COLUMN_ID=NAME.")
+        column_id, name = value.split("=", 1)
+        columns.append(FizzyCustomColumn(column_id=column_id.strip(), name=name.strip()))
+    return columns
 
 
 def _add_common_command_options(parser: argparse.ArgumentParser, *, include_board: bool = False) -> None:
@@ -273,9 +292,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     claim_p.add_argument(
         "--in-flight-column",
-        default=DEFAULT_IN_FLIGHT_COLUMN_ID,
+        required=True,
         metavar="COLUMN_ID",
-        help="Column ID used for the claim move step (default: In Flight).",
+        help="Real Fizzy custom column ID used for the claim move step.",
     )
     claim_p.add_argument(
         "--comment-body",
@@ -299,9 +318,20 @@ def _build_parser() -> argparse.ArgumentParser:
     comment_p.add_argument("--body", required=True, help="Comment body to pass to the Fizzy CLI.")
     _add_common_command_options(comment_p)
 
-    move_p = sub.add_parser("move", help="Print the Fizzy CLI command for moving a card to a column.")
+    move_p = sub.add_parser("move", help="Print the Fizzy CLI command for moving a card to a lane.")
     move_p.add_argument("card_number", type=int, metavar="CARD_NUMBER", help="Visible Fizzy card number.")
-    move_p.add_argument("--column", required=True, metavar="COLUMN_ID", help="Target Fizzy column identifier.")
+    move_p.add_argument(
+        "--column",
+        required=True,
+        metavar="COLUMN_ID_OR_LANE",
+        help="Target custom column ID, unique mapped column name, or system lane: maybe/not-now/done.",
+    )
+    move_p.add_argument(
+        "--custom-column",
+        action="append",
+        metavar="COLUMN_ID=NAME",
+        help="Known custom column mapping for safe name resolution; repeat as needed.",
+    )
     _add_common_command_options(move_p)
 
     return parser

--- a/src/fizzy_symphony/commands.py
+++ b/src/fizzy_symphony/commands.py
@@ -32,16 +32,17 @@ def build_card_claim_commands(
     card: CardAdapter,
     config: FizzyConfig,
     *,
-    in_flight_column_id: str = "In Flight",
+    in_flight_column_id: Optional[str] = None,
     comment_body: Optional[str] = None,
     assignee_id: Optional[str] = None,
     self_assign: bool = False,
 ) -> List[str]:
     """Build the composite dry-run claim commands for a single card number."""
     _ = board
+    target_column_id = in_flight_column_id or card.column_id
     return _adapter(config).build_claim_commands(
         card.number,
-        in_flight_column_id,
+        target_column_id,
         comment_body or card.comment_body or card.title,
         assignee_id=assignee_id,
         self_assign=self_assign,

--- a/src/fizzy_symphony/runners.py
+++ b/src/fizzy_symphony/runners.py
@@ -485,7 +485,7 @@ class _CodexPythonSdkClient:
             "cwd": params.get("cwd"),
             "model": params.get("model"),
             "approval_policy": params.get("approvalPolicy"),
-            "sandbox_policy": params.get("sandboxPolicy"),
+            "sandbox_policy": self._coerce_sdk_sandbox_policy(params.get("sandboxPolicy")),
         }
         clean_kwargs = {key: value for key, value in kwargs.items() if value is not None}
         self._turn_kwargs = dict(clean_kwargs)
@@ -551,6 +551,32 @@ class _CodexPythonSdkClient:
         if self._thread is None:
             raise RuntimeError("Codex Python SDK thread has not started.")
         return self._thread
+
+    @staticmethod
+    def _coerce_sdk_sandbox_policy(value: object) -> object:
+        if not isinstance(value, Mapping):
+            return value
+        try:
+            from codex_app_server.generated.v2_all import (
+                FullAccessReadOnlyAccess,
+                ReadOnlyAccess,
+                SandboxPolicy,
+                WorkspaceWriteSandboxPolicy,
+            )
+        except ImportError:
+            return value
+        if value.get("type") == "workspaceWrite":
+            return SandboxPolicy(
+                root=WorkspaceWriteSandboxPolicy(
+                    type="workspaceWrite",
+                    writableRoots=list(value.get("writableRoots") or []),
+                    networkAccess=bool(value.get("networkAccess")),
+                    readOnlyAccess=ReadOnlyAccess(
+                        root=FullAccessReadOnlyAccess(type="fullAccess")
+                    ),
+                )
+            )
+        return SandboxPolicy.model_validate(value)
 
 
 class _CodexAppServerJsonRpcClient:

--- a/src/fizzy_symphony/runners.py
+++ b/src/fizzy_symphony/runners.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import json
 import os
+import queue
+import select
 import shlex
+import shutil
 import subprocess
+import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Mapping, Optional, Protocol, Sequence, Union
+from typing import Callable, Dict, List, Mapping, Optional, Protocol, Sequence, Union
 
 from .workitem_queue import FizzyWorkItemPayload, JSONDict
 
@@ -24,6 +30,7 @@ class CodexRunRequest:
     workspace: Optional[str] = None
     model: Optional[str] = None
     approval_policy: Optional[str] = None
+    sandbox_mode: Optional[str] = None
     timeout_seconds: Optional[float] = None
     env: Mapping[str, str] = field(default_factory=dict)
     card_number: Optional[int] = None
@@ -64,6 +71,7 @@ class CodexRunRequest:
             workspace=_optional_string(runner.get("workspace") or workflow.get("workspace")),
             model=_optional_string(runner.get("model")),
             approval_policy=_optional_string(runner.get("approval_policy")),
+            sandbox_mode=_optional_string(runner.get("sandbox_mode")),
             timeout_seconds=timeout_seconds,
             env={str(key): str(value) for key, value in env.items()},
             card_number=card_number,
@@ -111,6 +119,30 @@ class CodexRunner(Protocol):
 
 
 Runner = CodexRunner
+
+
+class CodexAppServerClient(Protocol):
+    """Minimal Codex app-server surface used by the optional SDK runner."""
+
+    def __enter__(self) -> "CodexAppServerClient": ...
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None: ...
+
+    def initialize(self) -> JSONDict: ...
+
+    def start_thread(self, params: JSONDict) -> JSONDict: ...
+
+    def start_turn(self, params: JSONDict) -> JSONDict: ...
+
+    def wait_for_turn(
+        self,
+        thread_id: str,
+        turn_id: str,
+        timeout_seconds: Optional[float] = None,
+    ) -> JSONDict: ...
+
+
+CodexAppServerClientFactory = Callable[..., CodexAppServerClient]
 
 
 @dataclass(frozen=True)
@@ -209,14 +241,153 @@ class CodexCliRunner:
         return args
 
 
+@dataclass(frozen=True)
 class CodexSdkRunner:
-    """Placeholder for the future official Codex SDK runner."""
+    """Optional Codex app-server-backed runner for one-turn worker execution."""
 
-    def __call__(self, request: CodexRunRequest) -> CodexRunResult:  # noqa: ARG002
-        raise RuntimeError(
-            "Codex SDK runner is not implemented yet. Use CodexCliRunner until the "
-            "optional SDK/app-server integration is proven locally."
-        )
+    command: Command = field(
+        default_factory=lambda: ["codex", "app-server", "--listen", "stdio://"]
+    )
+    timeout_seconds: Optional[float] = None
+    workspace: Optional[str] = None
+    env: Mapping[str, str] = field(default_factory=dict)
+    client_factory: Optional[CodexAppServerClientFactory] = None
+    ephemeral: bool = True
+    experimental_raw_events: bool = True
+    sandbox_mode: str = "workspace-write"
+
+    def __call__(self, request: CodexRunRequest) -> CodexRunResult:
+        cwd = request.workspace or self.workspace or os.getcwd()
+        timeout = request.timeout_seconds
+        if timeout is None:
+            timeout = self.timeout_seconds
+        command = _normalize_command(self.command)
+        raw_metadata: JSONDict = {
+            "runner": "codex_sdk",
+            "protocol": "codex_app_server_jsonrpc_v2",
+            "command": command,
+            "workspace": cwd,
+            "timeout_seconds": timeout,
+            "card_number": request.card_number,
+        }
+
+        try:
+            client = self._make_client(
+                command=command,
+                timeout_seconds=timeout,
+                env=request.env,
+            )
+            with client as app_server:
+                initialize_result = app_server.initialize()
+                thread_params = self._thread_start_params(request, cwd)
+                thread_start_result = app_server.start_thread(thread_params)
+                thread = _mapping_value(thread_start_result, "thread")
+                thread_id = _optional_string(thread.get("id"))
+                if not thread_id:
+                    raise RuntimeError("Codex app-server thread/start did not return a thread id.")
+
+                turn_params = self._turn_start_params(request, cwd, thread_id)
+                turn_start_result = app_server.start_turn(turn_params)
+                turn = _mapping_value(turn_start_result, "turn")
+                turn_id = _optional_string(turn.get("id"))
+                if not turn_id:
+                    raise RuntimeError("Codex app-server turn/start did not return a turn id.")
+
+                completed_turn = app_server.wait_for_turn(
+                    thread_id,
+                    turn_id,
+                    timeout_seconds=timeout,
+                )
+
+            final_response = _extract_final_response(completed_turn)
+            turn_result = _mapping_value(completed_turn, "turn")
+            actual_turn_id = _optional_string(turn_result.get("id")) or turn_id
+            turn_status = _optional_string(turn_result.get("status"))
+            success = turn_status in (None, "completed")
+            raw_metadata.update(
+                {
+                    "thread_id": thread_id,
+                    "turn_id": actual_turn_id,
+                    "run_id": actual_turn_id,
+                    "app_server": {
+                        "initialize": initialize_result,
+                        "thread_start": thread_start_result,
+                        "turn_start": turn_start_result,
+                        "turn_completed": completed_turn,
+                    },
+                }
+            )
+            return CodexRunResult(
+                success=success,
+                final_response=final_response,
+                stderr="" if success else _turn_error_message(turn_result),
+                thread_id=thread_id,
+                artifacts={"turn_id": actual_turn_id, "run_id": actual_turn_id},
+                validation_summary=turn_status or "",
+                raw_metadata=raw_metadata,
+            )
+        except TimeoutError as exc:
+            return _sdk_failure_result(
+                "Codex app-server/SDK timed out",
+                exc,
+                raw_metadata,
+                timed_out=True,
+            )
+        except (FileNotFoundError, OSError) as exc:
+            return _sdk_failure_result(
+                "Codex app-server/SDK unavailable",
+                exc,
+                raw_metadata,
+            )
+        except Exception as exc:  # noqa: BLE001 - runner boundary must fail cleanly.
+            return _sdk_failure_result(
+                "Codex app-server/SDK run failed",
+                exc,
+                raw_metadata,
+            )
+
+    def _make_client(
+        self,
+        command: Sequence[str],
+        timeout_seconds: Optional[float],
+        env: Mapping[str, str],
+    ) -> CodexAppServerClient:
+        merged_env = dict(os.environ)
+        merged_env.update({str(key): str(value) for key, value in self.env.items()})
+        merged_env.update({str(key): str(value) for key, value in env.items()})
+        factory = self.client_factory or _default_codex_app_server_client
+        return factory(command=command, timeout_seconds=timeout_seconds, env=merged_env)
+
+    def _thread_start_params(self, request: CodexRunRequest, cwd: str) -> JSONDict:
+        return {
+            "cwd": cwd,
+            "model": request.model,
+            "approvalPolicy": request.approval_policy,
+            "sandbox": request.sandbox_mode or self.sandbox_mode,
+            "ephemeral": self.ephemeral,
+            "experimentalRawEvents": self.experimental_raw_events,
+        }
+
+    def _turn_start_params(
+        self,
+        request: CodexRunRequest,
+        cwd: str,
+        thread_id: str,
+    ) -> JSONDict:
+        metadata = {
+            "fizzy_symphony.runner": "codex_sdk",
+        }
+        if request.card_number is not None:
+            metadata["fizzy_symphony.card_number"] = str(request.card_number)
+        return {
+            "threadId": thread_id,
+            "cwd": cwd,
+            "model": request.model,
+            "approvalPolicy": request.approval_policy,
+            "input": [{"type": "text", "text": request.prompt}],
+            "sandboxPolicy": _sandbox_policy(request.sandbox_mode or self.sandbox_mode, cwd),
+            "responsesapiClientMetadata": metadata,
+        }
 
 
 def create_codex_runner(kind: str = "cli", **kwargs: object) -> CodexRunner:
@@ -225,11 +396,337 @@ def create_codex_runner(kind: str = "cli", **kwargs: object) -> CodexRunner:
     if kind == "cli":
         return CodexCliRunner(**kwargs)
     if kind == "sdk":
-        raise RuntimeError(
-            "Codex SDK runner is not implemented yet. Use CodexCliRunner until the "
-            "optional SDK/app-server integration is proven locally."
-        )
+        return CodexSdkRunner(**kwargs)
     raise ValueError(f"unsupported Codex runner kind: {kind!r}")
+
+
+def _default_codex_app_server_client(**kwargs: object) -> CodexAppServerClient:
+    """Prefer the official Python SDK when installed, then fall back to JSON-RPC."""
+
+    try:
+        import codex_app_server  # noqa: F401
+    except ImportError:
+        return _CodexAppServerJsonRpcClient(**kwargs)
+    return _CodexPythonSdkClient(**kwargs)
+
+
+class _CodexPythonSdkClient:
+    """Adapter over the official experimental `codex_app_server` Python SDK."""
+
+    def __init__(
+        self,
+        command: Sequence[str],
+        timeout_seconds: Optional[float] = None,
+        env: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        self.command = list(command)
+        self.timeout_seconds = timeout_seconds
+        self.env = dict(env) if env is not None else {}
+        self._codex: object = None
+        self._thread: object = None
+        self._turn_handle: object = None
+        self._turn_input: str = ""
+        self._turn_kwargs: JSONDict = {}
+        self._old_env: Dict[str, Optional[str]] = {}
+
+    def __enter__(self) -> "_CodexPythonSdkClient":
+        self._old_env = {key: os.environ.get(key) for key in self.env}
+        os.environ.update(self.env)
+        from codex_app_server import AppServerConfig, Codex
+
+        codex_bin = shutil.which(self.command[0]) or (self.command[0] if self.command else None)
+        self._codex = Codex(
+            AppServerConfig(
+                codex_bin=codex_bin,
+                env=dict(self.env) if self.env else None,
+                client_name="fizzy-symphony",
+                client_title="Fizzy Symphony",
+                client_version="0.1.0",
+                experimental_api=True,
+            )
+        )
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        close = getattr(self._codex, "close", None)
+        if callable(close):
+            close()
+        for key, value in self._old_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def initialize(self) -> JSONDict:
+        metadata = getattr(self._codex, "metadata", None)
+        return _json_dict(metadata)
+
+    def start_thread(self, params: JSONDict) -> JSONDict:
+        codex = self._require_codex()
+        kwargs = {
+            "cwd": params.get("cwd"),
+            "model": params.get("model"),
+            "approval_policy": params.get("approvalPolicy"),
+            "ephemeral": params.get("ephemeral"),
+            "config": params.get("config"),
+            "sandbox": params.get("sandbox"),
+        }
+        self._thread = codex.thread_start(**{key: value for key, value in kwargs.items() if value is not None})
+        thread_data = _json_dict(self._thread)
+        thread_id = _optional_string(thread_data.get("id") or getattr(self._thread, "id", None))
+        if thread_id:
+            thread_data["id"] = thread_id
+        return {"thread": thread_data}
+
+    def start_turn(self, params: JSONDict) -> JSONDict:
+        thread = self._require_thread()
+        self._turn_input = _text_from_sdk_input(params.get("input"))
+        kwargs = {
+            "cwd": params.get("cwd"),
+            "model": params.get("model"),
+            "approval_policy": params.get("approvalPolicy"),
+            "sandbox_policy": params.get("sandboxPolicy"),
+        }
+        clean_kwargs = {key: value for key, value in kwargs.items() if value is not None}
+        self._turn_kwargs = dict(clean_kwargs)
+        self._turn_handle = None
+        return {"turn": {"id": "python-sdk-run-pending", "status": "inProgress", "items": []}}
+
+    def wait_for_turn(
+        self,
+        thread_id: str,  # noqa: ARG002 - Python SDK thread object already owns it.
+        turn_id: str,
+        timeout_seconds: Optional[float] = None,
+    ) -> JSONDict:
+        effective_timeout = (
+            timeout_seconds if timeout_seconds is not None else self.timeout_seconds
+        )
+        if self._turn_handle is not None:
+            turn = _call_with_timeout(self._turn_handle.run, effective_timeout)
+            turn_data = _json_dict(turn)
+            if not turn_data.get("id"):
+                turn_data["id"] = turn_id
+            if not turn_data.get("status"):
+                turn_data["status"] = "completed"
+            return {"turn": turn_data, "notifications": []}
+
+        thread = self._require_thread()
+        result = _call_with_timeout(
+            lambda: thread.run(self._turn_input, **self._turn_kwargs),
+            effective_timeout,
+        )
+        final_response = getattr(result, "final_response", None)
+        raw_items = getattr(result, "items", [])
+        items = _json_value(raw_items) if isinstance(raw_items, list) else []
+        if final_response and not items:
+            items = [
+                {
+                    "id": "python-sdk-final-response",
+                    "type": "agentMessage",
+                    "text": str(final_response),
+                    "phase": "final_answer",
+                }
+            ]
+        resolved_turn_id = turn_id
+        if turn_id == "python-sdk-run-pending" and items:
+            last_item = items[-1]
+            if isinstance(last_item, Mapping) and last_item.get("id"):
+                resolved_turn_id = f"python-sdk-run-{last_item['id']}"
+        return {
+            "turn": {
+                "id": resolved_turn_id,
+                "status": "completed",
+                "items": items,
+            },
+            "notifications": [],
+            "usage": _json_value(getattr(result, "usage", None)),
+        }
+
+    def _require_codex(self):
+        if self._codex is None:
+            raise RuntimeError("Codex Python SDK client has not started.")
+        return self._codex
+
+    def _require_thread(self):
+        if self._thread is None:
+            raise RuntimeError("Codex Python SDK thread has not started.")
+        return self._thread
+
+
+class _CodexAppServerJsonRpcClient:
+    """Line-delimited JSON-RPC client for `codex app-server --listen stdio://`."""
+
+    def __init__(
+        self,
+        command: Sequence[str],
+        timeout_seconds: Optional[float] = None,
+        env: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        self.command = list(command)
+        self.timeout_seconds = timeout_seconds
+        self.env = dict(env) if env is not None else None
+        self._process: Optional[subprocess.Popen[str]] = None
+        self._next_id = 1
+        self._notifications: List[JSONDict] = []
+
+    def __enter__(self) -> "_CodexAppServerJsonRpcClient":
+        self._process = subprocess.Popen(
+            self.command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=self.env,
+        )
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        process = self._require_process()
+        if process.stdin:
+            process.stdin.close()
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=2)
+
+    def initialize(self) -> JSONDict:
+        result = self._request(
+            "initialize",
+            {
+                "clientInfo": {
+                    "name": "fizzy-symphony",
+                    "version": "0.1.0",
+                },
+                "capabilities": {"experimentalApi": True},
+            },
+        )
+        self._notification("initialized")
+        return result
+
+    def start_thread(self, params: JSONDict) -> JSONDict:
+        return self._request("thread/start", params)
+
+    def start_turn(self, params: JSONDict) -> JSONDict:
+        return self._request("turn/start", params)
+
+    def wait_for_turn(
+        self,
+        thread_id: str,
+        turn_id: str,
+        timeout_seconds: Optional[float] = None,
+    ) -> JSONDict:
+        effective_timeout = (
+            timeout_seconds if timeout_seconds is not None else self.timeout_seconds
+        )
+        deadline = _deadline(effective_timeout)
+        notifications: List[JSONDict] = list(self._notifications)
+        final_items: List[JSONDict] = []
+        self._notifications.clear()
+        while True:
+            message = self._read_message(deadline)
+            if "id" in message and "method" in message:
+                raise RuntimeError(
+                    f"Codex app-server requested unsupported interactive method "
+                    f"{message.get('method')!r}."
+                )
+            if "method" not in message:
+                continue
+            notifications.append(message)
+            method = message.get("method")
+            params = _mapping_value(message, "params")
+            if method == "error":
+                raise RuntimeError(str(params.get("message") or params))
+            if (
+                method == "item/completed"
+                and params.get("threadId") == thread_id
+                and params.get("turnId") == turn_id
+            ):
+                item = _mapping_value(params, "item")
+                if item.get("type") == "agentMessage":
+                    final_items.append(item)
+            if method == "turn/completed" and params.get("threadId") == thread_id:
+                turn = _mapping_value(params, "turn")
+                if turn.get("id") == turn_id:
+                    if final_items and not turn.get("items"):
+                        turn["items"] = final_items
+                    return {"turn": dict(turn), "notifications": notifications}
+            if method == "thread/status/changed" and params.get("threadId") == thread_id:
+                status = _mapping_value(params, "status")
+                if final_items and status.get("type") == "idle":
+                    return {
+                        "turn": {
+                            "id": turn_id,
+                            "status": "completed",
+                            "items": final_items,
+                        },
+                        "notifications": notifications,
+                    }
+
+    def _request(self, method: str, params: JSONDict) -> JSONDict:
+        request_id = self._next_id
+        self._next_id += 1
+        self._write_message(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            }
+        )
+        deadline = _deadline(self.timeout_seconds)
+        while True:
+            message = self._read_message(deadline)
+            if message.get("id") == request_id:
+                if "error" in message:
+                    error = _mapping_value(message, "error")
+                    raise RuntimeError(str(error.get("message") or error))
+                result = message.get("result")
+                if isinstance(result, Mapping):
+                    return dict(result)
+                return {}
+            if "method" in message:
+                self._notifications.append(message)
+
+    def _write_message(self, message: JSONDict) -> None:
+        process = self._require_process()
+        if process.stdin is None:
+            raise RuntimeError("Codex app-server stdin is unavailable.")
+        process.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
+        process.stdin.flush()
+
+    def _notification(self, method: str, params: Optional[JSONDict] = None) -> None:
+        message: JSONDict = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            message["params"] = params
+        self._write_message(message)
+
+    def _read_message(self, deadline: Optional[float]) -> JSONDict:
+        process = self._require_process()
+        if process.stdout is None:
+            raise RuntimeError("Codex app-server stdout is unavailable.")
+        wait_seconds = _seconds_until(deadline)
+        ready, _, _ = select.select([process.stdout], [], [], wait_seconds)
+        if not ready:
+            raise TimeoutError("Timed out waiting for Codex app-server response.")
+        line = process.stdout.readline()
+        if line == "":
+            stderr = _read_completed_stderr(process)
+            raise RuntimeError(f"Codex app-server exited before responding. {stderr}".strip())
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Codex app-server emitted invalid JSON: {line.strip()}") from exc
+        if not isinstance(message, Mapping):
+            raise RuntimeError(f"Codex app-server emitted non-object JSON: {message!r}")
+        return dict(message)
+
+    def _require_process(self) -> subprocess.Popen[str]:
+        if self._process is None:
+            raise RuntimeError("Codex app-server process has not started.")
+        return self._process
 
 
 def _normalize_command(command: Command) -> List[str]:
@@ -259,6 +756,173 @@ def _is_codex_exec(args: Sequence[str]) -> bool:
     return executable == "codex" and args[1] == "exec"
 
 
+def _sdk_failure_result(
+    prefix: str,
+    exc: BaseException,
+    raw_metadata: JSONDict,
+    timed_out: bool = False,
+) -> CodexRunResult:
+    raw_metadata.update(
+        {
+            "error_type": type(exc).__name__,
+            "error": str(exc),
+        }
+    )
+    return CodexRunResult(
+        success=False,
+        stderr=f"{prefix}: {exc}",
+        returncode=None,
+        timed_out=timed_out,
+        raw_metadata=raw_metadata,
+    )
+
+
+def _mapping_value(mapping: Mapping[str, object], key: str) -> JSONDict:
+    value = mapping.get(key)
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _json_dict(value: object) -> JSONDict:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(nested) for key, nested in value.items()}
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump(mode="json", by_alias=True, exclude_none=True)
+        if isinstance(dumped, Mapping):
+            return {str(key): _json_value(nested) for key, nested in dumped.items()}
+    if hasattr(value, "__dict__"):
+        return {
+            str(key): _json_value(nested)
+            for key, nested in vars(value).items()
+            if not key.startswith("_")
+        }
+    return {}
+
+
+def _json_value(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(nested) for key, nested in value.items()}
+    if isinstance(value, list):
+        return [_json_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_value(item) for item in value]
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="json", by_alias=True, exclude_none=True)
+    if hasattr(value, "__dict__") and not isinstance(value, (str, bytes)):
+        return _json_dict(value)
+    return value
+
+
+def _text_from_sdk_input(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts = []
+        for item in value:
+            if isinstance(item, Mapping) and item.get("type") == "text":
+                parts.append(str(item.get("text") or ""))
+        return "\n".join(part for part in parts if part)
+    if isinstance(value, Mapping) and value.get("type") == "text":
+        return str(value.get("text") or "")
+    return str(value or "")
+
+
+def _sandbox_policy(mode: Optional[str], cwd: str) -> Optional[JSONDict]:
+    if mode is None:
+        return None
+    if mode == "workspace-write":
+        return {
+            "type": "workspaceWrite",
+            "writableRoots": [str(Path(cwd).resolve())],
+            "networkAccess": False,
+        }
+    if mode == "read-only":
+        return {"type": "readOnly"}
+    if mode == "danger-full-access":
+        return {"type": "dangerFullAccess"}
+    return None
+
+
+def _extract_final_response(payload: JSONDict) -> str:
+    turn = _mapping_value(payload, "turn")
+    items = turn.get("items")
+    if isinstance(items, list):
+        final_messages = [
+            str(item.get("text") or "")
+            for item in items
+            if isinstance(item, Mapping)
+            and item.get("type") == "agentMessage"
+            and item.get("phase") == "final_answer"
+            and item.get("text")
+        ]
+        if final_messages:
+            return final_messages[-1].strip()
+
+        agent_messages = [
+            str(item.get("text") or "")
+            for item in items
+            if isinstance(item, Mapping)
+            and item.get("type") == "agentMessage"
+            and item.get("text")
+        ]
+        if agent_messages:
+            return agent_messages[-1].strip()
+
+    notifications = payload.get("notifications")
+    if isinstance(notifications, list):
+        deltas = []
+        for notification in notifications:
+            if not isinstance(notification, Mapping):
+                continue
+            if notification.get("method") not in (
+                "item/agentMessage/delta",
+                "agent/message/delta",
+            ):
+                continue
+            params = notification.get("params")
+            if isinstance(params, Mapping) and params.get("delta"):
+                deltas.append(str(params["delta"]))
+        if deltas:
+            return "".join(deltas).strip()
+
+    return ""
+
+
+def _turn_error_message(turn: Mapping[str, object]) -> str:
+    error = turn.get("error")
+    if isinstance(error, Mapping):
+        message = error.get("message")
+        if message:
+            return str(message)
+    if error:
+        return str(error)
+    status = _optional_string(turn.get("status")) or "unknown"
+    return f"Codex turn finished with status {status!r}."
+
+
+def _deadline(timeout_seconds: Optional[float]) -> Optional[float]:
+    if timeout_seconds is None:
+        return None
+    return time.monotonic() + timeout_seconds
+
+
+def _seconds_until(deadline: Optional[float]) -> Optional[float]:
+    if deadline is None:
+        return None
+    return max(0.0, deadline - time.monotonic())
+
+
+def _read_completed_stderr(process: subprocess.Popen[str]) -> str:
+    if process.poll() is None or process.stderr is None:
+        return ""
+    return process.stderr.read().strip()
+
+
 def _optional_string(value: object) -> Optional[str]:
     if value is None:
         return None
@@ -281,3 +945,27 @@ def _coerce_output(value: object) -> str:
     if isinstance(value, bytes):
         return value.decode(errors="replace")
     return str(value)
+
+
+def _call_with_timeout(call: Callable[[], object], timeout_seconds: Optional[float]) -> object:
+    if timeout_seconds is None:
+        return call()
+
+    results: "queue.Queue[tuple[bool, object]]" = queue.Queue(maxsize=1)
+
+    def run_call() -> None:
+        try:
+            results.put((True, call()))
+        except BaseException as exc:  # noqa: BLE001 - re-raised at runner boundary.
+            results.put((False, exc))
+
+    worker = threading.Thread(target=run_call, daemon=True)
+    worker.start()
+    worker.join(timeout_seconds)
+    if worker.is_alive():
+        raise TimeoutError("Timed out waiting for Codex Python SDK run.")
+
+    succeeded, value = results.get_nowait()
+    if succeeded:
+        return value
+    raise value

--- a/src/fizzy_symphony/symphony.py
+++ b/src/fizzy_symphony/symphony.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from shlex import quote
-from typing import List, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
 
 
 @dataclass(frozen=True)
@@ -30,6 +30,38 @@ class FizzySystemLane:
     kind: str
     role: str
     description: str
+
+
+@dataclass(frozen=True)
+class FizzyCustomColumn:
+    """Known custom Fizzy board column used for name-to-ID resolution."""
+
+    column_id: str
+    name: str
+
+    def __post_init__(self) -> None:
+        if not self.column_id:
+            raise ValueError("FizzyCustomColumn.column_id must not be empty.")
+        if not self.name:
+            raise ValueError("FizzyCustomColumn.name must not be empty.")
+
+
+@dataclass(frozen=True)
+class FizzyLaneTarget:
+    """Resolved target lane for a card move/update plan."""
+
+    kind: str
+    display_name: str
+    column_id: Optional[str] = None
+    pseudo_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.kind:
+            raise ValueError("FizzyLaneTarget.kind must not be empty.")
+        if self.kind == "custom_column" and not self.column_id:
+            raise ValueError("FizzyLaneTarget.column_id is required for custom columns.")
+        if self.kind != "custom_column" and not self.pseudo_id:
+            raise ValueError("FizzyLaneTarget.pseudo_id is required for system lanes.")
 
 
 @dataclass(frozen=True)
@@ -64,6 +96,16 @@ FIZZY_SYSTEM_LANES: Tuple[FizzySystemLane, ...] = (
         description="Closed cards; no more automated work should occur.",
     ),
 )
+
+FIZZY_SYSTEM_LANE_ALIASES = {
+    "maybe": "maybe",
+    "triage": "maybe",
+    "not-now": "not-now",
+    "not now": "not-now",
+    "not_now": "not-now",
+    "done": "done",
+    "closed": "done",
+}
 
 
 RECOMMENDED_COLUMNS: Tuple[SymphonyColumn, ...] = (
@@ -150,6 +192,58 @@ def fizzy_system_lanes() -> List[FizzySystemLane]:
     return list(FIZZY_SYSTEM_LANES)
 
 
+def resolve_fizzy_lane(
+    target: str,
+    *,
+    custom_columns: Sequence[Union[FizzyCustomColumn, Mapping[str, Any]]] = (),
+) -> FizzyLaneTarget:
+    """Resolve a requested card lane into a custom column or immutable system lane.
+
+    Unknown non-system targets are treated as already-known Fizzy column IDs so
+    existing boards can keep their own workflow names and IDs.
+    """
+    requested = target.strip() if target else ""
+    if not requested:
+        raise ValueError("target lane must not be empty.")
+
+    system_lane = _system_lane_for_target(requested)
+    if system_lane is not None:
+        return FizzyLaneTarget(
+            kind=system_lane.kind,
+            display_name=system_lane.name,
+            pseudo_id=system_lane.pseudo_id,
+        )
+
+    columns = [_coerce_custom_column(column) for column in custom_columns]
+    for column in columns:
+        if requested == column.column_id:
+            return FizzyLaneTarget(
+                kind="custom_column",
+                display_name=column.name,
+                column_id=column.column_id,
+            )
+
+    requested_name = _normalize_column_name(requested)
+    name_matches = [
+        column
+        for column in columns
+        if _normalize_column_name(column.name) == requested_name
+    ]
+    if len(name_matches) > 1:
+        raise ValueError(
+            f"Duplicate custom column name {requested!r}; use column IDs to disambiguate."
+        )
+    if name_matches:
+        column = name_matches[0]
+        return FizzyLaneTarget(
+            kind="custom_column",
+            display_name=column.name,
+            column_id=column.column_id,
+        )
+
+    return FizzyLaneTarget(kind="custom_column", display_name=requested, column_id=requested)
+
+
 def upstream_mapping() -> List[SymphonyMapping]:
     """Return a copy of the upstream-to-Fizzy mapping."""
     return list(UPSTREAM_MAPPING)
@@ -195,3 +289,32 @@ def format_mapping_table() -> str:
     for mapping in UPSTREAM_MAPPING:
         lines.append(f"- {mapping.upstream} -> {mapping.fizzy_symphony}: {mapping.note}")
     return "\n".join(lines)
+
+
+def _system_lane_for_target(target: str) -> Optional[FizzySystemLane]:
+    pseudo_id = FIZZY_SYSTEM_LANE_ALIASES.get(_normalize_lane_token(target))
+    if pseudo_id is None:
+        return None
+    for lane in FIZZY_SYSTEM_LANES:
+        if lane.pseudo_id == pseudo_id:
+            return lane
+    return None
+
+
+def _coerce_custom_column(column: Union[FizzyCustomColumn, Mapping[str, Any]]) -> FizzyCustomColumn:
+    if isinstance(column, FizzyCustomColumn):
+        return column
+    column_id = str(column.get("column_id") or column.get("id") or "")
+    name = str(column.get("name") or column.get("column_name") or "")
+    return FizzyCustomColumn(column_id=column_id, name=name)
+
+
+def _normalize_lane_token(value: str) -> str:
+    token = _normalize_column_name(value).replace("_", "-")
+    if token.endswith("?"):
+        token = token[:-1]
+    return token
+
+
+def _normalize_column_name(value: str) -> str:
+    return " ".join(value.strip().lower().split())

--- a/test-projects/workai-smoke/board.fixture.json
+++ b/test-projects/workai-smoke/board.fixture.json
@@ -9,8 +9,9 @@
       "minimum_task_cards": 8,
       "expected_artifacts": [
         "Fizzy board with a real golden ticket",
+        "Disposable board cleanup command",
         "SQLite workitem database",
-        "Codex SDK run metadata",
+        "Codex SDK thread/run metadata and raw metadata",
         "Sample project code changes",
         "Sample project test output",
         "Fizzy card comments and movement"

--- a/test-projects/workai-smoke/bootstrap_board.py
+++ b/test-projects/workai-smoke/bootstrap_board.py
@@ -188,9 +188,12 @@ def card_number(resource: Mapping[str, object]) -> Optional[str]:
     return str(value) if value else None
 
 
-def configure_live_board(fixture: dict, *, board_id: str) -> None:
+def configure_live_board(fixture: dict, *, board_id: str) -> dict:
     subprocess.run(["fizzy", "doctor"], check=True)
-    subprocess.run(["fizzy", "column", "list", "--board", board_id, "--agent", "--quiet"], check=True)
+    subprocess.run(
+        ["fizzy", "column", "list", "--board", board_id, "--agent", "--quiet"],
+        check=True,
+    )
 
     column_ids: dict[str, str] = {}
     for column in fixture["board"]["recommended_columns"]:
@@ -211,11 +214,30 @@ def configure_live_board(fixture: dict, *, board_id: str) -> None:
         if created_id:
             column_ids[column] = created_id
 
+    golden_tickets = []
     for card in fixture.get("golden_tickets", []):
-        create_and_configure_card(card, board_id=board_id, column_ids=column_ids, golden=True)
+        golden_tickets.append(
+            create_and_configure_card(card, board_id=board_id, column_ids=column_ids, golden=True)
+        )
 
+    task_cards = []
     for card in fixture.get("task_cards", []):
-        create_and_configure_card(card, board_id=board_id, column_ids=column_ids, golden=False)
+        task_cards.append(
+            create_and_configure_card(
+                card,
+                board_id=board_id,
+                column_ids=column_ids,
+                golden=False,
+            )
+        )
+
+    return {
+        "board_id": board_id,
+        "cleanup_command": shell_join(["fizzy", "board", "delete", board_id]),
+        "columns": column_ids,
+        "golden_tickets": golden_tickets,
+        "task_cards": task_cards,
+    }
 
 
 def create_and_configure_card(
@@ -224,7 +246,7 @@ def create_and_configure_card(
     board_id: str,
     column_ids: Mapping[str, str],
     golden: bool,
-) -> None:
+) -> dict:
     created = run_json(
         [
             "fizzy",
@@ -241,19 +263,29 @@ def create_and_configure_card(
         ]
     )
     number = card_number(created)
+    summary = {
+        "title": card["title"],
+        "number": number,
+        "golden": bool(card.get("golden")),
+        "target_column": card.get("target_column"),
+        "tags": list(card.get("tags", [])),
+        "marked_golden": False,
+    }
     if not number:
-        return
+        return summary
 
     for tag in card.get("tags", []):
         subprocess.run(["fizzy", "card", "tag", number, "--tag", tag], check=True)
 
     if card.get("golden"):
         subprocess.run(["fizzy", "card", "golden", number], check=True)
+        summary["marked_golden"] = True
 
     target_column = card.get("target_column")
     column_id = column_ids.get(str(target_column)) if target_column else None
     if column_id:
         subprocess.run(["fizzy", "card", "column", number, "--column", column_id], check=True)
+    return summary
 
 
 def main(argv: List[str] | None = None) -> int:
@@ -265,7 +297,11 @@ def main(argv: List[str] | None = None) -> int:
         action="store_true",
         help="With --live, create the disposable board before configuring it.",
     )
-    parser.add_argument("--live", action="store_true", help="Run Fizzy commands instead of printing them.")
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Run Fizzy commands instead of printing them.",
+    )
     args = parser.parse_args(argv)
 
     fixture = load_fixture(args.fixture)
@@ -277,14 +313,16 @@ def main(argv: List[str] | None = None) -> int:
         print("# Create a disposable board, export its id, then run the setup commands:")
         for command in commands:
             print(command)
+        print("# When the smoke is complete, delete only the disposable board:")
+        print(shell_join(["fizzy", "board", "delete", board_id]))
         return 0
 
     if not args.board_id and not args.create_board:
         parser.error("--live requires --board-id or --create-board")
 
     live_board_id = args.board_id or create_board(fixture)
-    configure_live_board(fixture, board_id=live_board_id)
-    print(json.dumps({"board_id": live_board_id}, indent=2, sort_keys=True))
+    summary = configure_live_board(fixture, board_id=live_board_id)
+    print(json.dumps(summary, indent=2, sort_keys=True))
     return 0
 
 

--- a/test-projects/workai-smoke/bootstrap_board.py
+++ b/test-projects/workai-smoke/bootstrap_board.py
@@ -231,12 +231,29 @@ def configure_live_board(fixture: dict, *, board_id: str) -> dict:
             )
         )
 
+    golden_number = next(
+        (card.get("number") for card in golden_tickets if card.get("golden")),
+        None,
+    )
+    card_number_env = ",".join(
+        f"{index}={card['number']}"
+        for index, card in enumerate(task_cards, start=1)
+        if card.get("number")
+    )
+    handoff_column_id = column_ids.get("Synthesize & Verify")
     return {
         "board_id": board_id,
         "cleanup_command": shell_join(["fizzy", "board", "delete", board_id]),
         "columns": column_ids,
         "golden_tickets": golden_tickets,
         "task_cards": task_cards,
+        "smoke_env": {
+            "WORKAI_SMOKE_BOARD_ID": board_id,
+            "WORKAI_SMOKE_CARD_NUMBERS": card_number_env,
+            "WORKAI_SMOKE_GOLDEN_CARD_NUMBER": golden_number,
+            "WORKAI_SMOKE_HANDOFF_COLUMN_ID": handoff_column_id,
+            "WORKAI_SMOKE_LIVE_FIZZY": "1",
+        },
     }
 
 

--- a/tests/test_adapters_fizzy_cli.py
+++ b/tests/test_adapters_fizzy_cli.py
@@ -5,6 +5,7 @@ import pytest
 from fizzy_symphony.adapters.fizzy_cli import FizzyCLIAdapter
 from fizzy_symphony.adapters.fizzy_openapi import FizzyOpenAPIAdapter
 from fizzy_symphony.models import FizzyConfig
+from fizzy_symphony.symphony import FizzyCustomColumn
 
 
 def _make_adapter(**kwargs) -> FizzyCLIAdapter:
@@ -78,6 +79,39 @@ def test_build_comment_command_quotes_body():
 def test_build_move_command_uses_column_id():
     cmd = _make_adapter().build_move_command(42, "ready-to-ship")
     assert cmd == "fizzy card column 42 --column ready-to-ship --agent --quiet"
+
+
+def test_build_move_command_maps_system_lanes():
+    adapter = _make_adapter()
+
+    assert adapter.build_move_command(42, "maybe") == "fizzy card untriage 42 --agent --quiet"
+    assert adapter.build_move_command(42, "not-now") == "fizzy card postpone 42 --agent --quiet"
+    assert adapter.build_move_command(42, "done") == "fizzy card close 42 --agent --quiet"
+
+
+def test_build_move_command_resolves_unique_custom_column_name():
+    cmd = _make_adapter().build_move_command(
+        42,
+        "Ready",
+        custom_columns=[
+            FizzyCustomColumn(column_id="col_ready", name="Ready"),
+            FizzyCustomColumn(column_id="col_review", name="Review"),
+        ],
+    )
+
+    assert cmd == "fizzy card column 42 --column col_ready --agent --quiet"
+
+
+def test_build_move_command_rejects_ambiguous_custom_column_name():
+    with pytest.raises(ValueError, match="Duplicate custom column name 'Ready'.*column IDs"):
+        _make_adapter().build_move_command(
+            42,
+            "Ready",
+            custom_columns=[
+                FizzyCustomColumn(column_id="col_a", name="Ready"),
+                FizzyCustomColumn(column_id="col_b", name="Ready"),
+            ],
+        )
 
 
 def test_build_list_command_can_fall_back_to_fizzy_yaml(tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def test_plan_command_prints_board_plan(capsys):
     assert "fizzy" in captured.out
     assert "fizzy doctor" in captured.out
     assert "fizzy card show 42 --agent --markdown" in captured.out
-    assert "fizzy card column 42 --column 'In Flight' --agent --quiet" in captured.out
+    assert "fizzy card column 42 --column col_ready_for_agents --agent --quiet" in captured.out
     assert "(dry-run mode — no commands were executed)" in captured.out
 
 
@@ -65,18 +65,18 @@ def test_list_command_prints_dry_run_fizzy_command(capsys):
 
 
 def test_claim_command_prints_composite_dry_run_fizzy_commands(capsys):
-    exit_code = main(["claim", "42", "--board", "work-ai-board", "--dry-run"])
+    exit_code = main(["claim", "42", "--board", "work-ai-board", "--in-flight-column", "col_42_in_flight", "--dry-run"])
     captured = capsys.readouterr()
 
     assert exit_code == 0
     assert "fizzy card show 42 --agent --markdown" in captured.out
-    assert "fizzy card column 42 --column 'In Flight' --agent --quiet" in captured.out
+    assert "fizzy card column 42 --column col_42_in_flight --agent --quiet" in captured.out
     assert "fizzy comment create --card 42 --body 'Claimed by fizzy-symphony worker.'" in captured.out
     assert "fizzy card claim" not in captured.out
 
 
 def test_claim_command_supports_self_assign(capsys):
-    exit_code = main(["claim", "42", "--self-assign", "--dry-run"])
+    exit_code = main(["claim", "42", "--self-assign", "--in-flight-column", "col_42_in_flight", "--dry-run"])
     captured = capsys.readouterr()
 
     assert exit_code == 0
@@ -119,3 +119,55 @@ def test_move_command_prints_dry_run_fizzy_command(capsys):
 
     assert exit_code == 0
     assert "fizzy card column 42 --column ready-to-ship --agent --quiet" in captured.out
+
+
+def test_move_command_prints_system_lane_commands(capsys):
+    assert main(["move", "42", "--column", "maybe", "--dry-run"]) == 0
+    assert "fizzy card untriage 42 --agent --quiet" in capsys.readouterr().out
+
+    assert main(["move", "42", "--column", "not-now", "--dry-run"]) == 0
+    assert "fizzy card postpone 42 --agent --quiet" in capsys.readouterr().out
+
+    assert main(["move", "42", "--column", "done", "--dry-run"]) == 0
+    assert "fizzy card close 42 --agent --quiet" in capsys.readouterr().out
+
+
+def test_move_command_can_resolve_unique_custom_column_name(capsys):
+    exit_code = main(
+        [
+            "move",
+            "42",
+            "--column",
+            "Ready for Agents",
+            "--custom-column",
+            "col_ready=Ready for Agents",
+            "--custom-column",
+            "col_review=Synthesize & Verify",
+            "--dry-run",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "fizzy card column 42 --column col_ready --agent --quiet" in captured.out
+
+
+def test_move_command_rejects_ambiguous_custom_column_name(capsys):
+    exit_code = main(
+        [
+            "move",
+            "42",
+            "--column",
+            "Ready",
+            "--custom-column",
+            "col_a=Ready",
+            "--custom-column",
+            "col_b=Ready",
+            "--dry-run",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "Duplicate custom column name 'Ready'" in captured.err
+    assert "column IDs" in captured.err

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -73,7 +73,7 @@ class TestCommandBuilders:
         commands = build_card_claim_commands(_make_board(), _make_card(number=42), _make_config())
         assert commands == [
             "fizzy card show 42 --agent --markdown",
-            "fizzy card column 42 --column 'In Flight' --agent --quiet",
+            "fizzy card column 42 --column backlog --agent --quiet",
             "fizzy comment create --card 42 --body 'Do something' --agent --quiet",
         ]
 
@@ -223,5 +223,5 @@ class TestFormatPlanAsText:
         assert "fizzy doctor" in text
         assert "fizzy card list" in text
         assert "fizzy card show 101" in text
-        assert "fizzy card column 101 --column 'In Flight'" in text
+        assert "fizzy card column 101 --column backlog" in text
         assert "fizzy comment create --card 101" in text

--- a/tests/test_rcc_robot_files.py
+++ b/tests/test_rcc_robot_files.py
@@ -1,10 +1,21 @@
+import json
+import shutil
 from pathlib import Path
 
-from robots.workitems.tasks import InMemoryWorkItemAdapter, run_smoke_sqlite_workitem_flow
+import pytest
+
+from fizzy_symphony.runners import CodexCliRunner, CodexRunResult
+from robots.workitems.tasks import (
+    FullSmokeBlocked,
+    InMemoryWorkItemAdapter,
+    run_smoke_sqlite_workitem_flow,
+    run_workai_production_smoke,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
 ROBOT_ROOT = ROOT / "robots" / "workitems"
+WORKAI_SAMPLE = ROOT / "test-projects" / "workai-smoke" / "sample_project"
 
 
 def test_rcc_workitem_robot_files_exist():
@@ -20,6 +31,7 @@ def test_robot_yaml_exposes_expected_tasks():
     assert "Doctor:" in robot_yaml
     assert "WorkitemsEnv:" in robot_yaml
     assert "SmokeSQLiteWorkitemFlow:" in robot_yaml
+    assert "WorkAIProductionSmoke:" in robot_yaml
     assert "robocorp.tasks" in robot_yaml
 
 
@@ -39,3 +51,240 @@ def test_smoke_helper_runs_with_in_memory_adapter(tmp_path):
     assert proof["output_payload"]["card_id"] == "smoke-card-1"
     assert proof["output_payload"]["comment"] == "Smoke runner completed card 1 without mutation."
     assert (tmp_path / "smoke-workitem-flow.json").is_file()
+
+
+def test_workai_production_smoke_refuses_unavailable_or_cli_runner(tmp_path):
+    sample_project = tmp_path / "sample_project"
+    shutil.copytree(WORKAI_SAMPLE, sample_project)
+
+    with pytest.raises(FullSmokeBlocked, match="Codex SDK runner"):
+        run_workai_production_smoke(
+            board_id="board_disposable",
+            output_dir=tmp_path / "output",
+            sample_project_dir=sample_project,
+            runner=_UnavailableSdkRunner(),
+            prefer_real_adapter=False,
+        )
+    with pytest.raises(FullSmokeBlocked, match="not CodexCliRunner"):
+        run_workai_production_smoke(
+            board_id="board_disposable",
+            output_dir=tmp_path / "output-cli",
+            sample_project_dir=sample_project,
+            runner=CodexCliRunner(command=["python", "-c", "print('not sdk')"]),
+            prefer_real_adapter=False,
+        )
+
+
+def test_workai_production_smoke_runs_all_cards_with_sdk_runner(tmp_path):
+    sample_project = tmp_path / "sample_project"
+    shutil.copytree(WORKAI_SAMPLE, sample_project)
+    runner = _ScriptedSdkRunner()
+
+    summary = run_workai_production_smoke(
+        board_id="board_disposable",
+        output_dir=tmp_path / "output",
+        sample_project_dir=sample_project,
+        runner=runner,
+        prefer_real_adapter=False,
+        live_fizzy=False,
+    )
+
+    assert summary["status"] == "PASS"
+    assert summary["board"]["id"] == "board_disposable"
+    assert summary["board"]["mutated_fizzy"] is False
+    assert summary["board"]["cleanup_command"] == "fizzy board delete board_disposable"
+    assert summary["preflight"]["sdk"]["thread_id"] == "thread-preflight"
+    assert summary["preflight"]["sqlite_workitems"]["adapter"] == "in-memory"
+    assert [item["card_number"] for item in summary["cards"]] == list(range(1, 9))
+    assert all(item["sdk"]["thread_id"].startswith("thread-card-") for item in summary["cards"])
+    assert all(item["sdk"]["run_id"].startswith("run-card-") for item in summary["cards"])
+    assert all(item["report_back"]["mode"] == "dry-run" for item in summary["cards"])
+    assert any("fizzy card golden" in command for command in summary["board"]["setup_commands"])
+    first_report_commands = summary["cards"][0]["report_back"]["commands"]
+    assert any("fizzy comment create --card 1" in command for command in first_report_commands)
+    assert any("<Synthesize & Verify column id>" in command for command in first_report_commands)
+    assert summary["sample_project_tests"]["returncode"] == 0
+    assert "passed" in summary["sample_project_tests"]["stdout"]
+    assert runner.card_numbers == [1, 2, 3, 4, 5, 6, 7, 8]
+    cli_text = (sample_project / "workai_smoke" / "cli.py").read_text(encoding="utf-8")
+    readme_text = (sample_project / "README.md").read_text(encoding="utf-8")
+    test_text = (sample_project / "tests" / "test_cli.py").read_text(encoding="utf-8")
+    assert cli_text.count("--json") == 1
+    assert "Smoke completion checklist" in readme_text
+    assert "test_json_output_mode" in test_text
+    assert Path(summary["artifacts"]["summary_path"]).is_file()
+    assert Path(summary["artifacts"]["pytest_output_path"]).is_file()
+
+
+def test_workai_production_smoke_live_mode_requires_real_card_mapping(tmp_path):
+    sample_project = tmp_path / "sample_project"
+    shutil.copytree(WORKAI_SAMPLE, sample_project)
+
+    with pytest.raises(FullSmokeBlocked, match="GOLDEN_CARD_NUMBER"):
+        run_workai_production_smoke(
+            board_id="board_disposable",
+            output_dir=tmp_path / "output",
+            sample_project_dir=sample_project,
+            runner=_ScriptedSdkRunner(),
+            prefer_real_adapter=False,
+            live_fizzy=True,
+            handoff_column_id="col_synthesize_and_verify",
+        )
+
+
+class _ScriptedSdkRunner:
+    runner_kind = "codex_sdk"
+
+    def __init__(self) -> None:
+        self.card_numbers = []
+
+    def __call__(self, request):
+        if request.metadata.get("preflight"):
+            return CodexRunResult(
+                success=True,
+                final_response="SDK preflight OK",
+                thread_id="thread-preflight",
+                raw_metadata={
+                    "runner": "codex_sdk",
+                    "thread_id": "thread-preflight",
+                    "run_id": "run-preflight",
+                    "raw": {"model": "fake-sdk"},
+                },
+            )
+
+        card_number = int(request.card_number)
+        self.card_numbers.append(card_number)
+        workspace = Path(str(request.workspace))
+        changed_files = _apply_scripted_card_change(workspace, card_number)
+
+        return CodexRunResult(
+            success=True,
+            final_response=f"Card {card_number} completed with SDK runner.",
+            thread_id=f"thread-card-{card_number}",
+            artifacts={"changed_files": changed_files},
+            validation_summary=f"scripted card {card_number}",
+            raw_metadata={
+                "runner": "codex_sdk",
+                "thread_id": f"thread-card-{card_number}",
+                "run_id": f"run-card-{card_number}",
+                "card_number": card_number,
+                "raw": {"changed_files": changed_files},
+            },
+        )
+
+
+class _UnavailableSdkRunner:
+    runner_kind = "codex_sdk"
+
+    def __call__(self, request):  # noqa: ARG002
+        raise RuntimeError("Codex SDK runner is not implemented yet")
+
+
+def _apply_scripted_card_change(workspace: Path, card_number: int):
+    changed = []
+    cli_path = workspace / "workai_smoke" / "cli.py"
+    init_path = workspace / "workai_smoke" / "__init__.py"
+    readme_path = workspace / "README.md"
+    test_path = workspace / "tests" / "test_cli.py"
+
+    if card_number in {1, 4, 5, 6, 7}:
+        cli_path.write_text(_SCRIPTED_CLI, encoding="utf-8")
+        changed.append("workai_smoke/cli.py")
+    if card_number in {5, 6}:
+        init_path.write_text(_SCRIPTED_INIT, encoding="utf-8")
+        changed.append("workai_smoke/__init__.py")
+    if card_number in {2, 8}:
+        text = readme_path.read_text(encoding="utf-8")
+        addition = "\n## Usage\n\n```bash\npython -m workai_smoke.cli --json Josh\n```\n"
+        checklist = (
+            "\n## Smoke completion checklist\n\n"
+            "- Code changed\n- Tests passed\n- Fizzy proof reported\n"
+        )
+        readme_path.write_text(
+            text + (addition if card_number == 2 else checklist),
+            encoding="utf-8",
+        )
+        changed.append("README.md")
+    if card_number == 3:
+        test_path.write_text(_SCRIPTED_TESTS, encoding="utf-8")
+        changed.append("tests/test_cli.py")
+
+    proof_path = workspace / f"card-{card_number}-proof.json"
+    proof_path.write_text(json.dumps({"card": card_number, "changed": changed}), encoding="utf-8")
+    changed.append(proof_path.name)
+    return changed
+
+
+_SCRIPTED_CLI = '''"""Small CLI that smoke-test cards can ask Codex to edit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import List
+
+from workai_smoke import __version__
+
+
+def greeting(name: str) -> str:
+    return f"Hello, {name}!"
+
+
+def farewell(name: str) -> str:
+    return f"Goodbye, {name}."
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("name")
+    parser.add_argument("--shout", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--version", action="version", version=__version__)
+    args = parser.parse_args(argv)
+    message = greeting(args.name)
+    if args.shout:
+        message = message.upper()
+    if args.json:
+        print(json.dumps({"name": args.name, "greeting": message}))
+    else:
+        print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+_SCRIPTED_INIT = '''"""Tiny editable package for WorkAI smoke tests."""
+
+__version__ = "0.1.0"
+
+from .cli import farewell, greeting
+
+__all__ = ["__version__", "farewell", "greeting"]
+'''
+
+_SCRIPTED_TESTS = '''import json
+
+from workai_smoke.cli import farewell, greeting, main
+
+
+def test_greeting_includes_name():
+    assert "Josh" in greeting("Josh")
+    assert greeting("Josh").endswith("!")
+
+
+def test_farewell_helper():
+    assert farewell("Josh") == "Goodbye, Josh."
+
+
+def test_json_output_mode(capsys):
+    assert main(["--json", "Josh"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"name": "Josh", "greeting": "Hello, Josh!"}
+
+
+def test_shout_mode(capsys):
+    assert main(["--shout", "Josh"]) == 0
+    assert capsys.readouterr().out == "HELLO, JOSH!\\n"
+'''

--- a/tests/test_rcc_robot_files.py
+++ b/tests/test_rcc_robot_files.py
@@ -8,6 +8,7 @@ from fizzy_symphony.runners import CodexCliRunner, CodexRunResult
 from robots.workitems.tasks import (
     FullSmokeBlocked,
     InMemoryWorkItemAdapter,
+    run_prompt_card_smoke,
     run_smoke_sqlite_workitem_flow,
     run_workai_production_smoke,
 )
@@ -32,6 +33,7 @@ def test_robot_yaml_exposes_expected_tasks():
     assert "WorkitemsEnv:" in robot_yaml
     assert "SmokeSQLiteWorkitemFlow:" in robot_yaml
     assert "WorkAIProductionSmoke:" in robot_yaml
+    assert "PromptCardSmoke:" in robot_yaml
     assert "robocorp.tasks" in robot_yaml
 
 
@@ -132,6 +134,32 @@ def test_workai_production_smoke_live_mode_requires_real_card_mapping(tmp_path):
         )
 
 
+def test_prompt_card_smoke_runs_one_prompt_with_sdk_runner(tmp_path):
+    sample_project = tmp_path / "sample_project"
+    shutil.copytree(WORKAI_SAMPLE, sample_project)
+    runner = _ScriptedPromptSdkRunner()
+
+    summary = run_prompt_card_smoke(
+        board_id="board_prompt",
+        card_number=42,
+        prompt="Create prompt-proof.txt",
+        workspace=sample_project,
+        output_dir=tmp_path / "output",
+        runner=runner,
+        prefer_real_adapter=False,
+        live_fizzy=False,
+    )
+
+    assert summary["status"] == "PASS"
+    assert summary["board"]["mutated_fizzy"] is False
+    assert summary["card_number"] == 42
+    assert summary["preflight"]["sqlite_workitems"]["adapter"] == "in-memory"
+    assert summary["sdk"]["thread_id"] == "thread-card-42"
+    assert summary["report_back"]["mode"] == "dry-run"
+    assert (sample_project / "prompt-proof.txt").read_text(encoding="utf-8") == "ok"
+    assert Path(summary["artifacts"]["summary_path"]).is_file()
+
+
 class _ScriptedSdkRunner:
     runner_kind = "codex_sdk"
 
@@ -178,6 +206,29 @@ class _UnavailableSdkRunner:
 
     def __call__(self, request):  # noqa: ARG002
         raise RuntimeError("Codex SDK runner is not implemented yet")
+
+
+class _ScriptedPromptSdkRunner(_ScriptedSdkRunner):
+    def __call__(self, request):
+        if request.metadata.get("preflight"):
+            return super().__call__(request)
+
+        card_number = int(request.card_number)
+        self.card_numbers.append(card_number)
+        workspace = Path(str(request.workspace))
+        (workspace / "prompt-proof.txt").write_text("ok", encoding="utf-8")
+        return CodexRunResult(
+            success=True,
+            final_response="Prompt card completed with SDK runner.",
+            thread_id=f"thread-card-{card_number}",
+            artifacts={"changed_files": ["prompt-proof.txt"]},
+            raw_metadata={
+                "runner": "codex_sdk",
+                "thread_id": f"thread-card-{card_number}",
+                "run_id": f"run-card-{card_number}",
+                "card_number": card_number,
+            },
+        )
 
 
 def _apply_scripted_card_change(workspace: Path, card_number: int):

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -7,6 +7,7 @@ from fizzy_symphony.runners import (
     CodexRunRequest,
     CodexSdkRunner,
     CodexWorkItemRunner,
+    _CodexPythonSdkClient,
     create_codex_runner,
 )
 from fizzy_symphony.workitem_queue import FizzyWorkItemPayload
@@ -174,15 +175,226 @@ def test_workitem_runner_adapts_payload_to_worker_result():
     assert result["raw_metadata"]["card_number"] == 44
 
 
-def test_sdk_runner_placeholder_fails_clearly():
-    runner = CodexSdkRunner()
+def test_workitem_runner_can_adapt_sdk_runner_result(tmp_path):
+    payload = FizzyWorkItemPayload(
+        source="fizzy",
+        card={"id": "card-12", "number": 12, "title": "Run SDK payload"},
+        workflow={"prompt_template": "SDK payload prompt", "workspace": str(tmp_path)},
+        runner={
+            "kind": "sdk",
+            "model": "gpt-5-codex",
+            "approval_policy": "never",
+            "timeout_seconds": 12,
+        },
+    )
+    client = _FakeCodexAppServerClient()
 
-    with pytest.raises(RuntimeError, match="Codex SDK runner is not implemented yet"):
-        runner(CodexRunRequest(prompt="not yet"))
+    result = CodexWorkItemRunner(CodexSdkRunner(client_factory=lambda **kwargs: client))(payload)
+
+    assert result["success"] is True
+    assert result["comment"] == "Final proof text"
+    assert result["final_response"] == "Final proof text"
+    assert result["thread_id"] == "thread-123"
+    assert result["artifacts"]["run_id"] == "turn-456"
+    assert result["raw_metadata"]["runner"] == "codex_sdk"
+    assert result["raw_metadata"]["card_number"] == 12
 
 
-def test_runner_factory_exposes_cli_and_rejects_unimplemented_sdk():
+class _FakeCodexAppServerClient:
+    def __init__(self):
+        self.calls = []
+        self.closed = False
+
+    def __enter__(self):
+        self.calls.append(("enter", None))
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.closed = True
+        self.calls.append(("exit", exc_type))
+
+    def initialize(self):
+        self.calls.append(("initialize", None))
+        return {"userAgent": "codex-cli 0.test", "codexHome": "/tmp/codex-home"}
+
+    def start_thread(self, params):
+        self.calls.append(("thread/start", params))
+        return {
+            "thread": {"id": "thread-123", "cwd": params["cwd"], "status": "running"},
+            "model": params["model"],
+            "approvalPolicy": params["approvalPolicy"],
+        }
+
+    def start_turn(self, params):
+        self.calls.append(("turn/start", params))
+        return {"turn": {"id": "turn-456", "status": "running", "items": []}}
+
+    def wait_for_turn(self, thread_id, turn_id, timeout_seconds=None):
+        self.calls.append(("wait_for_turn", (thread_id, turn_id, timeout_seconds)))
+        return {
+            "turn": {
+                "id": turn_id,
+                "status": "completed",
+                "items": [
+                    {
+                        "id": "msg-1",
+                        "type": "agentMessage",
+                        "text": "Interim note",
+                        "phase": "commentary",
+                    },
+                    {
+                        "id": "msg-2",
+                        "type": "agentMessage",
+                        "text": "Final proof text",
+                        "phase": "final_answer",
+                    },
+                ],
+            },
+            "notifications": [
+                {
+                    "method": "agent/message/delta",
+                    "params": {
+                        "threadId": thread_id,
+                        "turnId": turn_id,
+                        "delta": "Final proof text",
+                    },
+                }
+            ],
+        }
+
+
+def test_sdk_runner_constructs_without_mandatory_sdk_dependency():
+    runner = CodexSdkRunner(command=["codex", "app-server", "--listen", "stdio://"])
+
+    assert runner.command == ["codex", "app-server", "--listen", "stdio://"]
+
+
+def test_sdk_runner_runs_one_turn_through_app_server_protocol(tmp_path):
+    client = _FakeCodexAppServerClient()
+    runner = CodexSdkRunner(client_factory=lambda **kwargs: client)
+    request = CodexRunRequest(
+        prompt="Implement this card",
+        workspace=str(tmp_path),
+        model="gpt-5-codex",
+        approval_policy="never",
+        timeout_seconds=12,
+        env={"CODEX_HOME": "/tmp/custom-codex-home"},
+        card_number=12,
+    )
+
+    result = runner(request)
+
+    assert result.success is True
+    assert result.final_response == "Final proof text"
+    assert result.thread_id == "thread-123"
+    assert result.raw_metadata["runner"] == "codex_sdk"
+    assert result.raw_metadata["turn_id"] == "turn-456"
+    assert result.raw_metadata["app_server"]["initialize"]["userAgent"] == "codex-cli 0.test"
+    assert client.closed is True
+    assert client.calls[1] == ("initialize", None)
+    assert client.calls[2] == (
+        "thread/start",
+        {
+            "cwd": str(tmp_path),
+            "model": "gpt-5-codex",
+            "approvalPolicy": "never",
+            "sandbox": "workspace-write",
+            "ephemeral": True,
+            "experimentalRawEvents": True,
+        },
+    )
+    assert client.calls[3] == (
+        "turn/start",
+        {
+            "threadId": "thread-123",
+            "cwd": str(tmp_path),
+            "model": "gpt-5-codex",
+            "approvalPolicy": "never",
+            "input": [{"type": "text", "text": "Implement this card"}],
+            "sandboxPolicy": {
+                "type": "workspaceWrite",
+                "writableRoots": [str(tmp_path.resolve())],
+                "networkAccess": False,
+            },
+            "responsesapiClientMetadata": {
+                "fizzy_symphony.card_number": "12",
+                "fizzy_symphony.runner": "codex_sdk",
+            },
+        },
+    )
+
+
+def test_sdk_runner_uses_agent_message_delta_when_final_item_missing(tmp_path):
+    class DeltaOnlyClient(_FakeCodexAppServerClient):
+        def wait_for_turn(self, thread_id, turn_id, timeout_seconds=None):
+            return {
+                "turn": {"id": turn_id, "status": "completed", "items": []},
+                "notifications": [
+                    {
+                        "method": "agent/message/delta",
+                        "params": {"threadId": thread_id, "turnId": turn_id, "delta": "Hello "},
+                    },
+                    {
+                        "method": "agent/message/delta",
+                        "params": {"threadId": thread_id, "turnId": turn_id, "delta": "there"},
+                    },
+                ],
+            }
+
+    result = CodexSdkRunner(client_factory=lambda **kwargs: DeltaOnlyClient())(
+        CodexRunRequest(prompt="Say hi", workspace=str(tmp_path))
+    )
+
+    assert result.success is True
+    assert result.final_response == "Hello there"
+
+
+def test_sdk_runner_returns_clean_unavailable_failure(tmp_path):
+    def _missing_client(**kwargs):
+        raise FileNotFoundError("codex")
+
+    result = CodexSdkRunner(client_factory=_missing_client)(
+        CodexRunRequest(prompt="not available", workspace=str(tmp_path))
+    )
+
+    assert result.success is False
+    assert result.returncode is None
+    assert "Codex app-server/SDK unavailable" in result.stderr
+    assert result.raw_metadata["error_type"] == "FileNotFoundError"
+
+
+def test_sdk_runner_returns_clean_runtime_failure(tmp_path):
+    class FailingClient(_FakeCodexAppServerClient):
+        def start_turn(self, params):
+            raise RuntimeError("unauthorized")
+
+    result = CodexSdkRunner(client_factory=lambda **kwargs: FailingClient())(
+        CodexRunRequest(prompt="auth blocked", workspace=str(tmp_path))
+    )
+
+    assert result.success is False
+    assert "Codex app-server/SDK run failed: unauthorized" in result.stderr
+    assert result.raw_metadata["error_type"] == "RuntimeError"
+
+
+def test_python_sdk_client_enforces_timeout_without_blocking():
+    class SlowThread:
+        def run(self, prompt, **kwargs):  # noqa: ARG002
+            import time
+
+            time.sleep(1)
+
+    client = _CodexPythonSdkClient(
+        command=["codex", "app-server", "--listen", "stdio://"],
+        timeout_seconds=0.01,
+    )
+    client._thread = SlowThread()
+    client._turn_input = "slow"
+
+    with pytest.raises(TimeoutError, match="Codex Python SDK run"):
+        client.wait_for_turn("thread-1", "turn-1")
+
+
+def test_runner_factory_exposes_cli_and_sdk():
     assert isinstance(create_codex_runner("cli"), CodexCliRunner)
-
-    with pytest.raises(RuntimeError, match="Codex SDK runner is not implemented yet"):
-        create_codex_runner("sdk")
+    assert isinstance(create_codex_runner("sdk"), CodexSdkRunner)

--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -1,8 +1,12 @@
+import pytest
+
 from fizzy_symphony.symphony import (
+    FizzyCustomColumn,
     fizzy_system_lanes,
     format_init_board_plan,
     format_mapping_table,
     recommended_columns,
+    resolve_fizzy_lane,
     upstream_mapping,
 )
 
@@ -28,6 +32,44 @@ def test_fizzy_system_lanes_are_immutable_board_lanes():
     assert lanes["done"].kind == "closed"
 
 
+def test_resolve_fizzy_lane_maps_system_aliases():
+    maybe = resolve_fizzy_lane("triage")
+    not_now = resolve_fizzy_lane("not_now")
+    done = resolve_fizzy_lane("closed")
+
+    assert maybe.kind == "triage"
+    assert maybe.pseudo_id == "maybe"
+    assert not_now.kind == "not_now"
+    assert not_now.pseudo_id == "not-now"
+    assert done.kind == "closed"
+    assert done.pseudo_id == "done"
+
+
+def test_resolve_fizzy_lane_supports_custom_column_ids_and_names():
+    columns = [
+        FizzyCustomColumn(column_id="col_ready", name="Ready for Agents"),
+        FizzyCustomColumn(column_id="col_ship", name="Ready to Ship"),
+    ]
+
+    by_id = resolve_fizzy_lane("col_ship", custom_columns=columns)
+    by_name = resolve_fizzy_lane("Ready for Agents", custom_columns=columns)
+
+    assert by_id.kind == "custom_column"
+    assert by_id.column_id == "col_ship"
+    assert by_name.kind == "custom_column"
+    assert by_name.column_id == "col_ready"
+
+
+def test_resolve_fizzy_lane_rejects_duplicate_custom_column_names():
+    columns = [
+        FizzyCustomColumn(column_id="col_a", name="Ready"),
+        FizzyCustomColumn(column_id="col_b", name="Ready"),
+    ]
+
+    with pytest.raises(ValueError, match="Duplicate custom column name 'Ready'.*column IDs"):
+        resolve_fizzy_lane("Ready", custom_columns=columns)
+
+
 def test_format_init_board_plan_uses_existing_board():
     plan = format_init_board_plan("board-1")
 
@@ -36,6 +78,8 @@ def test_format_init_board_plan_uses_existing_board():
     assert "- Done (done, closed)" in plan
     assert "fizzy column list --board board-1 --agent --quiet" in plan
     assert "fizzy column create --board board-1 --name 'Synthesize & Verify'" in plan
+    assert "fizzy column create --board board-1 --name 'Maybe?'" not in plan
+    assert "fizzy column create --board board-1 --name 'Not Now'" not in plan
     assert "fizzy column create --board board-1 --name Done" not in plan
 
 

--- a/tests/test_workai_smoke_project.py
+++ b/tests/test_workai_smoke_project.py
@@ -144,6 +144,9 @@ def test_live_with_board_id_executes_configure_commands(monkeypatch, capsys):
     assert '"board_id": "board_123"' in captured.out
     assert '"cleanup_command": "fizzy board delete board_123"' in captured.out
     assert '"marked_golden": true' in captured.out
+    assert '"WORKAI_SMOKE_CARD_NUMBERS": "1=987,2=987,3=987,4=987,5=987,6=987,7=987,8=987"' in captured.out
+    assert '"WORKAI_SMOKE_GOLDEN_CARD_NUMBER": "987"' in captured.out
+    assert '"WORKAI_SMOKE_HANDOFF_COLUMN_ID": "col-Synthesize & Verify"' in captured.out
     assert all(call[1] is True for call in calls)
     assert ["fizzy", "column", "list", "--board", "board_123", "--agent", "--quiet"] in [
         call[0] for call in calls

--- a/tests/test_workai_smoke_project.py
+++ b/tests/test_workai_smoke_project.py
@@ -26,7 +26,11 @@ def test_fixture_describes_disposable_board_and_cards():
     assert production_smoke["requires_codex_sdk"] is True
     assert production_smoke["requires_rcc_sqlite"] is True
     assert production_smoke["minimum_task_cards"] == 8
-    assert "Codex SDK run metadata" in production_smoke["expected_artifacts"]
+    assert (
+        "Codex SDK thread/run metadata and raw metadata"
+        in production_smoke["expected_artifacts"]
+    )
+    assert "Disposable board cleanup command" in production_smoke["expected_artifacts"]
     assert data["board"]["recommended_columns"] == [
         "Shaping",
         "Ready for Agents",
@@ -94,6 +98,7 @@ def test_bootstrap_dry_run_does_not_execute_fizzy(monkeypatch, capsys):
     assert exit_code == 0
     assert "Dry run only" in captured.out
     assert "fizzy board create" in captured.out
+    assert "fizzy board delete ${WORKAI_SMOKE_BOARD_ID}" in captured.out
 
 
 def test_live_requires_explicit_board_id_before_execution(monkeypatch):
@@ -137,6 +142,8 @@ def test_live_with_board_id_executes_configure_commands(monkeypatch, capsys):
     assert exit_code == 0
     assert calls
     assert '"board_id": "board_123"' in captured.out
+    assert '"cleanup_command": "fizzy board delete board_123"' in captured.out
+    assert '"marked_golden": true' in captured.out
     assert all(call[1] is True for call in calls)
     assert ["fizzy", "column", "list", "--board", "board_123", "--agent", "--quiet"] in [
         call[0] for call in calls


### PR DESCRIPTION
## Summary
- add official Codex Python SDK-backed runner behavior with workspace-write sandbox support and timeout handling
- add RCC PromptCardSmoke for one live Fizzy card/prompt plus WorkAI smoke env output
- add devcontainer using ghcr.io/joshyorko/ror:latest and live operator guide from install/auth to finish

## Verification
- python -m json.tool .devcontainer/devcontainer.json
- .venv/bin/python -m pytest -q
- .venv/bin/python -m compileall src robots/workitems test-projects/workai-smoke
- git diff --check
- rcc ht vars -r robots/workitems/robot.yaml --json
- rcc run -r robots/workitems/robot.yaml -t Doctor --silent
- rcc run -r robots/workitems/robot.yaml -t SmokeSQLiteWorkitemFlow -e robots/workitems/devdata/env-sqlite.json --silent
- rcc run -r robots/workitems/robot.yaml -t PromptCardSmoke --silent (expected guard without env)

Closes #11
Closes #12
Closes #15