### PR TITLE
Implement guarded git worktree lifecycle

### DIFF
--- a/src/completion.js
+++ b/src/completion.js
@@ -316,6 +316,7 @@ export function evaluateCleanupEligibility({
   config = {},
   workspace = {},
   proof,
+  result = {},
   resultComment,
   completionMarker,
   completionPolicyResult = { success: true },
@@ -331,6 +332,10 @@ export function evaluateCleanupEligibility({
   if (!completionMarker?.id && !completionMarker?.body && !completionMarker?.payload) {
     return preserve("completion_marker_missing");
   }
+  const missingHandoff = missingCodeHandoff({ proof, result, workspace });
+  if (missingHandoff.length > 0) {
+    return { ...preserve("code_handoff_missing"), missing: missingHandoff };
+  }
   if (claimRelease && claimRelease.released !== true && claimRelease.status !== "released" && claimRelease.status !== "completed") {
     return preserve("claim_release_missing");
   }
@@ -341,6 +346,24 @@ export function evaluateCleanupEligibility({
 
 function preserve(reason) {
   return { action: "preserve", reason };
+}
+
+function missingCodeHandoff({ proof = {}, result = {}, workspace = {} } = {}) {
+  const payload = proof.payload ?? {};
+  const noCodeChange = payload.no_code_change === true ||
+    proof.no_code_change === true ||
+    result.no_code_change === true ||
+    workspace.no_code_change === true;
+  if (noCodeChange) return [];
+
+  const handoff = {
+    branch_name: payload.branch_name ?? result.branch_name ?? workspace.branch_name,
+    commit_sha: payload.commit_sha ?? result.commit_sha ?? workspace.commit_sha,
+    pr_url: payload.pr_url ?? payload.pull_request_url ?? result.pr_url ?? result.pull_request_url ?? workspace.pr_url
+  };
+  return Object.entries(handoff)
+    .filter(([, value]) => value === undefined || value === null || value === "")
+    .map(([field]) => field);
 }
 
 function markerBody(marker, payload) {

--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -86,6 +86,14 @@ export async function runReconciliationTick(options = {}) {
       }
 
       const workspaceIdentity = await resolveWorkspaceIdentity({ config, card, decision, workspaceManager });
+      await workspaceManager?.preflight?.({
+        config,
+        card,
+        route: decision.route,
+        decision,
+        identity: workspaceIdentity,
+        workspace: workspaceIdentity
+      });
       const claimResult = await claims.acquire({
         config,
         card,
@@ -656,21 +664,59 @@ async function runCard({
     const claimRelease = await claims.release({ config, claim, run: completed ?? run, status: "completed", now });
     orchestratorState?.completeRun?.(runId, { proof, result_comment_id: resultComment?.id });
     recordLifecycle(status, orchestratorState);
-    const cleanup = evaluateCleanupEligibility({
+    let cleanup = evaluateCleanupEligibility({
       config,
       workspace,
       proof,
+      result: streamResult,
       resultComment,
       completionMarker: recordedCompletionMarker,
       completionPolicyResult,
       claimRelease
     });
+
+    if (cleanup.action === "eligible" && typeof workspaceManager?.cleanup === "function") {
+      status?.recordCleanupState?.({
+        status: "cleanup_started",
+        reason: cleanup.reason
+      });
+      await writeRunAttempt(status, {
+        ...(completed ?? run),
+        proof,
+        result_comment_id: resultComment?.id,
+        completion_marker: recordedCompletionMarker,
+        cleanup_state: "cleanup_started"
+      }, "cleanup_started");
+      try {
+        cleanup = await workspaceManager.cleanup({
+          config,
+          run: completed ?? run,
+          card: refreshedCard,
+          route,
+          workspace,
+          proof,
+          result: streamResult,
+          resultComment,
+          completionMarker: recordedCompletionMarker,
+          completionPolicyResult,
+          claimRelease
+        });
+      } catch (error) {
+        cleanup = {
+          action: "preserve",
+          reason: "cleanup_failed",
+          error: normalizeError(error)
+        };
+      }
+    }
+
+    const cleanupStatus = cleanupStatusName(cleanup);
     status?.recordCleanupState?.({
-      status: cleanup.action === "eligible" ? "cleanup_planned" : "cleanup_preserved",
+      status: cleanupStatus,
       reason: cleanup.reason
     });
     await upsertWorkpad({ config, status, fizzy, card: refreshedCard, route, run: completed ?? run, workspace, phase: "handoff", proof, resultComment, now });
-    await writeRunAttempt(status, { ...(completed ?? run), cleanup_state: cleanup.action }, "completed");
+    await writeRunAttempt(status, { ...(completed ?? run), cleanup_state: cleanupStatus }, "completed");
     return { status: "completed", run: completed ?? run };
   } catch (error) {
     orchestratorState?.recordFailure?.(runId, error, {
@@ -779,6 +825,13 @@ function runnerFailure(result) {
 function isRetryableRunnerError(error = {}) {
   return !String(error.code ?? "").startsWith("COMPLETION_") &&
     error.code !== "STALE_ROUTE_FINGERPRINT";
+}
+
+function cleanupStatusName(cleanup = {}) {
+  if (cleanup.status) return cleanup.status;
+  if (cleanup.action === "removed") return "cleanup_completed";
+  if (cleanup.action === "eligible") return "cleanup_planned";
+  return "cleanup_preserved";
 }
 
 async function withOptionalTimeout(promise, timeoutMs) {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -530,38 +530,59 @@ async function defaultExec(file, args = [], options = {}) {
 }
 
 async function runGit(args, { cwd, exec = defaultExec, allowFailure = false } = {}) {
+  let raw;
   try {
-    const result = normalizeCommandResult(await exec("git", args, { cwd }));
-    return { ok: true, ...result };
+    raw = await exec("git", args, { cwd });
   } catch (error) {
     const result = normalizeCommandError(error);
     if (allowFailure) return { ok: false, ...result };
-    throw new FizzySymphonyError("GIT_COMMAND_FAILED", "Git command failed.", {
-      cwd,
-      args,
-      exit_code: result.exit_code,
-      stdout: result.stdout,
-      stderr: result.stderr,
-      cause: error.message
-    });
+    throw gitCommandFailed({ cwd, args, result, cause: error.message });
   }
+
+  const result = normalizeCommandResult(raw);
+  if (result.exit_code !== 0) {
+    if (allowFailure) return { ok: false, ...result };
+    throw gitCommandFailed({ cwd, args, result });
+  }
+
+  return { ok: true, ...result };
 }
 
 async function runCommand(argv, { cwd, exec = defaultExec } = {}) {
   const [file, ...args] = argv;
+  let raw;
   try {
-    return normalizeCommandResult(await exec(file, args, { cwd }));
+    raw = await exec(file, args, { cwd });
   } catch (error) {
     const result = normalizeCommandError(error);
-    throw new FizzySymphonyError("WORKSPACE_HOOK_FAILED", "Workspace lifecycle hook failed.", {
-      cwd,
-      argv,
-      exit_code: result.exit_code,
-      stdout: result.stdout,
-      stderr: result.stderr,
-      cause: error.message
-    });
+    throw hookCommandFailed({ cwd, argv, result, cause: error.message });
   }
+
+  const result = normalizeCommandResult(raw);
+  if (result.exit_code !== 0) throw hookCommandFailed({ cwd, argv, result });
+  return result;
+}
+
+function gitCommandFailed({ cwd, args, result, cause }) {
+  return new FizzySymphonyError("GIT_COMMAND_FAILED", "Git command failed.", {
+    cwd,
+    args,
+    exit_code: result.exit_code,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    cause
+  });
+}
+
+function hookCommandFailed({ cwd, argv, result, cause }) {
+  return new FizzySymphonyError("WORKSPACE_HOOK_FAILED", "Workspace lifecycle hook failed.", {
+    cwd,
+    argv,
+    exit_code: result.exit_code,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    cause
+  });
 }
 
 function normalizeCommandResult(result = {}) {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1,8 +1,12 @@
 import { createHash } from "node:crypto";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { execFile } from "node:child_process";
+import { access, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
 
+import { evaluateCleanupEligibility } from "./completion.js";
 import { FizzySymphonyError } from "./errors.js";
+import { loadWorkflow } from "./workflow.js";
 
 const GUARD_FILE_VERSION = 1;
 const GUARD_FILE_NAME = ".fizzy-symphony-workspace-guard.json";
@@ -10,7 +14,8 @@ const METADATA_MARKER = "fizzy-symphony:workspace-metadata:v1";
 const GUARD_MARKER = "fizzy-symphony:workspace-guard:v1";
 const SUPPORTED_ISOLATION_STRATEGIES = new Set(["git_worktree", "git_clone", "copy"]);
 
-const nodeFs = { mkdir, readdir, readFile, writeFile };
+const execFileAsync = promisify(execFile);
+const nodeFs = { access, mkdir, readdir, readFile, rm, writeFile };
 
 export function resolveWorkspaceIdentity({ config, route, card, workspaceName } = {}) {
   const name = workspaceName ?? route?.workspace;
@@ -111,7 +116,83 @@ export function branchName(identity, options = {}) {
   return `${prefix}/${name}`;
 }
 
-export async function prepareWorkspace({ config, identity, metadata = {}, fs = nodeFs } = {}) {
+export function createWorkspaceManager({ fs = nodeFs, exec = defaultExec } = {}) {
+  return {
+    resolveIdentity({ config, route, card, workspaceName } = {}) {
+      return resolveWorkspaceIdentity({ config, route, card, workspaceName });
+    },
+    preflight({ config, identity, workspace } = {}) {
+      return preflightWorkspaceSource({ config, identity: identity ?? workspace, fs, exec });
+    },
+    prepare({ config, identity, workspace, claim = {}, now = new Date() } = {}) {
+      return prepareWorkspace({
+        config,
+        identity: identity ?? workspace,
+        fs,
+        exec,
+        metadata: {
+          run_attempt_id: claim.attempt_id ?? claim.attemptId,
+          run_id: claim.run_id ?? claim.runId,
+          claim_id: claim.id ?? claim.claim_id,
+          created_at: toIso(now)
+        }
+      });
+    },
+    preserve({ run = {}, reason, finalStatus } = {}) {
+      return {
+        status: "preserved",
+        reason,
+        final_status: finalStatus,
+        workspace_path: run.workspace_path ?? run.workspace?.path ?? run.workspace?.workspace_path,
+        workspace_key: run.workspace_key ?? run.workspace?.key ?? run.workspace?.workspace_key
+      };
+    },
+    cleanup(options = {}) {
+      return cleanupWorkspace({ ...options, fs, exec });
+    }
+  };
+}
+
+export async function preflightWorkspaceSource({ config, identity, fs = nodeFs, exec = defaultExec } = {}) {
+  if (!identity) return { status: "skipped", reason: "workspace_identity_missing" };
+  if (identity.isolation_strategy !== "git_worktree") {
+    return { status: "skipped", reason: "unsupported_isolation_strategy", isolation_strategy: identity.isolation_strategy };
+  }
+
+  const sourceRepositoryPath = resolve(identity.canonical_source_repository_path ?? identity.source_repository_path);
+  await assertGitRepository(sourceRepositoryPath, exec);
+  await assertGitRef(sourceRepositoryPath, identity.source_ref, exec);
+
+  const workspace = workspaceConfig(config, identity.workspace_name);
+  const sourceStatus = await gitStatus({ cwd: sourceRepositoryPath, exec, ignoredPaths: [] });
+  const snapshotPolicy = config?.safety?.dirty_source_repo_policy === "snapshot";
+  const policyRequiresClean = !snapshotPolicy && (
+    workspace?.require_clean_source === true ||
+    config?.safety?.dirty_source_repo_policy === "fail"
+  );
+
+  if (policyRequiresClean && !sourceStatus.clean) {
+    throw new FizzySymphonyError(
+      "WORKSPACE_SOURCE_DIRTY",
+      "Source repository has local changes and the workspace policy requires a clean source.",
+      {
+        preserve_workspace: true,
+        source_repository_path: sourceRepositoryPath,
+        dirty_paths: sourceStatus.paths
+      }
+    );
+  }
+
+  return {
+    status: "ok",
+    source_repository_path: sourceRepositoryPath,
+    source_ref: identity.source_ref,
+    clean: sourceStatus.clean,
+    dirty_paths: sourceStatus.paths
+  };
+}
+
+export async function prepareWorkspace({ config, identity, metadata = {}, fs = nodeFs, exec = defaultExec } = {}) {
   const key = identity.workspace_key ?? workspaceKey(identity);
   const path = identity.workspace_path ?? workspacePathFromRoot(
     identity.workspace_root ?? config?.workspaces?.root,
@@ -129,21 +210,177 @@ export async function prepareWorkspace({ config, identity, metadata = {}, fs = n
   const existing = await readJsonIfExists(metadataPath, fs);
   if (existing) validateExistingWorkspaceMetadata(existing, identity);
 
-  const fullMetadata = buildWorkspaceMetadata({ config, identity, metadata, key, path });
+  const branch = branchName(identity);
+  let created = false;
+  let sourceHead;
+
+  if (identity.isolation_strategy === "git_worktree") {
+    const preflight = await preflightWorkspaceSource({ config, identity, fs, exec });
+    sourceHead = await gitCommit(resolve(identity.canonical_source_repository_path), identity.source_ref, exec);
+    const pathExists = await exists(path, fs);
+    if (!pathExists) {
+      await fs.mkdir(dirname(path), { recursive: true });
+      await addGitWorktree({
+        sourceRepositoryPath: preflight.source_repository_path,
+        workspacePath: path,
+        branch,
+        sourceRef: identity.source_ref,
+        exec
+      });
+      created = true;
+    } else {
+      if (!existing) {
+        throw new FizzySymphonyError(
+          "WORKSPACE_METADATA_MISSING",
+          "Existing workspace path is missing daemon metadata; preserving workspace.",
+          {
+            preserve_workspace: true,
+            workspace_key: key,
+            workspace_path: path,
+            metadata_path: metadataPath
+          }
+        );
+      }
+      await validateReusableWorktree({
+        sourceRepositoryPath: preflight.source_repository_path,
+        workspacePath: path,
+        branch,
+        metadata: existing,
+        metadataPath,
+        guardPath,
+        fs,
+        exec
+      });
+    }
+    await excludeGuardFile(path, fs, exec);
+  } else {
+    await fs.mkdir(path, { recursive: true });
+    created = !existing;
+  }
+
+  await fs.mkdir(metadataRoot, { recursive: true });
+  const fullMetadata = buildWorkspaceMetadata({
+    config,
+    identity,
+    metadata: {
+      ...metadata,
+      branch_name: branch,
+      source_head: sourceHead
+    },
+    key,
+    path
+  });
   const guard = buildGuard({ identity, key, metadataPath });
 
-  await fs.mkdir(path, { recursive: true });
-  await fs.mkdir(metadataRoot, { recursive: true });
   await fs.writeFile(guardPath, `${JSON.stringify(guard, null, 2)}\n`, "utf8");
   await fs.writeFile(metadataPath, `${JSON.stringify(fullMetadata, null, 2)}\n`, "utf8");
 
+  const workflow = await loadWorkflowForHooks({ config, identity, workspacePath: path, fs });
+  const hookResults = [];
+  if (created) {
+    const afterCreate = await runWorkflowHook({ workflow, hook: "after_create", cwd: path, exec });
+    if (afterCreate) hookResults.push(afterCreate);
+  }
+  const beforeRun = await runWorkflowHook({ workflow, hook: "before_run", cwd: path, exec });
+  if (beforeRun) hookResults.push(beforeRun);
+
   return {
+    key,
+    path,
     workspace_key: key,
     workspace_path: path,
     guard_path: guardPath,
     metadata_path: metadataPath,
+    source_repo: identity.source_repository_path,
+    sourceRepo: identity.source_repository_path,
+    branch_name: branch,
+    identity_digest: identity.workspace_identity_digest,
+    workspace_identity_digest: identity.workspace_identity_digest,
+    created,
+    hooks: hookResults,
     guard,
     metadata: fullMetadata
+  };
+}
+
+export async function cleanupWorkspace({
+  config = {},
+  workspace = {},
+  proof,
+  result,
+  resultComment,
+  completionMarker,
+  completionPolicyResult,
+  claimRelease,
+  fs = nodeFs,
+  exec = defaultExec
+} = {}) {
+  const eligibility = evaluateCleanupEligibility({
+    config,
+    workspace,
+    proof,
+    result,
+    resultComment,
+    completionMarker,
+    completionPolicyResult,
+    claimRelease
+  });
+  if (eligibility.action !== "eligible") return eligibility;
+
+  const workspacePath = workspace.path ?? workspace.workspace_path;
+  const workspaceKeyValue = workspace.key ?? workspace.workspace_key;
+  if (!workspacePath) return preserve("workspace_path_missing");
+
+  const metadataPath = workspace.metadata_path ??
+    (workspaceKeyValue && config.workspaces?.metadata_root
+      ? workspacePathFromRoot(resolve(config.workspaces.metadata_root), `${workspaceKeyValue}.json`, config?.safety?.allowed_roots)
+      : null);
+  if (!metadataPath) return preserve("workspace_metadata_path_missing");
+
+  const metadata = await readJsonIfExists(metadataPath, fs);
+  if (!metadata) return preserve("workspace_metadata_missing");
+
+  const guardPath = workspace.guard_path ?? join(workspacePath, GUARD_FILE_NAME);
+  const guardResult = await validateGuardForMetadata({ metadata, metadataPath, guardPath, fs });
+  if (!guardResult.ok) return preserve(guardResult.code, guardResult.details);
+
+  const sourceRepositoryPath = resolve(metadata.canonical_source_repository_path ?? metadata.source_repository_path);
+  const filesystem = await inspectWorktreeForCleanup({
+    workspacePath,
+    metadata,
+    exec
+  });
+  if (!filesystem.clean) return preserve("worktree_dirty", { filesystem_evidence: filesystem });
+  if (filesystem.unpushed_commits.length > 0) return preserve("worktree_unpushed", { filesystem_evidence: filesystem });
+  if (filesystem.branch_merged === false) return preserve("worktree_unmerged", { filesystem_evidence: filesystem });
+
+  const workflow = await loadWorkflowForHooks({ config, metadata, workspacePath, fs });
+  try {
+    await runWorkflowHook({ workflow, hook: "before_remove", cwd: workspacePath, exec });
+  } catch (error) {
+    return preserve("before_remove_hook_failed", { error: normalizeError(error) });
+  }
+
+  const postHookFilesystem = await inspectWorktreeForCleanup({
+    workspacePath,
+    metadata,
+    exec
+  });
+  if (!postHookFilesystem.clean) {
+    return preserve("worktree_dirty", { filesystem_evidence: postHookFilesystem });
+  }
+
+  await runGit(["worktree", "remove", workspacePath], { cwd: sourceRepositoryPath, exec });
+  await fs.rm?.(metadataPath, { force: true });
+  return {
+    action: "removed",
+    status: "cleanup_completed",
+    reason: "guards_passed",
+    method: "git_worktree_remove",
+    force: false,
+    workspace_key: workspaceKeyValue,
+    workspace_path: workspacePath,
+    filesystem_evidence: postHookFilesystem
   };
 }
 
@@ -277,6 +514,384 @@ export function validateExistingWorkspaceMetadata(existing, identity) {
   }
 
   return true;
+}
+
+async function defaultExec(file, args = [], options = {}) {
+  const result = await execFileAsync(file, args, {
+    cwd: options.cwd,
+    env: options.env ?? process.env,
+    maxBuffer: options.maxBuffer ?? 10 * 1024 * 1024
+  });
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exit_code: 0
+  };
+}
+
+async function runGit(args, { cwd, exec = defaultExec, allowFailure = false } = {}) {
+  try {
+    const result = normalizeCommandResult(await exec("git", args, { cwd }));
+    return { ok: true, ...result };
+  } catch (error) {
+    const result = normalizeCommandError(error);
+    if (allowFailure) return { ok: false, ...result };
+    throw new FizzySymphonyError("GIT_COMMAND_FAILED", "Git command failed.", {
+      cwd,
+      args,
+      exit_code: result.exit_code,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      cause: error.message
+    });
+  }
+}
+
+async function runCommand(argv, { cwd, exec = defaultExec } = {}) {
+  const [file, ...args] = argv;
+  try {
+    return normalizeCommandResult(await exec(file, args, { cwd }));
+  } catch (error) {
+    const result = normalizeCommandError(error);
+    throw new FizzySymphonyError("WORKSPACE_HOOK_FAILED", "Workspace lifecycle hook failed.", {
+      cwd,
+      argv,
+      exit_code: result.exit_code,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      cause: error.message
+    });
+  }
+}
+
+function normalizeCommandResult(result = {}) {
+  if (typeof result === "string") return { stdout: result, stderr: "", exit_code: 0 };
+  return {
+    stdout: String(result.stdout ?? ""),
+    stderr: String(result.stderr ?? ""),
+    exit_code: Number(result.exit_code ?? result.status ?? result.code ?? 0)
+  };
+}
+
+function normalizeCommandError(error = {}) {
+  return {
+    stdout: String(error.stdout ?? ""),
+    stderr: String(error.stderr ?? ""),
+    exit_code: Number(error.exit_code ?? error.status ?? (Number.isInteger(error.code) ? error.code : 1)),
+    code: error.code,
+    message: error.message ?? String(error)
+  };
+}
+
+async function assertGitRepository(sourceRepositoryPath, exec) {
+  const result = await runGit(["rev-parse", "--is-inside-work-tree"], {
+    cwd: sourceRepositoryPath,
+    exec,
+    allowFailure: true
+  });
+  if (!result.ok || result.stdout.trim() !== "true") {
+    throw new FizzySymphonyError("WORKSPACE_SOURCE_REPO_INVALID", "Workspace source repository is not a git work tree.", {
+      source_repository_path: sourceRepositoryPath,
+      preserve_workspace: true
+    });
+  }
+}
+
+async function assertGitRef(sourceRepositoryPath, sourceRef, exec) {
+  const result = await runGit(["cat-file", "-e", `${sourceRef}^{commit}`], {
+    cwd: sourceRepositoryPath,
+    exec,
+    allowFailure: true
+  });
+  if (!result.ok) {
+    throw new FizzySymphonyError("WORKSPACE_SOURCE_REF_INVALID", "Workspace source ref does not resolve to a commit.", {
+      source_repository_path: sourceRepositoryPath,
+      source_ref: sourceRef,
+      preserve_workspace: true
+    });
+  }
+}
+
+async function gitCommit(sourceRepositoryPath, sourceRef, exec) {
+  const result = await runGit(["rev-parse", `${sourceRef}^{commit}`], { cwd: sourceRepositoryPath, exec });
+  return result.stdout.trim();
+}
+
+async function gitStatus({ cwd, exec, ignoredPaths = [GUARD_FILE_NAME] }) {
+  const result = await runGit(["status", "--porcelain=v1", "--untracked-files=all"], { cwd, exec });
+  const entries = parsePorcelainStatus(result.stdout).filter((entry) => !ignoredPaths.includes(entry.path));
+  return {
+    clean: entries.length === 0,
+    paths: entries.map((entry) => entry.path),
+    entries
+  };
+}
+
+function parsePorcelainStatus(stdout) {
+  return String(stdout ?? "")
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .map((line) => {
+      const status = line.slice(0, 2);
+      const rawPath = line.slice(3);
+      const path = rawPath.includes(" -> ") ? rawPath.split(" -> ").at(-1) : rawPath;
+      return { status, path };
+    });
+}
+
+async function addGitWorktree({ sourceRepositoryPath, workspacePath, branch, sourceRef, exec }) {
+  const branchExists = await runGit(["show-ref", "--verify", "--quiet", `refs/heads/${branch}`], {
+    cwd: sourceRepositoryPath,
+    exec,
+    allowFailure: true
+  });
+  const args = branchExists.ok
+    ? ["worktree", "add", workspacePath, branch]
+    : ["worktree", "add", "-b", branch, workspacePath, sourceRef];
+  try {
+    await runGit(args, { cwd: sourceRepositoryPath, exec });
+  } catch (error) {
+    throw new FizzySymphonyError("WORKSPACE_WORKTREE_CREATE_FAILED", "Unable to create git worktree.", {
+      preserve_workspace: true,
+      source_repository_path: sourceRepositoryPath,
+      workspace_path: workspacePath,
+      branch,
+      source_ref: sourceRef,
+      cause: error.message,
+      cause_details: error.details ?? {}
+    });
+  }
+}
+
+async function validateReusableWorktree({
+  sourceRepositoryPath,
+  workspacePath,
+  branch,
+  metadata,
+  metadataPath,
+  guardPath,
+  fs,
+  exec
+}) {
+  const guardResult = await validateGuardForMetadata({ metadata, metadataPath, guardPath, fs });
+  if (!guardResult.ok) {
+    throw new FizzySymphonyError(guardResult.code, "Existing workspace guard is missing or does not match metadata.", {
+      preserve_workspace: true,
+      workspace_path: workspacePath,
+      metadata_path: metadataPath,
+      guard_path: guardPath,
+      ...guardResult.details
+    });
+  }
+
+  const worktreeRegistered = await registeredWorktreePath(sourceRepositoryPath, workspacePath, exec);
+  if (!worktreeRegistered) {
+    throw new FizzySymphonyError("WORKSPACE_WORKTREE_UNREGISTERED", "Existing workspace path is not a registered git worktree for the source repository.", {
+      preserve_workspace: true,
+      source_repository_path: sourceRepositoryPath,
+      workspace_path: workspacePath
+    });
+  }
+
+  const actualBranch = (await runGit(["branch", "--show-current"], { cwd: workspacePath, exec })).stdout.trim();
+  if (actualBranch !== branch) {
+    throw new FizzySymphonyError("WORKSPACE_BRANCH_MISMATCH", "Existing workspace branch does not match deterministic workspace branch.", {
+      preserve_workspace: true,
+      workspace_path: workspacePath,
+      expected_branch: branch,
+      actual_branch: actualBranch
+    });
+  }
+
+  const status = await gitStatus({ cwd: workspacePath, exec });
+  if (!status.clean) {
+    throw new FizzySymphonyError("WORKSPACE_WORKTREE_DIRTY", "Existing workspace has local changes; preserving workspace.", {
+      preserve_workspace: true,
+      workspace_path: workspacePath,
+      dirty_paths: status.paths
+    });
+  }
+}
+
+async function registeredWorktreePath(sourceRepositoryPath, workspacePath, exec) {
+  const result = await runGit(["worktree", "list", "--porcelain"], { cwd: sourceRepositoryPath, exec });
+  const expected = resolve(workspacePath);
+  return result.stdout
+    .split(/\r?\n/u)
+    .some((line) => line.startsWith("worktree ") && resolve(line.slice("worktree ".length)) === expected);
+}
+
+async function excludeGuardFile(workspacePath, fs, exec) {
+  const result = await runGit(["rev-parse", "--git-path", "info/exclude"], { cwd: workspacePath, exec });
+  const excludePath = result.stdout.trim();
+  let content = "";
+  try {
+    content = await fs.readFile(excludePath, "utf8");
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+  const line = `/${GUARD_FILE_NAME}`;
+  if (content.split(/\r?\n/u).includes(line)) return;
+  const next = content.endsWith("\n") || content === "" ? `${content}${line}\n` : `${content}\n${line}\n`;
+  await fs.writeFile(excludePath, next, "utf8");
+}
+
+async function loadWorkflowForHooks({ config, identity, metadata, workspacePath, fs }) {
+  const workspaceName = identity?.workspace_name ?? metadata?.workspace_name;
+  const sourceRepo = identity?.canonical_source_repository_path ?? metadata?.canonical_source_repository_path;
+  const workspace = {
+    sourceRepo,
+    source_repo: sourceRepo,
+    path: workspacePath,
+    workspace_path: workspacePath,
+    config: workspaceConfig(config, workspaceName)
+  };
+  try {
+    return await loadWorkflow({ workspace, config, fs });
+  } catch (error) {
+    if (error.code === "WORKFLOW_MISSING") return null;
+    throw error;
+  }
+}
+
+async function runWorkflowHook({ workflow, hook, cwd, exec }) {
+  const hooks = workflow?.frontMatter?.hooks ?? workflow?.front_matter?.hooks ?? {};
+  const spec = hooks?.[hook];
+  if (!spec) return null;
+
+  const commands = normalizeHookCommands(spec);
+  const results = [];
+  for (const argv of commands) {
+    const result = await runCommand(argv, { cwd, exec });
+    results.push({ argv, ...result });
+  }
+  return { hook, commands: results };
+}
+
+function normalizeHookCommands(spec) {
+  if (typeof spec === "string") return [singleStringCommand(spec)];
+  if (Array.isArray(spec)) {
+    if (spec.every((entry) => typeof entry === "string")) return [spec];
+    return spec.flatMap(normalizeHookCommands);
+  }
+  if (spec && typeof spec === "object") {
+    if (Array.isArray(spec.commands)) return spec.commands.flatMap(normalizeHookCommands);
+    if (typeof spec.command === "string") {
+      const args = spec.args === undefined ? [] : spec.args;
+      if (!Array.isArray(args) || !args.every((entry) => typeof entry === "string")) {
+        throw new FizzySymphonyError("WORKSPACE_HOOK_INVALID", "Workspace hook args must be a list of strings.", { spec });
+      }
+      return [[spec.command, ...args]];
+    }
+  }
+  throw new FizzySymphonyError("WORKSPACE_HOOK_INVALID", "Workspace hook must be a command string, argv list, or command object.", { spec });
+}
+
+function singleStringCommand(value) {
+  const command = String(value).trim();
+  if (!command || /\s/u.test(command)) {
+    throw new FizzySymphonyError("WORKSPACE_HOOK_INVALID", "String workspace hooks must name one executable without shell syntax.", {
+      hook: value
+    });
+  }
+  return [command];
+}
+
+async function inspectWorktreeForCleanup({ workspacePath, metadata, exec }) {
+  const status = await gitStatus({ cwd: workspacePath, exec });
+  const branch = (await runGit(["branch", "--show-current"], { cwd: workspacePath, exec })).stdout.trim();
+  const sourceRef = metadata.source_ref ?? metadata.base_ref ?? "HEAD";
+  const commitsAhead = await revListCount({ cwd: workspacePath, range: `${sourceRef}..HEAD`, exec });
+  const upstream = await runGit(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], {
+    cwd: workspacePath,
+    exec,
+    allowFailure: true
+  });
+  const unpushedCommits = [];
+  if (commitsAhead > 0) {
+    if (!upstream.ok) {
+      unpushedCommits.push(`${commitsAhead} commit(s) without upstream`);
+    } else {
+      const aheadUpstream = await revListCount({ cwd: workspacePath, range: `${upstream.stdout.trim()}..HEAD`, exec });
+      if (aheadUpstream > 0) unpushedCommits.push(`${aheadUpstream} commit(s) ahead of ${upstream.stdout.trim()}`);
+    }
+  }
+  const merged = commitsAhead === 0
+    ? true
+    : (await runGit(["merge-base", "--is-ancestor", "HEAD", sourceRef], {
+        cwd: workspacePath,
+        exec,
+        allowFailure: true
+      })).ok;
+
+  return {
+    clean: status.clean,
+    dirty_paths: status.paths,
+    untracked_files: status.entries.filter((entry) => entry.status === "??").map((entry) => entry.path),
+    unpushed_commits: unpushedCommits,
+    branch,
+    branch_merged: merged
+  };
+}
+
+async function revListCount({ cwd, range, exec }) {
+  const result = await runGit(["rev-list", "--count", range], { cwd, exec, allowFailure: true });
+  if (!result.ok) return 0;
+  return Number.parseInt(result.stdout.trim(), 10) || 0;
+}
+
+async function validateGuardForMetadata({ metadata, metadataPath, guardPath, fs }) {
+  const guard = await readJsonIfExists(guardPath, fs);
+  if (!guard) {
+    return {
+      ok: false,
+      code: "WORKSPACE_GUARD_MISSING",
+      details: { metadata_path: metadataPath, guard_path: guardPath }
+    };
+  }
+  const mismatches = guardMismatches(guard, metadata, metadataPath);
+  if (guard.guard !== GUARD_MARKER) mismatches.push("guard");
+  if (mismatches.length > 0) {
+    return {
+      ok: false,
+      code: "WORKSPACE_METADATA_GUARD_MISMATCH",
+      details: { metadata_path: metadataPath, guard_path: guardPath, mismatches }
+    };
+  }
+  return { ok: true, guard };
+}
+
+function workspaceConfig(config, workspaceName) {
+  return config?.workspaces?.registry?.[workspaceName] ?? {};
+}
+
+async function exists(path, fs) {
+  try {
+    await fs.access(path);
+    return true;
+  } catch (error) {
+    if (error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function preserve(reason, details = {}) {
+  return { action: "preserve", reason, ...details };
+}
+
+function toIso(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return date.toISOString();
+}
+
+function normalizeError(error = {}) {
+  if (typeof error === "string") return { code: "ERROR", message: error };
+  return {
+    code: error.code ?? "ERROR",
+    message: error.message ?? String(error),
+    details: error.details ?? {}
+  };
 }
 
 function buildWorkspaceMetadata({ config, identity, metadata, key, path }) {

--- a/test/completion.test.js
+++ b/test/completion.test.js
@@ -172,7 +172,7 @@ test("cleanup eligibility preserves workspace when proof, result, marker, releas
   const complete = {
     config,
     workspace: { path: workspacePath },
-    proof: { file: "/tmp/state/proof/run_1.json", digest: "sha256:proof" },
+    proof: { file: "/tmp/state/proof/run_1.json", digest: "sha256:proof", payload: { no_code_change: true } },
     resultComment: { id: "comment_1" },
     completionMarker: { id: "marker_1" },
     claimRelease: { released: true }

--- a/test/reconciler.test.js
+++ b/test/reconciler.test.js
@@ -186,6 +186,57 @@ test("runReconciliationTick proves the fake vertical slice order from discovery 
   assert.equal(snapshot.poll.last_completed_at, "2026-04-29T12:02:00.000Z");
 });
 
+test("runReconciliationTick runs workspace preflight before acquiring a claim", async () => {
+  const calls = [];
+  const config = configFixture(1);
+  const status = statusStore(config);
+  const route = routeFixture();
+  const card = cardFixture("card_1", 1);
+  const preflightError = new Error("source repo is dirty");
+  preflightError.code = "WORKSPACE_SOURCE_DIRTY";
+
+  await assert.rejects(
+    () => runReconciliationTick({
+      config,
+      status,
+      now: fixedNow,
+      fizzy: {
+        async discoverCandidates() {
+          calls.push("discover");
+          return [card];
+        }
+      },
+      router: {
+        async validateCandidate() {
+          calls.push("route");
+          return { action: "spawn", card, route, prompt: "Do the safe fake turn." };
+        }
+      },
+      claims: {
+        async acquire() {
+          calls.push("claim");
+          throw new Error("claims must not run when workspace preflight fails");
+        }
+      },
+      workspaceManager: {
+        async resolveIdentity() {
+          calls.push("resolveIdentity");
+          return { workspace_identity_digest: "sha256:workspace", workspace_path: "/tmp/workspace" };
+        },
+        async preflight() {
+          calls.push("preflight");
+          throw preflightError;
+        }
+      },
+      workflowLoader: {},
+      runner: {}
+    }),
+    (error) => error.code === "WORKSPACE_SOURCE_DIRTY"
+  );
+
+  assert.deepEqual(calls, ["discover", "route", "resolveIdentity", "preflight"]);
+});
+
 test("runReconciliationTick writes local run attempt records through completion", async () => {
   const calls = [];
   const stateDir = await mkdtemp(join(tmpdir(), "fizzy-symphony-reconciler-runs-"));

--- a/test/recovery.test.js
+++ b/test/recovery.test.js
@@ -1,14 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { promisify } from "node:util";
 
 import { createRunRegistry } from "../src/run-registry.js";
 import { evaluateCleanupRecovery, performStartupRecovery } from "../src/recovery.js";
 import { prepareWorkspace, resolveWorkspaceIdentity } from "../src/workspace.js";
 
 const NOW = "2026-04-29T12:10:00.000Z";
+const execFileAsync = promisify(execFile);
 
 function configFixture(dir) {
   return {
@@ -84,7 +87,29 @@ function attemptFor(identity, overrides = {}) {
   };
 }
 
+async function git(cwd, args) {
+  return execFileAsync("git", args, { cwd });
+}
+
+async function initSourceRepo(dir) {
+  const source = join(dir, "source");
+  await mkdir(source, { recursive: true });
+  try {
+    await git(source, ["rev-parse", "--is-inside-work-tree"]);
+    return;
+  } catch {
+    // Create the source repository once per temp root.
+  }
+  await git(source, ["init", "-b", "main"]);
+  await git(source, ["config", "user.email", "agent@example.test"]);
+  await git(source, ["config", "user.name", "Agent"]);
+  await writeFile(join(source, "WORKFLOW.md"), "# Policy\n", "utf8");
+  await git(source, ["add", "."]);
+  await git(source, ["commit", "-m", "initial"]);
+}
+
 async function preparedIdentity(dir, overrides = {}) {
+  await initSourceRepo(dir);
   const config = configFixture(dir);
   const identity = resolveWorkspaceIdentity({
     config,

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -1,19 +1,25 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { promisify } from "node:util";
 
 import {
   branchName,
+  cleanupWorkspace,
   prepareWorkspace,
+  preflightWorkspaceSource,
   resolveWorkspaceIdentity,
   scanWorkspaceMetadata,
   validateExistingWorkspaceMetadata,
   workspaceKey,
   workspacePath
 } from "../src/workspace.js";
+
+const execFileAsync = promisify(execFile);
 
 function shortDigest(value) {
   return createHash("sha256").update(value).digest("hex").slice(0, 12);
@@ -63,6 +69,32 @@ function card(overrides = {}) {
     board_id: "board_1",
     ...overrides
   };
+}
+
+async function git(cwd, args) {
+  const result = await execFileAsync("git", args, { cwd });
+  return String(result.stdout ?? "").trim();
+}
+
+async function initSourceRepo(dir, { workflow = "# Policy\n", extraFiles = {} } = {}) {
+  const source = join(dir, "source repo");
+  await mkdir(source, { recursive: true });
+  await git(source, ["init", "-b", "main"]);
+  await git(source, ["config", "user.email", "agent@example.test"]);
+  await git(source, ["config", "user.name", "Agent"]);
+  await writeFile(join(source, "WORKFLOW.md"), workflow, "utf8");
+  for (const [path, content] of Object.entries(extraFiles)) {
+    const fullPath = join(source, path);
+    await mkdir(resolve(fullPath, ".."), { recursive: true });
+    await writeFile(fullPath, content, "utf8");
+  }
+  await git(source, ["add", "."]);
+  await git(source, ["commit", "-m", "initial"]);
+  return source;
+}
+
+async function assertMissing(path) {
+  await assert.rejects(() => access(path), (error) => error.code === "ENOENT");
 }
 
 test("resolveWorkspaceIdentity builds deterministic identity, key, path, and branch name", async () => {
@@ -138,6 +170,7 @@ test("workspacePath rejects key escapes and roots outside configured allowed_roo
 
 test("prepareWorkspace writes guard and metadata before runner dispatch would start", async () => {
   const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-prepare-"));
+  await initSourceRepo(dir);
   const config = baseConfig(dir);
   const identity = resolveWorkspaceIdentity({ config, route: route(), card: card() });
   const metadata = {
@@ -167,8 +200,261 @@ test("prepareWorkspace writes guard and metadata before runner dispatch would st
   assert.equal(guard.workspace_identity_digest, identity.workspace_identity_digest);
 });
 
+test("prepareWorkspace creates a deterministic git worktree branch and runs create/run hooks", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-worktree-create-"));
+  const hookScript = [
+    "import { appendFileSync } from 'node:fs';",
+    "appendFileSync('../hook.log', `${process.argv[2]}\\n`);"
+  ].join("\n");
+  await initSourceRepo(dir, {
+    workflow: [
+      "---",
+      "hooks:",
+      "  after_create:",
+      "    command: node",
+      "    args:",
+      "      - hooks.js",
+      "      - after_create",
+      "  before_run:",
+      "    command: node",
+      "    args:",
+      "      - hooks.js",
+      "      - before_run",
+      "---",
+      "# Policy",
+      ""
+    ].join("\n"),
+    extraFiles: { "hooks.js": hookScript }
+  });
+  const config = baseConfig(dir);
+  const identity = resolveWorkspaceIdentity({ config, route: route(), card: card() });
+
+  const prepared = await prepareWorkspace({
+    config,
+    identity,
+    metadata: { run_attempt_id: "attempt_1", created_at: "2026-04-29T12:00:00.000Z" }
+  });
+
+  assert.equal(await git(prepared.workspace_path, ["branch", "--show-current"]), branchName(identity));
+  assert.equal(await git(prepared.workspace_path, ["rev-parse", "--show-toplevel"]), prepared.workspace_path);
+  assert.deepEqual((await readFile(join(config.workspaces.registry.app.worktree_root, "hook.log"), "utf8")).trim().split("\n"), [
+    "after_create",
+    "before_run"
+  ]);
+
+  const writtenMetadata = JSON.parse(await readFile(prepared.metadata_path, "utf8"));
+  assert.equal(writtenMetadata.branch_name, branchName(identity));
+  assert.equal(writtenMetadata.workspace_path, prepared.workspace_path);
+});
+
+test("prepareWorkspace reuses a clean matching worktree without rerunning after_create", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-worktree-reuse-"));
+  await initSourceRepo(dir);
+  const config = baseConfig(dir);
+  const identity = resolveWorkspaceIdentity({ config, route: route(), card: card() });
+
+  const first = await prepareWorkspace({
+    config,
+    identity,
+    metadata: { run_attempt_id: "attempt_1", created_at: "2026-04-29T12:00:00.000Z" }
+  });
+  const second = await prepareWorkspace({
+    config,
+    identity,
+    metadata: { run_attempt_id: "attempt_2", created_at: "2026-04-29T12:05:00.000Z" }
+  });
+
+  assert.equal(second.workspace_path, first.workspace_path);
+  assert.equal(await git(second.workspace_path, ["branch", "--show-current"]), branchName(identity));
+  assert.equal(second.created, false);
+
+  const writtenMetadata = JSON.parse(await readFile(second.metadata_path, "utf8"));
+  assert.equal(writtenMetadata.run_attempt_id, "attempt_2");
+});
+
+test("prepareWorkspace preserves a dirty existing worktree instead of reusing it", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-worktree-dirty-"));
+  await initSourceRepo(dir);
+  const config = baseConfig(dir);
+  const identity = resolveWorkspaceIdentity({ config, route: route(), card: card() });
+  const prepared = await prepareWorkspace({
+    config,
+    identity,
+    metadata: { run_attempt_id: "attempt_1", created_at: "2026-04-29T12:00:00.000Z" }
+  });
+  await writeFile(join(prepared.workspace_path, "debug.log"), "keep me\n", "utf8");
+
+  await assert.rejects(
+    () => prepareWorkspace({
+      config,
+      identity,
+      metadata: { run_attempt_id: "attempt_2", created_at: "2026-04-29T12:05:00.000Z" }
+    }),
+    (error) => error.code === "WORKSPACE_WORKTREE_DIRTY" &&
+      error.details.preserve_workspace === true &&
+      error.details.workspace_path === prepared.workspace_path
+  );
+
+  assert.equal(await readFile(join(prepared.workspace_path, "debug.log"), "utf8"), "keep me\n");
+});
+
+test("preflightWorkspaceSource rejects dirty source repositories when policy requires a clean source", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-source-dirty-"));
+  const source = await initSourceRepo(dir);
+  const config = baseConfig(dir);
+  const identity = resolveWorkspaceIdentity({ config, route: route(), card: card() });
+  await writeFile(join(source, "scratch.txt"), "dirty\n", "utf8");
+
+  await assert.rejects(
+    () => preflightWorkspaceSource({ config, identity }),
+    (error) => error.code === "WORKSPACE_SOURCE_DIRTY" &&
+      error.details.preserve_workspace === true &&
+      error.details.source_repository_path === resolve(source)
+  );
+});
+
+test("preflightWorkspaceSource allows dirty source repositories when snapshot policy supplies a commit", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-source-snapshot-"));
+  const source = await initSourceRepo(dir);
+  const snapshot = await git(source, ["rev-parse", "HEAD"]);
+  const config = baseConfig(dir, {
+    safety: {
+      allowed_roots: [dir],
+      dirty_source_repo_policy: "snapshot"
+    }
+  });
+  const identity = resolveWorkspaceIdentity({
+    config,
+    route: route({ source_snapshot_id: snapshot }),
+    card: card()
+  });
+  await writeFile(join(source, "scratch.txt"), "dirty\n", "utf8");
+
+  const preflight = await preflightWorkspaceSource({ config, identity });
+
+  assert.equal(preflight.status, "ok");
+  assert.equal(preflight.clean, false);
+  assert.equal(identity.source_ref, snapshot);
+
+  const prepared = await prepareWorkspace({
+    config,
+    identity,
+    metadata: { run_attempt_id: "attempt_1", created_at: "2026-04-29T12:00:00.000Z" }
+  });
+  const writtenMetadata = JSON.parse(await readFile(prepared.metadata_path, "utf8"));
+
+  assert.equal(writtenMetadata.source_snapshot_id, snapshot);
+  assert.equal(writtenMetadata.source_ref_kind, "source_snapshot_id");
+});
+
+test("cleanupWorkspace removes clean proven worktrees with non-force git worktree removal", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-cleanup-remove-"));
+  const hookScript = [
+    "import { appendFileSync } from 'node:fs';",
+    "appendFileSync('../remove.log', 'before_remove\\n');"
+  ].join("\n");
+  await initSourceRepo(dir, {
+    workflow: [
+      "---",
+      "hooks:",
+      "  before_remove:",
+      "    command: node",
+      "    args:",
+      "      - hooks.js",
+      "---",
+      "# Policy",
+      ""
+    ].join("\n"),
+    extraFiles: { "hooks.js": hookScript }
+  });
+  const config = baseConfig(dir, {
+    safety: {
+      allowed_roots: [dir],
+      dirty_source_repo_policy: "fail",
+      cleanup: { policy: "remove_clean_only" }
+    }
+  });
+  const identity = resolveWorkspaceIdentity({ config, route: route(), card: card() });
+  const prepared = await prepareWorkspace({
+    config,
+    identity,
+    metadata: { run_attempt_id: "attempt_1", created_at: "2026-04-29T12:00:00.000Z" }
+  });
+  const proof = {
+    file: join(dir, ".fizzy-symphony", "run", "proof", "run_1.json"),
+    digest: "sha256:proof",
+    payload: { no_code_change: true }
+  };
+  await mkdir(resolve(proof.file, ".."), { recursive: true });
+  await writeFile(proof.file, "{}\n", "utf8");
+
+  const result = await cleanupWorkspace({
+    config,
+    workspace: prepared,
+    proof,
+    resultComment: { id: "comment_1" },
+    completionMarker: { id: "marker_1" },
+    claimRelease: { released: true }
+  });
+
+  assert.equal(result.action, "removed");
+  assert.equal(result.method, "git_worktree_remove");
+  assert.equal(result.force, false);
+  assert.equal(await readFile(join(config.workspaces.registry.app.worktree_root, "remove.log"), "utf8"), "before_remove\n");
+  await assertMissing(prepared.workspace_path);
+  await assertMissing(prepared.metadata_path);
+});
+
+test("cleanupWorkspace preserves dirty and unpushed worktrees", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-cleanup-preserve-"));
+  await initSourceRepo(dir);
+  const config = baseConfig(dir, {
+    safety: {
+      allowed_roots: [dir],
+      dirty_source_repo_policy: "fail",
+      cleanup: { policy: "remove_clean_only" }
+    }
+  });
+  const identity = resolveWorkspaceIdentity({ config, route: route(), card: card() });
+  const prepared = await prepareWorkspace({
+    config,
+    identity,
+    metadata: { run_attempt_id: "attempt_1", created_at: "2026-04-29T12:00:00.000Z" }
+  });
+  const proof = {
+    file: join(dir, ".fizzy-symphony", "run", "proof", "run_1.json"),
+    digest: "sha256:proof",
+    payload: { no_code_change: true }
+  };
+  await mkdir(resolve(proof.file, ".."), { recursive: true });
+  await writeFile(proof.file, "{}\n", "utf8");
+  const complete = {
+    config,
+    workspace: prepared,
+    proof,
+    resultComment: { id: "comment_1" },
+    completionMarker: { id: "marker_1" },
+    claimRelease: { released: true }
+  };
+
+  await writeFile(join(prepared.workspace_path, "debug.log"), "dirty\n", "utf8");
+  const dirty = await cleanupWorkspace(complete);
+  assert.equal(dirty.action, "preserve");
+  assert.equal(dirty.reason, "worktree_dirty");
+  await rm(join(prepared.workspace_path, "debug.log"));
+
+  await writeFile(join(prepared.workspace_path, "feature.txt"), "new work\n", "utf8");
+  await git(prepared.workspace_path, ["add", "feature.txt"]);
+  await git(prepared.workspace_path, ["commit", "-m", "feature"]);
+  const unpushed = await cleanupWorkspace(complete);
+  assert.equal(unpushed.action, "preserve");
+  assert.equal(unpushed.reason, "worktree_unpushed");
+  assert.equal(await git(prepared.workspace_path, ["branch", "--show-current"]), branchName(identity));
+});
+
 test("metadata mismatch preserves existing workspace metadata and fails dispatch", async () => {
   const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-metadata-mismatch-"));
+  await initSourceRepo(dir);
   const config = baseConfig(dir);
   const identity = resolveWorkspaceIdentity({ config, route: route(), card: card() });
   const prepared = await prepareWorkspace({
@@ -219,6 +505,7 @@ test("validateExistingWorkspaceMetadata rejects identity and canonical repositor
 
 test("scanWorkspaceMetadata preserves workspaces with missing guards and guard metadata mismatches", async () => {
   const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-scan-metadata-"));
+  await initSourceRepo(dir);
   const config = baseConfig(dir);
   const identity = resolveWorkspaceIdentity({ config, route: route(), card: card({ id: "card_missing", number: 1 }) });
   const missingGuard = await prepareWorkspace({

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -313,6 +313,36 @@ test("preflightWorkspaceSource rejects dirty source repositories when policy req
   );
 });
 
+test("preflightWorkspaceSource treats nonzero injected git results as failed commands", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-injected-git-failure-"));
+  const config = baseConfig(dir);
+  const identity = resolveWorkspaceIdentity({ config, route: route(), card: card() });
+  const calls = [];
+  const exec = async (file, args, options) => {
+    calls.push({ file, args, cwd: options.cwd });
+    if (args[0] === "rev-parse" && args[1] === "--is-inside-work-tree") {
+      return { stdout: "true\n", stderr: "", exit_code: 0 };
+    }
+    if (args[0] === "cat-file") {
+      return { stdout: "", stderr: "missing ref\n", exit_code: 1 };
+    }
+    if (args[0] === "status") {
+      return { stdout: "", stderr: "", exit_code: 0 };
+    }
+    throw new Error(`unexpected command: ${file} ${args.join(" ")}`);
+  };
+
+  await assert.rejects(
+    () => preflightWorkspaceSource({ config, identity, exec }),
+    (error) => error.code === "WORKSPACE_SOURCE_REF_INVALID" &&
+      error.details.source_ref === "main"
+  );
+  assert.deepEqual(calls.map((call) => call.args.slice(0, 2)), [
+    ["rev-parse", "--is-inside-work-tree"],
+    ["cat-file", "-e"]
+  ]);
+});
+
 test("preflightWorkspaceSource allows dirty source repositories when snapshot policy supplies a commit", async () => {
   const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-source-snapshot-"));
   const source = await initSourceRepo(dir);
@@ -345,6 +375,41 @@ test("preflightWorkspaceSource allows dirty source repositories when snapshot po
 
   assert.equal(writtenMetadata.source_snapshot_id, snapshot);
   assert.equal(writtenMetadata.source_ref_kind, "source_snapshot_id");
+});
+
+test("prepareWorkspace treats nonzero injected hook results as hook failures", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-injected-hook-failure-"));
+  await initSourceRepo(dir, {
+    workflow: [
+      "---",
+      "hooks:",
+      "  before_run:",
+      "    command: failing-hook",
+      "---",
+      "# Policy",
+      ""
+    ].join("\n")
+  });
+  const config = baseConfig(dir);
+  const identity = resolveWorkspaceIdentity({ config, route: route(), card: card() });
+  const exec = async (file, args, options) => {
+    if (file === "failing-hook") {
+      return { stdout: "", stderr: "hook failed\n", exit_code: 7 };
+    }
+    return execFileAsync(file, args, options);
+  };
+
+  await assert.rejects(
+    () => prepareWorkspace({
+      config,
+      identity,
+      metadata: { run_attempt_id: "attempt_1", created_at: "2026-04-29T12:00:00.000Z" },
+      exec
+    }),
+    (error) => error.code === "WORKSPACE_HOOK_FAILED" &&
+      error.details.exit_code === 7 &&
+      error.details.stderr === "hook failed\n"
+  );
 });
 
 test("cleanupWorkspace removes clean proven worktrees with non-force git worktree removal", async () => {


### PR DESCRIPTION
## Summary
- create and reuse deterministic per-card git worktrees and branches
- add source repo preflight, snapshot-policy handling, metadata/guard validation, and WORKFLOW hook execution
- add guarded non-force cleanup with proof/handoff/dirty/unpushed checks

## Checks
- npm test