### PR TITLE
Add local HTTP status and webhook server

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -1,10 +1,13 @@
 import http from "node:http";
+import { createHmac, timingSafeEqual } from "node:crypto";
 
 import { FizzySymphonyError } from "./errors.js";
 
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_BASE_PORT = 4567;
 const MAX_SCAN_ATTEMPTS = 100;
+const DEFAULT_WEBHOOK_PATH = "/webhook";
+const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
 
 export async function bindServerListener(serverConfig = {}, options = {}) {
   const host = serverConfig.host ?? DEFAULT_HOST;
@@ -93,6 +96,263 @@ function closeServer(server) {
   });
 }
 
+export async function startLocalHttpServer(deps = {}, options = {}) {
+  const config = deps.config ?? {};
+  const requestListener = createLocalHttpHandler(deps);
+  return bindServerListener(config.server ?? {}, { ...options, requestListener });
+}
+
+export function createLocalHttpHandler(deps = {}) {
+  const {
+    config = {},
+    status,
+    enqueueWebhookHint = () => null,
+    now = () => new Date(),
+    logger,
+    maxBodyBytes = DEFAULT_MAX_BODY_BYTES,
+    seenWebhookEventIds = new Set()
+  } = deps;
+  const webhookPath = normalizePath(config.webhook?.path ?? DEFAULT_WEBHOOK_PATH);
+
+  return async function localHttpHandler(request, response) {
+    try {
+      const pathname = requestPathname(request);
+
+      if (pathname === "/health") {
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        return writeJson(response, 200, callStatus(status, "health", { live: true, status: "live" }));
+      }
+
+      if (pathname === "/ready") {
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        const readiness = callStatus(status, "ready", { ready: false, status: "not_ready", blockers: [] });
+        return writeJson(response, readiness.ready ? 200 : 503, readiness);
+      }
+
+      if (pathname === "/status") {
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        return writeJson(response, 200, callStatus(status, "status", {}));
+      }
+
+      if (pathname === webhookPath) {
+        if (config.webhook?.enabled === false) {
+          return writeError(response, 404, "WEBHOOK_DISABLED", "Webhook intake is disabled.");
+        }
+        if (request.method !== "POST") return methodNotAllowed(response, ["POST"]);
+        return await handleWebhook(request, response, {
+          config,
+          enqueueWebhookHint,
+          now,
+          maxBodyBytes,
+          seenWebhookEventIds
+        });
+      }
+
+      return writeError(response, 404, "NOT_FOUND", "Route not found.");
+    } catch (error) {
+      logger?.error?.({ error }, "local HTTP handler failed");
+      return writeError(response, 500, "HTTP_HANDLER_ERROR", "Local HTTP handler failed.");
+    }
+  };
+}
+
+export function createWebhookHintQueue(options = {}) {
+  const limit = options.limit ?? 1000;
+  const queue = [];
+
+  return {
+    enqueue: (hint = {}) => {
+      const normalized = clone(hint);
+      queue.push(normalized);
+      while (queue.length > limit) queue.shift();
+      return clone(normalized);
+    },
+    drain: () => queue.splice(0).map(clone),
+    snapshot: () => queue.map(clone),
+    get size() {
+      return queue.length;
+    }
+  };
+}
+
+async function handleWebhook(request, response, options = {}) {
+  const {
+    config = {},
+    enqueueWebhookHint,
+    now,
+    maxBodyBytes,
+    seenWebhookEventIds
+  } = options;
+  let rawBody;
+
+  try {
+    rawBody = await readRawBody(request, { maxBodyBytes });
+  } catch (error) {
+    if (error.code === "WEBHOOK_BODY_TOO_LARGE") {
+      return writeError(response, 413, error.code, "Webhook request body is too large.");
+    }
+    throw error;
+  }
+
+  const secret = config.webhook?.secret ? String(config.webhook.secret) : "";
+  if (secret) {
+    const supplied = request.headers["x-webhook-signature"];
+    if (!supplied) {
+      return writeError(response, 401, "WEBHOOK_SIGNATURE_REQUIRED", "Webhook signature is required.");
+    }
+    if (!verifyWebhookSignature(rawBody, supplied, secret)) {
+      return writeError(response, 401, "WEBHOOK_SIGNATURE_INVALID", "Webhook signature is invalid.");
+    }
+  }
+
+  let event;
+  try {
+    event = JSON.parse(rawBody.toString("utf8"));
+  } catch {
+    return writeError(response, 400, "INVALID_WEBHOOK_PAYLOAD", "Webhook payload must be valid JSON.");
+  }
+
+  const hint = candidateHintFromWebhookEvent(event, { now });
+  if (!hint.card_id) {
+    return writeError(response, 400, "INVALID_WEBHOOK_PAYLOAD", "Webhook payload must identify a candidate card.");
+  }
+
+  if (hint.event_id && seenWebhookEventIds.has(hint.event_id)) {
+    return writeJson(response, 200, {
+      ok: true,
+      status: "duplicate",
+      hint: publicHint(hint),
+      signature_verification: secret ? "enabled" : "disabled",
+      webhook_management: config.webhook?.manage ? "managed" : "unmanaged"
+    });
+  }
+
+  if (hint.event_id) seenWebhookEventIds.add(hint.event_id);
+  await enqueueWebhookHint(hint);
+
+  return writeJson(response, 202, {
+    ok: true,
+    status: "accepted",
+    hint: publicHint(hint),
+    signature_verification: secret ? "enabled" : "disabled",
+    webhook_management: config.webhook?.manage ? "managed" : "unmanaged"
+  });
+}
+
+function readRawBody(request, { maxBodyBytes = DEFAULT_MAX_BODY_BYTES } = {}) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let bytes = 0;
+    let tooLarge = false;
+
+    request.on("data", (chunk) => {
+      bytes += chunk.length;
+      if (bytes > maxBodyBytes) {
+        tooLarge = true;
+        return;
+      }
+      chunks.push(chunk);
+    });
+    request.on("end", () => {
+      if (tooLarge) {
+        const error = new Error("Webhook request body is too large.");
+        error.code = "WEBHOOK_BODY_TOO_LARGE";
+        reject(error);
+        return;
+      }
+      resolve(Buffer.concat(chunks));
+    });
+    request.on("error", reject);
+  });
+}
+
+function verifyWebhookSignature(rawBody, signatureHeader, secret) {
+  const supplied = normalizeSignature(signatureHeader);
+  if (!/^[a-f0-9]{64}$/iu.test(supplied)) return false;
+
+  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+  const suppliedBytes = Buffer.from(supplied, "hex");
+  const expectedBytes = Buffer.from(expected, "hex");
+  return suppliedBytes.length === expectedBytes.length && timingSafeEqual(suppliedBytes, expectedBytes);
+}
+
+function normalizeSignature(signatureHeader) {
+  const raw = Array.isArray(signatureHeader) ? signatureHeader[0] : signatureHeader;
+  const value = String(raw ?? "").trim();
+  return value.startsWith("sha256=") ? value.slice("sha256=".length) : value;
+}
+
+function candidateHintFromWebhookEvent(event, { now = () => new Date() } = {}) {
+  if (!event || typeof event !== "object" || Array.isArray(event)) return {};
+
+  const card = event.card ?? event.data?.card ?? event.payload?.card ?? {};
+  const board = event.board ?? event.data?.board ?? event.payload?.board ?? {};
+  const cardId = event.card_id ?? event.cardId ?? card.id ?? card.card_id;
+  const boardId = event.board_id ?? event.boardId ?? board.id ?? board.board_id ?? card.board_id ?? card.boardId;
+
+  return omitUndefined({
+    source: "webhook",
+    event_id: event.event_id ?? event.eventId ?? event.id,
+    card_id: cardId,
+    board_id: boardId,
+    received_at: toIso(typeof now === "function" ? now() : now)
+  });
+}
+
+function publicHint(hint = {}) {
+  return omitUndefined({
+    event_id: hint.event_id,
+    card_id: hint.card_id,
+    board_id: hint.board_id
+  });
+}
+
+function callStatus(status, method, fallback) {
+  return typeof status?.[method] === "function" ? status[method]() : fallback;
+}
+
+function requestPathname(request) {
+  return new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+}
+
+function normalizePath(path) {
+  const value = String(path || DEFAULT_WEBHOOK_PATH);
+  return value.startsWith("/") ? value : `/${value}`;
+}
+
+function methodNotAllowed(response, allowed) {
+  return writeError(response, 405, "METHOD_NOT_ALLOWED", "Method not allowed.", {}, {
+    allow: allowed.join(", ")
+  });
+}
+
+function writeError(response, statusCode, code, message, details = {}, headers = {}) {
+  return writeJson(response, statusCode, { ok: false, error: { code, message, details } }, headers);
+}
+
+function writeJson(response, statusCode, body, headers = {}) {
+  if (response.headersSent) return;
+  response.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8",
+    ...headers
+  });
+  response.end(`${JSON.stringify(body)}\n`);
+}
+
+function toIso(value) {
+  if (value instanceof Date) return value.toISOString();
+  return new Date(value).toISOString();
+}
+
+function omitUndefined(object) {
+  return Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined));
+}
+
+function clone(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
 function isAddressUnavailable(error) {
   return error?.code === "EADDRINUSE" || error?.code === "EACCES";
 }
@@ -110,4 +370,3 @@ function defaultRequestListener(_request, response) {
   response.statusCode = 404;
   response.end("not found\n");
 }
-

--- a/src/status.js
+++ b/src/status.js
@@ -3,6 +3,7 @@ import { basename, dirname, join } from "node:path";
 
 const HISTORY_LIMIT = 50;
 const RUN_ATTEMPT_SCHEMA_VERSION = "fizzy-symphony-run-attempt-v1";
+const DEFAULT_WEBHOOK_PATH = "/webhook";
 
 export function createStatusStore(options = {}) {
   const {
@@ -129,11 +130,7 @@ export function createStatusStore(options = {}) {
       endpoint: clone(state.instance.endpoint),
       watched_boards: watchedBoards(state.config),
       poll_interval_ms: state.config.polling?.interval_ms ?? null,
-      webhook: {
-        enabled: Boolean(state.config.webhook?.enabled),
-        managed: Boolean(state.config.webhook?.manage),
-        recent_delivery_errors: clone(state.managed_webhooks.recent_delivery_errors)
-      },
+      webhook: webhookStatus(state.config, state.managed_webhooks),
       managed_webhooks: clone(state.managed_webhooks),
       etag_cache: clone(state.etag_cache),
       runner: {
@@ -589,6 +586,32 @@ function endpointFromConfig(config) {
     host: config.server.host ?? "127.0.0.1",
     port: config.server.port ?? null,
     base_url: config.server.port ? `http://${config.server.host ?? "127.0.0.1"}:${config.server.port}` : null
+  };
+}
+
+function webhookStatus(config = {}, managedWebhooks = {}) {
+  const webhook = config.webhook ?? {};
+  const intakeEnabled = webhook.enabled !== false;
+  const managementEnabled = Boolean(webhook.manage);
+  const signatureConfigured = Boolean(webhook.secret);
+
+  return {
+    enabled: intakeEnabled,
+    intake_enabled: intakeEnabled,
+    path: webhook.path ?? DEFAULT_WEBHOOK_PATH,
+    managed: managementEnabled,
+    management: {
+      enabled: managementEnabled,
+      status: managementEnabled ? "managed" : "unmanaged"
+    },
+    signature_verification: signatureConfigured
+      ? { enabled: true, status: "enabled" }
+      : {
+          enabled: false,
+          status: "disabled",
+          reason: "webhook.secret is not configured"
+        },
+    recent_delivery_errors: clone(managedWebhooks.recent_delivery_errors ?? [])
   };
 }
 

--- a/test/listener.test.js
+++ b/test/listener.test.js
@@ -1,11 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
 import { mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import net from "node:net";
 
-import { bindServerListener } from "../src/listener.js";
+import { bindServerListener, createWebhookHintQueue, startLocalHttpServer } from "../src/listener.js";
 import { startLocalInstance } from "../src/instance-registry.js";
 import { coordinationConfig, tempProject } from "./helpers.js";
 
@@ -104,6 +105,249 @@ test("bindServerListener supports direct fixed bind-and-hold without registry si
   }
 });
 
+test("local HTTP server serves health, readiness, and live status JSON", async () => {
+  const liveSnapshot = {
+    schema_version: "fizzy-symphony-status-v1",
+    instance: { id: "instance-http" },
+    webhook: { enabled: true, management: { status: "unmanaged" } }
+  };
+  const server = await startLocalHttpServer({
+    config: httpConfig(),
+    status: {
+      health: () => ({ live: true, status: "live", ready: false }),
+      ready: () => ({
+        ready: false,
+        status: "not_ready",
+        blockers: [{ code: "RUNNER_NOT_READY", message: "Runner is unavailable." }]
+      }),
+      status: () => liveSnapshot
+    }
+  });
+
+  try {
+    const health = await fetchJson(`${server.endpoint.base_url}/health`);
+    assert.equal(health.response.status, 200);
+    assert.deepEqual(health.body, { live: true, status: "live", ready: false });
+
+    const ready = await fetchJson(`${server.endpoint.base_url}/ready`);
+    assert.equal(ready.response.status, 503);
+    assert.equal(ready.body.ready, false);
+    assert.equal(ready.body.blockers[0].code, "RUNNER_NOT_READY");
+
+    liveSnapshot.poll = { tick_in_progress: true };
+    const status = await fetchJson(`${server.endpoint.base_url}/status`);
+    assert.equal(status.response.status, 200);
+    assert.deepEqual(status.body, liveSnapshot);
+  } finally {
+    await server.close();
+  }
+});
+
+test("local HTTP server returns JSON errors for unknown routes and unsupported methods", async () => {
+  const server = await startLocalHttpServer({
+    config: httpConfig(),
+    status: readyStatus()
+  });
+
+  try {
+    const unknown = await fetchJson(`${server.endpoint.base_url}/nope`);
+    assert.equal(unknown.response.status, 404);
+    assert.equal(unknown.body.error.code, "NOT_FOUND");
+
+    const wrongMethod = await fetchJson(`${server.endpoint.base_url}/health`, { method: "POST" });
+    assert.equal(wrongMethod.response.status, 405);
+    assert.equal(wrongMethod.response.headers.get("allow"), "GET");
+    assert.equal(wrongMethod.body.error.code, "METHOD_NOT_ALLOWED");
+
+    const webhookWrongMethod = await fetchJson(`${server.endpoint.base_url}/webhook`, { method: "GET" });
+    assert.equal(webhookWrongMethod.response.status, 405);
+    assert.equal(webhookWrongMethod.response.headers.get("allow"), "POST");
+    assert.equal(webhookWrongMethod.body.error.code, "METHOD_NOT_ALLOWED");
+  } finally {
+    await server.close();
+  }
+});
+
+test("webhook accepts a valid signature and enqueues a candidate hint only", async () => {
+  const hints = [];
+  const config = httpConfig({
+    webhook: { enabled: true, path: "/webhook", secret: "webhook-secret", manage: false }
+  });
+  const server = await startLocalHttpServer({
+    config,
+    status: readyStatus(),
+    now: () => new Date("2026-04-29T12:00:00.000Z"),
+    enqueueWebhookHint: (hint) => {
+      hints.push(hint);
+      return hint;
+    }
+  });
+
+  try {
+    const body = JSON.stringify({
+      id: "event_1",
+      action: "card.updated",
+      card: { id: "card_1", board_id: "board_1", title: "Implement server" }
+    });
+    const accepted = await fetchJson(`${server.endpoint.base_url}/webhook`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-webhook-signature": signature(body, config.webhook.secret)
+      },
+      body
+    });
+
+    assert.equal(accepted.response.status, 202);
+    assert.equal(accepted.body.status, "accepted");
+    assert.equal(accepted.body.signature_verification, "enabled");
+    assert.deepEqual(accepted.body.hint, { event_id: "event_1", card_id: "card_1", board_id: "board_1" });
+    assert.deepEqual(hints, [{
+      source: "webhook",
+      event_id: "event_1",
+      card_id: "card_1",
+      board_id: "board_1",
+      received_at: "2026-04-29T12:00:00.000Z"
+    }]);
+    assert.equal(Object.hasOwn(hints[0], "event"), false);
+    assert.equal(Object.hasOwn(hints[0], "action"), false);
+  } finally {
+    await server.close();
+  }
+});
+
+test("webhook rejects missing or invalid signatures when a secret is configured", async () => {
+  const hints = [];
+  const config = httpConfig({
+    webhook: { enabled: true, path: "/webhook", secret: "webhook-secret", manage: false }
+  });
+  const server = await startLocalHttpServer({
+    config,
+    status: readyStatus(),
+    enqueueWebhookHint: (hint) => hints.push(hint)
+  });
+
+  try {
+    const body = JSON.stringify({ id: "event_1", card_id: "card_1", board_id: "board_1" });
+
+    const missing = await fetchJson(`${server.endpoint.base_url}/webhook`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body
+    });
+    assert.equal(missing.response.status, 401);
+    assert.equal(missing.body.error.code, "WEBHOOK_SIGNATURE_REQUIRED");
+
+    const invalid = await fetchJson(`${server.endpoint.base_url}/webhook`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-webhook-signature": "not-a-valid-signature"
+      },
+      body
+    });
+    assert.equal(invalid.response.status, 401);
+    assert.equal(invalid.body.error.code, "WEBHOOK_SIGNATURE_INVALID");
+    assert.deepEqual(hints, []);
+  } finally {
+    await server.close();
+  }
+});
+
+test("webhook accepts valid JSON without a signature when no secret is configured", async () => {
+  const queue = createWebhookHintQueue();
+  const config = httpConfig({
+    webhook: { enabled: true, path: "/custom-webhook", secret: "", manage: false }
+  });
+  const server = await startLocalHttpServer({
+    config,
+    status: readyStatus(),
+    now: () => new Date("2026-04-29T12:05:00.000Z"),
+    enqueueWebhookHint: queue.enqueue
+  });
+
+  try {
+    const accepted = await fetchJson(`${server.endpoint.base_url}/custom-webhook`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ event_id: "event_2", card_id: "card_2", board_id: "board_1" })
+    });
+
+    assert.equal(accepted.response.status, 202);
+    assert.equal(accepted.body.signature_verification, "disabled");
+    assert.deepEqual(queue.drain(), [{
+      source: "webhook",
+      event_id: "event_2",
+      card_id: "card_2",
+      board_id: "board_1",
+      received_at: "2026-04-29T12:05:00.000Z"
+    }]);
+    assert.equal(queue.size, 0);
+  } finally {
+    await server.close();
+  }
+});
+
+test("webhook rejects malformed JSON without enqueueing a hint", async () => {
+  const hints = [];
+  const server = await startLocalHttpServer({
+    config: httpConfig({ webhook: { enabled: true, path: "/webhook", secret: "", manage: false } }),
+    status: readyStatus(),
+    enqueueWebhookHint: (hint) => hints.push(hint)
+  });
+
+  try {
+    const malformed = await fetchJson(`${server.endpoint.base_url}/webhook`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json"
+    });
+
+    assert.equal(malformed.response.status, 400);
+    assert.equal(malformed.body.error.code, "INVALID_WEBHOOK_PAYLOAD");
+    assert.deepEqual(hints, []);
+  } finally {
+    await server.close();
+  }
+});
+
+test("webhook intake disabled returns a clear error while unmanaged intake can still accept hooks", async () => {
+  const disabled = await startLocalHttpServer({
+    config: httpConfig({ webhook: { enabled: false, path: "/webhook", manage: false } }),
+    status: readyStatus()
+  });
+
+  try {
+    const rejected = await fetchJson(`${disabled.endpoint.base_url}/webhook`, {
+      method: "POST",
+      body: JSON.stringify({ id: "event_disabled", card_id: "card_1" })
+    });
+    assert.equal(rejected.response.status, 404);
+    assert.equal(rejected.body.error.code, "WEBHOOK_DISABLED");
+  } finally {
+    await disabled.close();
+  }
+
+  const hints = [];
+  const unmanaged = await startLocalHttpServer({
+    config: httpConfig({ webhook: { enabled: true, path: "/webhook", secret: "", manage: false } }),
+    status: readyStatus(),
+    enqueueWebhookHint: (hint) => hints.push(hint)
+  });
+
+  try {
+    const accepted = await fetchJson(`${unmanaged.endpoint.base_url}/webhook`, {
+      method: "POST",
+      body: JSON.stringify({ id: "event_unmanaged", card_id: "card_1", board_id: "board_1" })
+    });
+    assert.equal(accepted.response.status, 202);
+    assert.equal(accepted.body.webhook_management, "unmanaged");
+    assert.equal(hints.length, 1);
+  } finally {
+    await unmanaged.close();
+  }
+});
+
 async function reservePortWithFreeNext() {
   for (let attempt = 0; attempt < 30; attempt += 1) {
     const server = await listenOn(0);
@@ -152,3 +396,44 @@ function closeServer(server) {
   });
 }
 
+function httpConfig(overrides = {}) {
+  return {
+    server: {
+      host: "127.0.0.1",
+      port: "auto",
+      port_allocation: "random",
+      ...(overrides.server ?? {})
+    },
+    webhook: {
+      enabled: true,
+      path: "/webhook",
+      secret: "",
+      manage: false,
+      ...(overrides.webhook ?? {})
+    }
+  };
+}
+
+function readyStatus() {
+  return {
+    health: () => ({ live: true, status: "live", ready: true }),
+    ready: () => ({ ready: true, status: "ready", blockers: [] }),
+    status: () => ({
+      schema_version: "fizzy-symphony-status-v1",
+      readiness: { ready: true, status: "ready", blockers: [] }
+    })
+  };
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  return {
+    response,
+    body: text ? JSON.parse(text) : null
+  };
+}
+
+function signature(body, secret) {
+  return createHmac("sha256", secret).update(body).digest("hex");
+}

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -273,6 +273,49 @@ test("status defaults token/rate metadata and webhook warnings to unavailable or
   assert.equal(snapshot.token_rate_limit.reason, "not_recorded");
 });
 
+test("status exposes webhook intake, management, and signature state without leaking secrets", () => {
+  const signed = createStatusStore({
+    instance: { id: "instance-signed" },
+    config: {
+      ...configFixture(),
+      webhook: {
+        enabled: true,
+        path: "/fizzy-hook",
+        secret: "super-secret-value",
+        manage: false
+      }
+    }
+  }).status();
+
+  assert.equal(signed.webhook.enabled, true);
+  assert.equal(signed.webhook.intake_enabled, true);
+  assert.equal(signed.webhook.path, "/fizzy-hook");
+  assert.equal(signed.webhook.management.enabled, false);
+  assert.equal(signed.webhook.management.status, "unmanaged");
+  assert.equal(signed.webhook.signature_verification.enabled, true);
+  assert.equal(signed.webhook.signature_verification.status, "enabled");
+  assert.equal(JSON.stringify(signed).includes("super-secret-value"), false);
+
+  const unsigned = createStatusStore({
+    instance: { id: "instance-unsigned" },
+    config: {
+      ...configFixture(),
+      webhook: {
+        enabled: true,
+        path: "/webhook",
+        secret: "",
+        manage: true
+      }
+    }
+  }).status();
+
+  assert.equal(unsigned.webhook.management.enabled, true);
+  assert.equal(unsigned.webhook.management.status, "managed");
+  assert.equal(unsigned.webhook.signature_verification.enabled, false);
+  assert.equal(unsigned.webhook.signature_verification.status, "disabled");
+  assert.equal(unsigned.webhook.signature_verification.reason, "webhook.secret is not configured");
+});
+
 test("run attempt records are written atomically under observability state_dir", async () => {
   const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-run-registry-"));
   const store = createStatusStore({


### PR DESCRIPTION
## Summary
- Add an injectable local HTTP handler/server for `/health`, `/ready`, `/status`, and configured webhook intake.
- Verify webhook HMAC-SHA256 signatures when `webhook.secret` is configured, accept unsigned valid JSON when absent, and enqueue normalized candidate hints only.
- Expand status snapshots with webhook intake, management, and signature-verification metadata without leaking secrets.

## Tests
- `node --test test/listener.test.js test/status.test.js`
- `npm test`

## Notes
- Webhook management being disabled is reported as unmanaged but does not disable local intake when `webhook.enabled` is true.
- Webhook hints contain candidate identifiers only; polling/reconciliation remains authoritative for routing, claims, and dispatch.