### PR TITLE
Implement real Codex CLI app-server runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@ Fizzy-backed Symphony daemon scaffold.
 ## Current Status
 
 The first MVP selects Node.js ESM with no external runtime dependencies. As of 2026-04-29, the
-current local baseline is 75/75 passing via `npm test`.
+current local baseline is 157/157 passing via `npm test`.
 
 The current implementation covers config generation/parsing, setup validation hooks, golden-ticket
 startup validation, route decisions, claim markers, workspace metadata, workflow loading/rendering,
-status snapshots, and an injected fake-Fizzy/fake-runner reconciliation slice.
+status snapshots, an injected fake-Fizzy/fake-runner reconciliation slice, and a real Codex CLI
+app-server runner behind the SDK-shaped runner interface.
 
-Live Fizzy and Codex integrations are still injected test seams. Real Fizzy HTTP, real Codex
-app-server execution, full completion handling, and hardening/smoke tests are later MVP layers.
+Live Fizzy HTTP, full completion handling, and hardening/smoke tests are later MVP layers. The
+Codex CLI app-server runner keeps process/protocol seams injectable for tests.
 
 ## Commands
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -209,6 +209,38 @@ runner:
     args:
       - app-server
 
+  # Required: no. Default: 10000 ms.
+  # Maximum time to wait for the initialize handshake.
+  initialize_timeout_ms: 10000
+
+  # Required: no. Default: 60000 ms.
+  # Maximum time to wait for ordinary app-server requests.
+  request_timeout_ms: 60000
+
+  # Required: no. Default: 10000 ms.
+  # Maximum time to wait for turn/interrupt before cancellation escalates.
+  cancel_timeout_ms: 10000
+
+  # Required: no. Default: 10000 ms.
+  # Maximum time to wait for thread unsubscribe/archive during session stop.
+  stop_session_timeout_ms: 10000
+
+  # Required: no. Default: 5000 ms.
+  # Grace period after SIGTERM before app-server process termination escalates.
+  terminate_timeout_ms: 5000
+
+  # Required: no. Default: 2000 ms.
+  # Grace period after SIGKILL before manual intervention is surfaced.
+  kill_timeout_ms: 2000
+
+  # Required: no. Default: inherited from agent.turn_timeout_ms.
+  # Set only to override the per-turn stream wait used by the app-server runner.
+  stream_timeout_ms: 3600000
+
+  # Required: no. Default: 65536 bytes.
+  # Bounded stderr retained for app-server failure diagnostics.
+  max_stderr_bytes: 65536
+
   health:
     # Required: no. Default: true.
     enabled: true

--- a/config.example.yml
+++ b/config.example.yml
@@ -222,7 +222,7 @@ runner:
   cancel_timeout_ms: 10000
 
   # Required: no. Default: 10000 ms.
-  # Maximum time to wait for thread unsubscribe/archive during session stop.
+  # Maximum time to wait for thread unsubscribe during session stop.
   stop_session_timeout_ms: 10000
 
   # Required: no. Default: 5000 ms.

--- a/docs/popper-handoff-runbook.md
+++ b/docs/popper-handoff-runbook.md
@@ -16,7 +16,7 @@ operate the local scaffold safely while `fizzy-symphony` is still under construc
 ## Current Implementation Status
 
 The current scaffold is a Node.js ESM project with no external runtime dependencies. The local
-baseline on 2026-04-29 is 75/75 passing via `npm test`.
+baseline on 2026-04-29 is 157/157 passing via `npm test`.
 
 Implemented scaffold behavior:
 
@@ -29,9 +29,10 @@ Implemented scaffold behavior:
 - workflow loading and prompt rendering
 - status snapshots
 - injected fake-Fizzy and fake-runner reconciliation slice
+- real Codex CLI app-server runner behind the SDK-shaped runner interface
 
-The live Fizzy client, live Codex app-server runner, full supervisor, completion policy application,
-durable proof writing, webhook/poll hardening, and real smoke tests are not implemented yet.
+The live Fizzy client, full supervisor/completion policy application, durable proof writing,
+webhook/poll hardening, and real smoke tests are not implemented yet.
 
 ## Workspace Boundaries
 
@@ -150,8 +151,8 @@ These items are intentionally deferred or unsafe for the current MVP:
 - `codex exec` is not the normal MVP runner contract
 - silent duplicate golden-ticket resolution must not be used
 - destructive cleanup of dirty or unproven worktrees must not be used
-- real Fizzy smoke tests and real Codex app-server smoke tests come after the fake-Fizzy/fake-runner
-  scaffold is complete
+- real Fizzy smoke tests and model-consuming real Codex smoke tests come after the process/protocol
+  seams are covered by unit tests
 
 ## Suggested Next Card Ordering
 
@@ -161,7 +162,7 @@ order:
 1. Finish config, setup, and startup validation gaps.
 2. Extend deterministic workspace and claim foundations.
 3. Build polling, routing precedence, and loop-prevention reconciliation.
-4. Add the SDK-shaped Codex app-server runner and supervisor.
+4. Add the full supervisor around the SDK-shaped Codex app-server runner.
 5. Implement completion policies, proof recording, workpad updates, cleanup guards, and status
    endpoints.
 6. Add real Fizzy and real Codex smoke tests only after fake integrations cover the MVP safety

--- a/docs/spec-coverage.md
+++ b/docs/spec-coverage.md
@@ -59,8 +59,8 @@ Status values are intentionally limited to `passing`, `newly covered`, or `defer
 
 ### Runner health checks
 - Status: passing
-- Tests: `test/runner-contract.test.js`, `test/validation.test.js`, `test/reconciler.test.js`, `test/orchestrator-state.test.js`
-- Coverage: detect/validate/health success, app-server startup failure, input-required failure in unattended mode, timeout/stall cancellation, cancellation, metadata extraction, same-thread continuation, and runner failure release/status behavior.
+- Tests: `test/runner-contract.test.js`, `test/codex-app-server-transport.test.js`, `test/codex-cli-app-server-runner.test.js`, `test/validation.test.js`, `test/reconciler.test.js`, `test/orchestrator-state.test.js`
+- Coverage: fake-runner seam preservation, Codex app-server argv/cwd launch without shell eval, JSONL request/response matching, initialize handshake, detect/validate/health success, malformed protocol/stderr/exit handling, input-required failure in unattended mode, timeout/stall cancellation, cancellation, metadata extraction, same-thread continuation, owned-process termination, and runner failure release/status behavior.
 
 ### Status snapshot
 - Status: newly covered

--- a/src/codex-app-server-transport.js
+++ b/src/codex-app-server-transport.js
@@ -1,0 +1,310 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+
+const DEFAULT_MAX_STDERR_BYTES = 64 * 1024;
+const DEFAULT_CLOSE_TIMEOUT_MS = 250;
+const DEFAULT_TERM_TIMEOUT_MS = 5000;
+const DEFAULT_KILL_TIMEOUT_MS = 2000;
+
+export function launchCodexAppServerTransport(options = {}) {
+  const {
+    command = "codex",
+    args = ["app-server"],
+    cwd = process.cwd(),
+    env = process.env,
+    spawn = nodeSpawn,
+    maxStderrBytes = DEFAULT_MAX_STDERR_BYTES
+  } = options;
+
+  const child = spawn(command, args, {
+    cwd,
+    env,
+    shell: false,
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+
+  return new CodexAppServerTransport(child, { maxStderrBytes });
+}
+
+export class CodexAppServerTransport {
+  constructor(child, options = {}) {
+    this.child = child;
+    this.maxStderrBytes = options.maxStderrBytes ?? DEFAULT_MAX_STDERR_BYTES;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.events = new EventEmitter();
+    this.buffer = "";
+    this.stderr = "";
+    this.exited = false;
+
+    child.stdout?.setEncoding?.("utf8");
+    child.stderr?.setEncoding?.("utf8");
+    child.stdout?.on?.("data", (chunk) => this.receiveStdout(chunk));
+    child.stderr?.on?.("data", (chunk) => this.receiveStderr(chunk));
+    child.once?.("exit", (code, signal) => this.handleExit(code, signal));
+    child.once?.("error", (error) => this.handleChildError(error));
+  }
+
+  request(method, params, options = {}) {
+    if (this.exited) {
+      return Promise.reject(appServerError("APP_SERVER_EXITED", "Codex app-server process has exited.", {
+        stderr: this.stderr
+      }));
+    }
+
+    const id = this.nextId++;
+    const message = params === undefined ? { id, method } : { id, method, params };
+
+    return new Promise((resolve, reject) => {
+      let timeout;
+      const timeoutMs = Number(options.timeoutMs);
+      if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+        timeout = setTimeout(() => {
+          this.pending.delete(id);
+          reject(appServerError("APP_SERVER_REQUEST_TIMEOUT", `Codex app-server request timed out: ${method}.`, {
+            method,
+            timeout_ms: timeoutMs
+          }));
+        }, timeoutMs);
+      }
+
+      this.pending.set(id, { method, resolve, reject, timeout });
+      try {
+        this.writeMessage(message);
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pending.delete(id);
+        reject(error);
+      }
+    });
+  }
+
+  onNotification(handler) {
+    this.events.on("notification", handler);
+    return () => this.events.off("notification", handler);
+  }
+
+  onServerRequest(handler) {
+    this.events.on("serverRequest", handler);
+    return () => this.events.off("serverRequest", handler);
+  }
+
+  onExit(handler) {
+    this.events.on("exit", handler);
+    return () => this.events.off("exit", handler);
+  }
+
+  onProtocolError(handler) {
+    this.events.on("protocolError", handler);
+    return () => this.events.off("protocolError", handler);
+  }
+
+  respond(id, result) {
+    this.writeMessage({ id, result });
+  }
+
+  respondError(id, error) {
+    this.writeMessage({
+      id,
+      error: {
+        code: error?.code ?? "APP_SERVER_CLIENT_ERROR",
+        message: error?.message ?? String(error ?? "Codex app-server client error."),
+        data: error?.details
+      }
+    });
+  }
+
+  async close(options = {}) {
+    if (this.exited) return { status: "closed" };
+    this.child.stdin?.end?.();
+    this.child.kill?.(options.signal ?? "SIGTERM");
+    await delay(options.timeoutMs ?? DEFAULT_CLOSE_TIMEOUT_MS);
+    return { status: this.exited ? "closed" : "closing" };
+  }
+
+  async terminate(options = {}) {
+    const termTimeoutMs = options.termTimeoutMs ?? DEFAULT_TERM_TIMEOUT_MS;
+    const killTimeoutMs = options.killTimeoutMs ?? DEFAULT_KILL_TIMEOUT_MS;
+
+    if (this.exited) return { status: "terminated", already_exited: true };
+
+    this.child.kill?.("SIGTERM");
+    if (await this.waitForExit(termTimeoutMs)) {
+      return { status: "terminated", signal: "SIGTERM" };
+    }
+
+    this.child.kill?.("SIGKILL");
+    if (await this.waitForExit(killTimeoutMs)) {
+      return { status: "terminated", signal: "SIGKILL" };
+    }
+
+    return { status: "failed", signal: "SIGKILL", error: { code: "APP_SERVER_KILL_TIMEOUT" } };
+  }
+
+  receiveStdout(chunk) {
+    this.buffer += String(chunk);
+    let newline = this.buffer.indexOf("\n");
+    while (newline !== -1) {
+      const line = this.buffer.slice(0, newline).trim();
+      this.buffer = this.buffer.slice(newline + 1);
+      if (line) this.handleLine(line);
+      newline = this.buffer.indexOf("\n");
+    }
+  }
+
+  receiveStderr(chunk) {
+    this.stderr = `${this.stderr}${String(chunk)}`;
+    if (this.stderr.length > this.maxStderrBytes) {
+      this.stderr = this.stderr.slice(this.stderr.length - this.maxStderrBytes);
+    }
+  }
+
+  handleLine(line) {
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch (error) {
+      const protocolError = appServerError(
+        "APP_SERVER_MALFORMED_MESSAGE",
+        `Malformed Codex app-server JSONL message: ${error.message}`,
+        { line }
+      );
+      this.rejectAll(protocolError);
+      this.events.emit("protocolError", protocolError);
+      return;
+    }
+
+    if (message && Object.hasOwn(message, "id") && (Object.hasOwn(message, "result") || Object.hasOwn(message, "error"))) {
+      this.handleResponse(message);
+      return;
+    }
+
+    if (message && Object.hasOwn(message, "id") && message.method) {
+      this.handleServerRequest(message);
+      return;
+    }
+
+    if (message?.method) {
+      this.events.emit("notification", message);
+      return;
+    }
+
+    const protocolError = appServerError("APP_SERVER_UNKNOWN_MESSAGE", "Unknown Codex app-server protocol message.", {
+      message
+    });
+    this.rejectAll(protocolError);
+    this.events.emit("protocolError", protocolError);
+  }
+
+  handleResponse(message) {
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+    clearTimeout(pending.timeout);
+
+    if (Object.hasOwn(message, "error")) {
+      pending.reject(appServerError(
+        message.error?.code ?? "APP_SERVER_PROTOCOL_ERROR",
+        message.error?.message ?? `Codex app-server request failed: ${pending.method}.`,
+        { method: pending.method, error: message.error }
+      ));
+      return;
+    }
+
+    pending.resolve(message.result);
+  }
+
+  handleServerRequest(message) {
+    const handlers = this.events.listeners("serverRequest");
+    if (handlers.length === 0) {
+      this.respondError(message.id, appServerError("APP_SERVER_UNHANDLED_REQUEST", "Unhandled Codex app-server server request.", {
+        method: message.method
+      }));
+      return;
+    }
+
+    for (const handler of handlers) {
+      try {
+        const result = handler(message);
+        if (result?.then) {
+          result
+            .then((resolved) => {
+              if (resolved !== undefined) this.respond(message.id, resolved);
+            })
+            .catch((error) => this.respondError(message.id, error));
+        } else if (result !== undefined) {
+          this.respond(message.id, result);
+        }
+      } catch (error) {
+        this.respondError(message.id, error);
+      }
+    }
+  }
+
+  handleExit(code, signal) {
+    this.exited = true;
+    const error = appServerError(
+      "APP_SERVER_EXITED",
+      `Codex app-server exited${code === null ? "" : ` with code ${code}`}${signal ? ` from ${signal}` : ""}.${this.stderr ? ` stderr: ${this.stderr}` : ""}`,
+      { code, signal, stderr: this.stderr }
+    );
+    this.rejectAll(error);
+    this.events.emit("exit", { code, signal, stderr: this.stderr });
+  }
+
+  handleChildError(error) {
+    const wrapped = appServerError(error.code ?? "APP_SERVER_PROCESS_ERROR", error.message, {
+      cause: error.message,
+      stderr: this.stderr
+    });
+    this.rejectAll(wrapped);
+    this.events.emit("protocolError", wrapped);
+  }
+
+  writeMessage(message) {
+    if (!this.child.stdin?.write) {
+      throw appServerError("APP_SERVER_STDIN_UNAVAILABLE", "Codex app-server stdin is unavailable.");
+    }
+    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  rejectAll(error) {
+    for (const [id, pending] of this.pending.entries()) {
+      this.pending.delete(id);
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+  }
+
+  waitForExit(timeoutMs) {
+    if (this.exited) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        cleanup();
+        resolve(false);
+      }, timeoutMs);
+      const onExit = () => {
+        cleanup();
+        resolve(true);
+      };
+      const cleanup = () => {
+        clearTimeout(timeout);
+        this.events.off("exit", onExit);
+      };
+      this.events.on("exit", onExit);
+    });
+  }
+}
+
+function appServerError(code, message, details = {}) {
+  const error = new Error(message);
+  error.code = code;
+  error.details = details;
+  return error;
+}
+
+function delay(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/src/codex-cli-app-server-runner.js
+++ b/src/codex-cli-app-server-runner.js
@@ -1,0 +1,890 @@
+import { execFile as nodeExecFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { launchCodexAppServerTransport } from "./codex-app-server-transport.js";
+import { redact } from "./logger.js";
+
+const execFile = promisify(nodeExecFile);
+
+const IMPLEMENTATION = "CodexCliAppServerRunner";
+const KIND = "cli_app_server";
+const PROTOCOL_VERSION = "0.125.0";
+const PROTOCOL_METHODS = ["initialize", "thread/start", "turn/start", "turn/interrupt", "thread/unsubscribe", "thread/archive"];
+const REQUEST_METHODS_REQUIRING_OPERATOR = new Set([
+  "item/commandExecution/requestApproval",
+  "item/fileChange/requestApproval",
+  "item/tool/requestUserInput",
+  "mcpServer/elicitation/request",
+  "item/permissions/requestApproval",
+  "item/tool/call",
+  "account/chatgptAuthTokens/refresh",
+  "applyPatchApproval",
+  "execCommandApproval"
+]);
+
+const DEFAULTS = {
+  initializeTimeoutMs: 10000,
+  requestTimeoutMs: 60000,
+  cancelTimeoutMs: 10000,
+  stopSessionTimeoutMs: 10000,
+  termTimeoutMs: 5000,
+  killTimeoutMs: 2000,
+  streamTimeoutMs: 0
+};
+
+export function createCodexCliAppServerRunner(options = {}) {
+  const sessions = new Map();
+  const transportFactory = options.transportFactory ?? ((transportOptions) => launchCodexAppServerTransport(transportOptions));
+  const versionProbe = options.versionProbe ?? ((command, probeOptions) => probeCodexVersion(command, {
+    execFile: options.execFile,
+    timeoutMs: probeOptions?.timeoutMs
+  }));
+  const now = options.now ?? (() => new Date().toISOString());
+
+  const runner = {
+    async detect(config = {}) {
+      const runnerConfig = resolveRunnerConfig(config);
+      const command = runnerConfig.cli_app_server.command;
+      const args = runnerConfig.cli_app_server.args;
+      const probe = await versionProbe(command, { timeoutMs: runnerConfig.detect_timeout_ms });
+      const report = omitUndefined({
+        kind: KIND,
+        implementation: IMPLEMENTATION,
+        available: probe.ok !== false,
+        command,
+        argv: [command, ...args],
+        command_path: probe.command_path,
+        version: probe.version,
+        protocol: protocolReport(),
+        reason: probe.ok === false ? probe.reason ?? probe.message : undefined,
+        remediation: probe.ok === false
+          ? `Install or expose the Codex CLI executable '${command}', then rerun setup or startup validation.`
+          : undefined
+      });
+      return report;
+    },
+
+    async validate(config = {}, workspace = null) {
+      const runnerConfig = resolveRunnerConfig(config);
+      const workspaceInfo = await workspaceForValidation(workspace);
+      let transport;
+
+      try {
+        transport = transportFactory(transportOptions(runnerConfig, workspaceInfo.path));
+        const handshake = await initializeTransport(transport, runnerConfig);
+        return {
+          ok: true,
+          kind: KIND,
+          implementation: IMPLEMENTATION,
+          workspace: workspaceInfo.path,
+          argv: [runnerConfig.cli_app_server.command, ...runnerConfig.cli_app_server.args],
+          policy_payload_valid: true,
+          smoke_turn_skipped: true,
+          handshake: {
+            ok: true,
+            user_agent: handshake.userAgent,
+            platform_os: handshake.platformOs,
+            platform_family: handshake.platformFamily
+          },
+          warnings: ["Model-consuming smoke turn skipped by default."]
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          kind: KIND,
+          implementation: IMPLEMENTATION,
+          workspace: workspaceInfo.path,
+          argv: [runnerConfig.cli_app_server.command, ...runnerConfig.cli_app_server.args],
+          handshake: {
+            ok: false,
+            error: normalizeRunnerError(error, "APP_SERVER_HANDSHAKE_FAILED")
+          },
+          remediation: "Confirm `codex app-server --listen stdio://` starts locally and Codex authentication/configuration is present."
+        };
+      } finally {
+        await transport?.close?.();
+        if (workspaceInfo.temporary) {
+          await rm(workspaceInfo.path, { recursive: true, force: true });
+        }
+      }
+    },
+
+    async health(config = {}) {
+      const checkedAt = now();
+      const validation = await runner.validate(config, null);
+      if (validation.ok) {
+        return {
+          status: "ready",
+          readiness_effect: "ready",
+          kind: KIND,
+          implementation: IMPLEMENTATION,
+          checked_at: checkedAt,
+          version: validation.handshake?.user_agent,
+          protocol: protocolReport(),
+          smoke_turn_skipped: true
+        };
+      }
+
+      return {
+        status: "unavailable",
+        readiness_effect: "blocks_dispatch",
+        kind: KIND,
+        implementation: IMPLEMENTATION,
+        checked_at: checkedAt,
+        failure_code: validation.handshake?.error?.code ?? "APP_SERVER_HEALTH_FAILED",
+        failure_message: validation.handshake?.error?.message ?? "Codex app-server health check failed.",
+        remediation: validation.remediation
+      };
+    },
+
+    async startSession(workspace, policies = {}, metadata = {}) {
+      const runnerConfig = resolveRunnerConfig(policies.config ?? policies.runner ?? {});
+      const path = workspacePath(workspace);
+      const transport = transportFactory(transportOptions(runnerConfig, path));
+      const context = createSessionContext({ transport, runnerConfig, now });
+      wireTransportContext(context);
+
+      try {
+        const handshake = await initializeTransport(transport, runnerConfig);
+        const threadStart = await transport.request(
+          "thread/start",
+          threadStartParams({ path, policies, metadata, runnerConfig }),
+          { timeoutMs: timeoutValue(runnerConfig, "requestTimeoutMs") }
+        );
+        const thread = threadStart.thread ?? {};
+        const sessionId = thread.id;
+        const session = omitUndefined({
+          type: "Session",
+          session_id: sessionId,
+          thread_id: sessionId,
+          kind: KIND,
+          implementation: IMPLEMENTATION,
+          process_id: transport.child?.pid,
+          process_owned: true,
+          workspace: path,
+          workspace_path: path,
+          started_at: now(),
+          policies: serializablePolicies(policies),
+          metadata,
+          app_server: {
+            user_agent: handshake.userAgent,
+            platform_os: handshake.platformOs,
+            protocol: protocolReport()
+          }
+        });
+        context.session = session;
+        sessions.set(sessionId, context);
+        return session;
+      } catch (error) {
+        await transport.close?.();
+        throw error;
+      }
+    },
+
+    async startTurn(session, prompt, metadata = {}) {
+      const context = sessions.get(session.session_id);
+      if (!context) throw runnerError("APP_SERVER_SESSION_NOT_FOUND", "Codex app-server session is not active.", { session_id: session.session_id });
+      const runnerConfig = context.runnerConfig;
+      const response = await context.transport.request(
+        "turn/start",
+        turnStartParams({ session, prompt, metadata, runnerConfig }),
+        { timeoutMs: timeoutValue(runnerConfig, "requestTimeoutMs") }
+      );
+      const turn = response.turn ?? {};
+
+      return omitUndefined({
+        type: "Turn",
+        run_id: metadata.run_id,
+        attempt_number: metadata.attempt_number,
+        session_id: session.session_id,
+        thread_id: session.thread_id,
+        turn_id: turn.id,
+        started_at: now(),
+        prompt_digest: sha256(prompt),
+        workspace: session.workspace_path ?? session.workspace,
+        workspace_path: session.workspace_path ?? session.workspace,
+        metadata,
+        runner: {
+          kind: KIND,
+          implementation: IMPLEMENTATION,
+          protocol: protocolReport()
+        }
+      });
+    },
+
+    async stream(turn, onEvent) {
+      const context = sessions.get(turn.session_id);
+      if (!context) {
+        return turnFailure(turn, "runner_error", normalizeRunnerError(
+          runnerError("APP_SERVER_SESSION_NOT_FOUND", "Codex app-server session is not active."),
+          "APP_SERVER_SESSION_NOT_FOUND"
+        ));
+      }
+
+      const emitted = [];
+      let timeout;
+      try {
+        const streamTimeoutMs = timeoutValue(context.runnerConfig, "streamTimeoutMs");
+        if (streamTimeoutMs > 0) {
+          timeout = setTimeout(() => {
+            context.streamFailure = {
+              failure_kind: "timed_out",
+              error: normalizeRunnerError(
+                runnerError("APP_SERVER_STREAM_TIMEOUT", "Codex app-server stream timed out.", { timeout_ms: streamTimeoutMs }),
+                "APP_SERVER_STREAM_TIMEOUT"
+              )
+            };
+            wake(context);
+          }, streamTimeoutMs);
+        }
+
+        while (true) {
+          if (context.inputRequired) {
+            const event = inputRequiredEvent(turn, context.inputRequired);
+            emitted.push(event);
+            onEvent?.(event);
+            await this.cancel(turn, "input_required");
+            return turnFailure(turn, "input_required", context.inputRequired.error, emitted);
+          }
+
+          if (context.streamFailure) {
+            return turnFailure(turn, context.streamFailure.failure_kind, context.streamFailure.error, emitted);
+          }
+
+          const next = shiftMatchingNotification(context, turn);
+          if (next) {
+            const event = normalizeNotification(next, turn, now);
+            emitted.push(event);
+            onEvent?.(event);
+            if (event.type === "assistant.delta" && event.text) {
+              context.output += event.text;
+            }
+            if (event.final) return turnResultFromFinal(turn, event, emitted, context.output);
+            continue;
+          }
+
+          await waitForContext(context);
+        }
+      } finally {
+        clearTimeout(timeout);
+      }
+    },
+
+    async cancel(turn, reason = "cancelled") {
+      const context = sessions.get(turn.session_id);
+      if (!context) {
+        return cancelFailure(turn, reason, "APP_SERVER_SESSION_NOT_FOUND", "Codex app-server session is not active.");
+      }
+
+      try {
+        await context.transport.request("turn/interrupt", {
+          threadId: turn.thread_id,
+          turnId: turn.turn_id
+        }, { timeoutMs: timeoutValue(context.runnerConfig, "cancelTimeoutMs") });
+        return {
+          type: "CancelResult",
+          status: "cancelled",
+          success: true,
+          interrupted: true,
+          session_stopped: false,
+          process_killed: false,
+          session_id: turn.session_id,
+          thread_id: turn.thread_id,
+          turn_id: turn.turn_id,
+          reason
+        };
+      } catch (error) {
+        const normalized = normalizeRunnerError(error, "APP_SERVER_CANCEL_FAILED");
+        return {
+          type: "CancelResult",
+          status: normalized.code === "APP_SERVER_REQUEST_TIMEOUT" ? "timeout" : "failed",
+          success: false,
+          interrupted: false,
+          session_stopped: false,
+          process_killed: false,
+          session_id: turn.session_id,
+          thread_id: turn.thread_id,
+          turn_id: turn.turn_id,
+          reason,
+          error: normalized
+        };
+      }
+    },
+
+    async stopSession(session) {
+      const context = sessions.get(session.session_id);
+      if (!context) {
+        return {
+          type: "StopSessionResult",
+          status: "failed",
+          success: false,
+          session_id: session.session_id,
+          thread_id: session.thread_id,
+          error: normalizeRunnerError(
+            runnerError("APP_SERVER_SESSION_NOT_FOUND", "Codex app-server session is not active."),
+            "APP_SERVER_SESSION_NOT_FOUND"
+          )
+        };
+      }
+
+      try {
+        await context.transport.request("thread/unsubscribe", { threadId: session.thread_id }, {
+          timeoutMs: timeoutValue(context.runnerConfig, "stopSessionTimeoutMs")
+        });
+        await context.transport.request("thread/archive", { threadId: session.thread_id }, {
+          timeoutMs: timeoutValue(context.runnerConfig, "stopSessionTimeoutMs")
+        });
+        await context.transport.close?.();
+        sessions.delete(session.session_id);
+        return {
+          type: "StopSessionResult",
+          status: "stopped",
+          success: true,
+          session_id: session.session_id,
+          thread_id: session.thread_id
+        };
+      } catch (error) {
+        return {
+          type: "StopSessionResult",
+          status: "failed",
+          success: false,
+          session_id: session.session_id,
+          thread_id: session.thread_id,
+          error: normalizeRunnerError(error, "APP_SERVER_STOP_SESSION_FAILED")
+        };
+      }
+    },
+
+    async terminateOwnedProcess(session) {
+      if (session.process_owned !== true) {
+        return {
+          type: "TerminateProcessResult",
+          status: "unknown_ownership",
+          success: false,
+          session_id: session.session_id,
+          thread_id: session.thread_id,
+          remediation: "Process ownership is unknown; preserve the workspace and terminate manually after inspection."
+        };
+      }
+
+      const context = sessions.get(session.session_id);
+      if (!context) {
+        return {
+          type: "TerminateProcessResult",
+          status: "failed",
+          success: false,
+          session_id: session.session_id,
+          thread_id: session.thread_id,
+          error: normalizeRunnerError(
+            runnerError("APP_SERVER_SESSION_NOT_FOUND", "Codex app-server session is not active."),
+            "APP_SERVER_SESSION_NOT_FOUND"
+          )
+        };
+      }
+
+      const result = await context.transport.terminate?.({
+        termTimeoutMs: timeoutValue(context.runnerConfig, "termTimeoutMs"),
+        killTimeoutMs: timeoutValue(context.runnerConfig, "killTimeoutMs")
+      });
+      sessions.delete(session.session_id);
+      return {
+        type: "TerminateProcessResult",
+        status: result?.status === "terminated" ? "terminated" : "failed",
+        success: result?.status === "terminated",
+        session_id: session.session_id,
+        thread_id: session.thread_id,
+        process_id: session.process_id,
+        signal: result?.signal,
+        error: result?.error
+      };
+    }
+  };
+  return runner;
+}
+
+async function initializeTransport(transport, runnerConfig) {
+  return transport.request("initialize", {
+    clientInfo: {
+      name: "fizzy-symphony",
+      title: "Fizzy Symphony",
+      version: "0.1.0"
+    },
+    capabilities: {
+      experimentalApi: true
+    }
+  }, { timeoutMs: timeoutValue(runnerConfig, "initializeTimeoutMs") });
+}
+
+function createSessionContext({ transport, runnerConfig, now }) {
+  return {
+    transport,
+    runnerConfig,
+    now,
+    session: null,
+    notifications: [],
+    output: "",
+    waiters: [],
+    inputRequired: null,
+    streamFailure: null
+  };
+}
+
+function wireTransportContext(context) {
+  context.transport.onNotification?.((message) => {
+    context.notifications.push(message);
+    wake(context);
+  });
+  context.transport.onServerRequest?.((message) => handleServerRequest(context, message));
+  context.transport.onExit?.((exit) => {
+    context.streamFailure = {
+      failure_kind: "runner_error",
+      error: normalizeRunnerError(
+        runnerError("APP_SERVER_EXITED", "Codex app-server exited before the turn completed.", exit),
+        "APP_SERVER_EXITED"
+      )
+    };
+    wake(context);
+  });
+  context.transport.onProtocolError?.((error) => {
+    context.streamFailure = {
+      failure_kind: "runner_error",
+      error: normalizeRunnerError(error, "APP_SERVER_PROTOCOL_ERROR")
+    };
+    wake(context);
+  });
+}
+
+function handleServerRequest(context, message) {
+  const inputRequired = inputRequiredFailure(message);
+  context.inputRequired = inputRequired;
+
+  if (message.id !== undefined) {
+    const response = serverRequestRejection(message);
+    if (response.error) {
+      context.transport.respondError?.(message.id, response.error);
+    } else {
+      context.transport.respond?.(message.id, response.result);
+    }
+  }
+
+  wake(context);
+}
+
+function serverRequestRejection(message) {
+  switch (message.method) {
+    case "item/commandExecution/requestApproval":
+      return { result: { decision: "cancel" } };
+    case "item/fileChange/requestApproval":
+      return { result: { decision: "cancel" } };
+    case "item/tool/requestUserInput":
+      return { result: { answers: {} } };
+    case "mcpServer/elicitation/request":
+      return { result: { action: "cancel", content: null, _meta: null } };
+    case "item/permissions/requestApproval":
+      return { result: { permissions: {}, scope: "turn" } };
+    case "item/tool/call":
+      return { result: { contentItems: [], success: false } };
+    case "applyPatchApproval":
+    case "execCommandApproval":
+      return { result: { decision: "abort" } };
+    case "account/chatgptAuthTokens/refresh":
+      return {
+        error: runnerError(
+          "RUNNER_INPUT_REQUIRED",
+          "Codex app-server requested ChatGPT token refresh in unattended mode."
+        )
+      };
+    default:
+      return {
+        error: runnerError("APP_SERVER_UNHANDLED_REQUEST", `Unhandled Codex app-server server request: ${message.method}.`)
+      };
+  }
+}
+
+function inputRequiredFailure(message) {
+  const method = message.method;
+  const kind = REQUEST_METHODS_REQUIRING_OPERATOR.has(method) ? "approval/input request" : "server request";
+  return {
+    method,
+    thread_id: message.params?.threadId ?? message.params?.conversationId,
+    turn_id: message.params?.turnId,
+    error: {
+      type: "RunnerError",
+      code: "RUNNER_INPUT_REQUIRED",
+      message: `Codex app-server requested an operator ${kind} in unattended mode.`,
+      remediation: "Review the card workspace, adjust runner.codex approval/input policy or run Codex interactively, then rerun the card.",
+      retryable: false,
+      raw_error: {
+        method,
+        params: redact(safeParams(message.params))
+      }
+    }
+  };
+}
+
+function inputRequiredEvent(turn, failure) {
+  return {
+    type: "runner.input_required",
+    method: failure.method,
+    timestamp: new Date().toISOString(),
+    session_id: turn.session_id,
+    thread_id: failure.thread_id ?? turn.thread_id,
+    turn_id: failure.turn_id ?? turn.turn_id,
+    error: failure.error
+  };
+}
+
+function normalizeNotification(message, turn, now) {
+  const params = message.params ?? {};
+  const base = {
+    type: methodToEventType(message.method),
+    method: message.method,
+    timestamp: now(),
+    session_id: turn.session_id,
+    thread_id: params.threadId ?? turn.thread_id,
+    turn_id: params.turnId ?? params.turn?.id ?? turn.turn_id
+  };
+
+  if (message.method === "item/agentMessage/delta") {
+    return omitUndefined({
+      ...base,
+      type: "assistant.delta",
+      text: params.delta ?? params.text
+    });
+  }
+
+  if (message.method === "turn/completed") {
+    return omitUndefined({
+      ...base,
+      type: "turn.completed",
+      final: true,
+      status: normalizeTurnStatus(params.turn?.status),
+      error: params.turn?.error ? normalizeTurnError(params.turn.error) : undefined,
+      duration_ms: params.turn?.durationMs
+    });
+  }
+
+  if (message.method === "error") {
+    return omitUndefined({
+      ...base,
+      type: "turn.error",
+      final: true,
+      status: "failed",
+      error: normalizeTurnError(params.error),
+      retryable: params.willRetry
+    });
+  }
+
+  if (message.method === "thread/tokenUsage/updated") {
+    return omitUndefined({
+      ...base,
+      type: "runner.token_usage",
+      token_usage: redact(params.usage ?? params.tokenUsage)
+    });
+  }
+
+  return omitUndefined({
+    ...base,
+    status: normalizeTurnStatus(params.turn?.status ?? params.status),
+    safe_payload: redact(safeParams(params))
+  });
+}
+
+function turnResultFromFinal(turn, event, events, output) {
+  const success = event.status === "completed";
+  return omitUndefined({
+    type: "TurnResult",
+    success,
+    status: event.status,
+    session_id: turn.session_id,
+    thread_id: turn.thread_id,
+    turn_id: turn.turn_id,
+    output_summary: output ? output.slice(0, 4000) : undefined,
+    events,
+    error: success ? undefined : event.error ?? {
+      type: "RunnerError",
+      code: "RUNNER_TURN_FAILED",
+      message: `Codex turn ended with status ${event.status}.`,
+      remediation: "Inspect the workspace and runner events before retrying.",
+      retryable: true
+    }
+  });
+}
+
+function turnFailure(turn, failureKind, error, events = []) {
+  return {
+    type: "TurnResult",
+    success: false,
+    status: "failed",
+    session_id: turn.session_id,
+    thread_id: turn.thread_id,
+    turn_id: turn.turn_id,
+    failure_kind: failureKind,
+    events,
+    error
+  };
+}
+
+function cancelFailure(turn, reason, code, message) {
+  return {
+    type: "CancelResult",
+    status: "failed",
+    success: false,
+    interrupted: false,
+    session_stopped: false,
+    process_killed: false,
+    session_id: turn.session_id,
+    thread_id: turn.thread_id,
+    turn_id: turn.turn_id,
+    reason,
+    error: normalizeRunnerError(runnerError(code, message), code)
+  };
+}
+
+function shiftMatchingNotification(context, turn) {
+  const index = context.notifications.findIndex((message) => {
+    const params = message.params ?? {};
+    const threadId = params.threadId ?? params.conversationId;
+    const turnId = params.turnId ?? params.turn?.id;
+    return (!threadId || threadId === turn.thread_id) && (!turnId || turnId === turn.turn_id);
+  });
+  if (index === -1) return null;
+  return context.notifications.splice(index, 1)[0];
+}
+
+function waitForContext(context) {
+  return new Promise((resolve) => {
+    context.waiters.push(resolve);
+  });
+}
+
+function wake(context) {
+  const waiters = context.waiters.splice(0);
+  for (const waiter of waiters) waiter();
+}
+
+function threadStartParams({ path, policies, metadata, runnerConfig }) {
+  const model = metadata.model ?? policies.route?.model ?? policies.config?.agent?.default_model;
+  return omitUndefined({
+    model: model || undefined,
+    cwd: path,
+    approvalPolicy: approvalPolicy(runnerConfig),
+    approvalsReviewer: "user",
+    sandbox: runnerConfig.codex.thread_sandbox,
+    config: {},
+    serviceName: "fizzy-symphony",
+    ephemeral: false,
+    sessionStartSource: { custom: "fizzy-symphony" },
+    experimentalRawEvents: false,
+    persistExtendedHistory: true
+  });
+}
+
+function turnStartParams({ session, prompt, metadata, runnerConfig }) {
+  return omitUndefined({
+    threadId: session.thread_id,
+    input: [{ type: "text", text: String(prompt ?? ""), text_elements: [] }],
+    cwd: session.workspace_path ?? session.workspace,
+    approvalPolicy: approvalPolicy(runnerConfig),
+    approvalsReviewer: "user",
+    sandboxPolicy: sandboxPolicy(runnerConfig, session.workspace_path ?? session.workspace),
+    model: metadata.model || undefined
+  });
+}
+
+function approvalPolicy(runnerConfig) {
+  if (runnerConfig.codex.interactive === true) return "on-request";
+  return "on-request";
+}
+
+function sandboxPolicy(runnerConfig, path) {
+  const type = runnerConfig.codex.turn_sandbox_policy?.type ?? "workspaceWrite";
+  if (type === "dangerFullAccess") return { type: "dangerFullAccess" };
+  if (type === "readOnly") {
+    return {
+      type: "readOnly",
+      access: { type: "restricted", includePlatformDefaults: true, readableRoots: [path] },
+      networkAccess: false
+    };
+  }
+  return {
+    type: "workspaceWrite",
+    writableRoots: [path],
+    readOnlyAccess: { type: "restricted", includePlatformDefaults: true, readableRoots: [] },
+    networkAccess: false,
+    excludeTmpdirEnvVar: false,
+    excludeSlashTmp: false
+  };
+}
+
+function transportOptions(runnerConfig, cwd) {
+  return {
+    command: runnerConfig.cli_app_server.command,
+    args: runnerConfig.cli_app_server.args,
+    cwd,
+    maxStderrBytes: runnerConfig.max_stderr_bytes
+  };
+}
+
+function resolveRunnerConfig(config = {}) {
+  const runner = config.runner ?? config;
+  return {
+    preferred: runner.preferred ?? "cli_app_server",
+    fallback: runner.fallback ?? "cli_app_server",
+    cli_app_server: {
+      command: runner.cli_app_server?.command ?? "codex",
+      args: runner.cli_app_server?.args ?? ["app-server"]
+    },
+    codex: {
+      interactive: runner.codex?.interactive === true,
+      approval_policy: runner.codex?.approval_policy ?? { mode: "reject" },
+      thread_sandbox: runner.codex?.thread_sandbox ?? "workspace-write",
+      turn_sandbox_policy: runner.codex?.turn_sandbox_policy ?? { type: "workspaceWrite" }
+    },
+    timeouts: {
+      initializeTimeoutMs: runner.initialize_timeout_ms ?? DEFAULTS.initializeTimeoutMs,
+      requestTimeoutMs: runner.request_timeout_ms ?? DEFAULTS.requestTimeoutMs,
+      cancelTimeoutMs: runner.cancel_timeout_ms ?? DEFAULTS.cancelTimeoutMs,
+      stopSessionTimeoutMs: runner.stop_session_timeout_ms ?? DEFAULTS.stopSessionTimeoutMs,
+      termTimeoutMs: runner.terminate_timeout_ms ?? DEFAULTS.termTimeoutMs,
+      killTimeoutMs: runner.kill_timeout_ms ?? DEFAULTS.killTimeoutMs,
+      streamTimeoutMs: config.agent?.turn_timeout_ms ?? runner.stream_timeout_ms ?? DEFAULTS.streamTimeoutMs
+    },
+    detect_timeout_ms: runner.detect_timeout_ms,
+    max_stderr_bytes: runner.max_stderr_bytes
+  };
+}
+
+function timeoutValue(runnerConfig, key) {
+  return Number(runnerConfig.timeouts?.[key] ?? DEFAULTS[key] ?? 0);
+}
+
+async function workspaceForValidation(workspace) {
+  const path = workspacePath(workspace);
+  if (path) return { path, temporary: false };
+  const temporary = await mkdtemp(join(tmpdir(), "fizzy-symphony-codex-health-"));
+  return { path: temporary, temporary: true };
+}
+
+function workspacePath(workspace) {
+  if (typeof workspace === "string") return workspace;
+  return workspace?.path ?? workspace?.workspace_path ?? null;
+}
+
+function serializablePolicies(policies) {
+  return redact({
+    route: policies.route,
+    workflow: policies.workflow ? {
+      front_matter: policies.workflow.front_matter ?? policies.workflow.frontMatter,
+      body_length: String(policies.workflow.body ?? "").length
+    } : undefined
+  });
+}
+
+async function probeCodexVersion(command, options = {}) {
+  try {
+    const result = await execFile(command, ["--version"], {
+      timeout: options.timeoutMs ?? 5000,
+      shell: false
+    });
+    return { ok: true, version: String(result.stdout || result.stderr).trim() };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error.code === "ENOENT" ? "command_not_found" : "version_probe_failed",
+      message: error.message
+    };
+  }
+}
+
+function protocolReport() {
+  return {
+    source: "codex app-server generate-ts",
+    version: PROTOCOL_VERSION,
+    methods: PROTOCOL_METHODS
+  };
+}
+
+function normalizeTurnStatus(status) {
+  if (status === "completed") return "completed";
+  if (status === "interrupted") return "cancelled";
+  if (status === "failed") return "failed";
+  if (status === "inProgress") return "running";
+  return status;
+}
+
+function normalizeTurnError(error) {
+  if (!error) return undefined;
+  return {
+    type: "RunnerError",
+    code: codexErrorCode(error.codexErrorInfo),
+    message: error.message ?? "Codex app-server reported a turn error.",
+    remediation: "Inspect the runner events and workspace before retrying.",
+    retryable: error.codexErrorInfo !== "unauthorized",
+    raw_error: redact(error)
+  };
+}
+
+function normalizeRunnerError(error, fallbackCode) {
+  return {
+    type: "RunnerError",
+    code: error?.code ?? fallbackCode,
+    message: error?.message ?? String(error ?? "Codex runner error."),
+    remediation: error?.remediation ?? "Inspect Codex CLI authentication, app-server availability, and the card workspace.",
+    retryable: error?.retryable ?? !["RUNNER_INPUT_REQUIRED", "APP_SERVER_SESSION_NOT_FOUND"].includes(error?.code ?? fallbackCode),
+    raw_error: redact(error?.details)
+  };
+}
+
+function runnerError(code, message, details = {}) {
+  const error = new Error(message);
+  error.code = code;
+  error.details = details;
+  return error;
+}
+
+function codexErrorCode(info) {
+  if (!info) return "CODEX_TURN_ERROR";
+  if (typeof info === "string") return `CODEX_${info.replace(/[A-Z]/gu, (char) => `_${char}`).toUpperCase()}`;
+  return `CODEX_${Object.keys(info)[0]?.replace(/[A-Z]/gu, (char) => `_${char}`).toUpperCase() ?? "TURN_ERROR"}`;
+}
+
+function methodToEventType(method) {
+  switch (method) {
+    case "turn/started":
+      return "turn.started";
+    case "turn/completed":
+      return "turn.completed";
+    case "thread/started":
+      return "session.started";
+    default:
+      return String(method).replaceAll("/", ".");
+  }
+}
+
+function safeParams(params = {}) {
+  if (!params || typeof params !== "object") return params;
+  return omitUndefined({
+    threadId: params.threadId,
+    turnId: params.turnId,
+    itemId: params.itemId,
+    status: params.status,
+    command: params.command,
+    cwd: params.cwd,
+    reason: params.reason,
+    message: params.message,
+    serverName: params.serverName
+  });
+}
+
+function sha256(value) {
+  return createHash("sha256").update(String(value ?? "")).digest("hex");
+}
+
+function omitUndefined(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}

--- a/src/codex-cli-app-server-runner.js
+++ b/src/codex-cli-app-server-runner.js
@@ -13,7 +13,7 @@ const execFile = promisify(nodeExecFile);
 const IMPLEMENTATION = "CodexCliAppServerRunner";
 const KIND = "cli_app_server";
 const PROTOCOL_VERSION = "0.125.0";
-const PROTOCOL_METHODS = ["initialize", "thread/start", "turn/start", "turn/interrupt", "thread/unsubscribe", "thread/archive"];
+const PROTOCOL_METHODS = ["initialize", "thread/start", "turn/start", "turn/interrupt", "thread/unsubscribe"];
 const REQUEST_METHODS_REQUIRING_OPERATOR = new Set([
   "item/commandExecution/requestApproval",
   "item/fileChange/requestApproval",
@@ -333,9 +333,6 @@ export function createCodexCliAppServerRunner(options = {}) {
 
       try {
         await context.transport.request("thread/unsubscribe", { threadId: session.thread_id }, {
-          timeoutMs: timeoutValue(context.runnerConfig, "stopSessionTimeoutMs")
-        });
-        await context.transport.request("thread/archive", { threadId: session.thread_id }, {
           timeoutMs: timeoutValue(context.runnerConfig, "stopSessionTimeoutMs")
         });
         await context.transport.close?.();
@@ -678,7 +675,7 @@ function threadStartParams({ path, policies, metadata, runnerConfig }) {
     config: {},
     serviceName: "fizzy-symphony",
     ephemeral: false,
-    sessionStartSource: { custom: "fizzy-symphony" },
+    sessionStartSource: "clear",
     experimentalRawEvents: false,
     persistExtendedHistory: true
   });

--- a/src/config.js
+++ b/src/config.js
@@ -111,6 +111,14 @@ const schema = {
       command: true,
       args: [true]
     },
+    initialize_timeout_ms: true,
+    request_timeout_ms: true,
+    cancel_timeout_ms: true,
+    stop_session_timeout_ms: true,
+    terminate_timeout_ms: true,
+    kill_timeout_ms: true,
+    stream_timeout_ms: true,
+    max_stderr_bytes: true,
     health: {
       enabled: true,
       interval_ms: true
@@ -346,6 +354,13 @@ function durationPaths() {
     "agent.stall_timeout_ms",
     "agent.max_retry_backoff_ms",
     "runner.health.interval_ms",
+    "runner.initialize_timeout_ms",
+    "runner.request_timeout_ms",
+    "runner.cancel_timeout_ms",
+    "runner.stop_session_timeout_ms",
+    "runner.terminate_timeout_ms",
+    "runner.kill_timeout_ms",
+    "runner.stream_timeout_ms",
     "claims.lease_ms",
     "claims.renew_interval_ms",
     "claims.steal_grace_ms",

--- a/src/runner-contract.js
+++ b/src/runner-contract.js
@@ -1,5 +1,7 @@
 const CONTRACT = "codex-runner-fake-v1";
 
+export { createCodexCliAppServerRunner } from "./codex-cli-app-server-runner.js";
+
 export function createFakeCodexRunner(options = {}) {
   let sessionCounter = 0;
   let turnCounter = 0;

--- a/test/codex-app-server-transport.test.js
+++ b/test/codex-app-server-transport.test.js
@@ -1,0 +1,141 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
+
+import { launchCodexAppServerTransport } from "../src/codex-app-server-transport.js";
+
+test("app-server transport launches explicit argv in the workspace without shell eval", async () => {
+  const child = new FakeChildProcess();
+  const calls = [];
+  const transport = launchCodexAppServerTransport({
+    command: "codex",
+    args: ["app-server", "--listen", "stdio://"],
+    cwd: "/tmp/card-workspace",
+    spawn: (command, args, options) => {
+      calls.push({ command, args, options });
+      return child;
+    }
+  });
+
+  assert.equal(calls[0].command, "codex");
+  assert.deepEqual(calls[0].args, ["app-server", "--listen", "stdio://"]);
+  assert.equal(calls[0].options.cwd, "/tmp/card-workspace");
+  assert.equal(calls[0].options.shell, false);
+  assert.deepEqual(calls[0].options.stdio, ["pipe", "pipe", "pipe"]);
+
+  await transport.close();
+});
+
+test("app-server transport matches JSONL responses, notifications, and server requests", async () => {
+  const child = new FakeChildProcess();
+  const transport = launchCodexAppServerTransport({
+    command: "codex",
+    args: ["app-server"],
+    cwd: "/tmp/card-workspace",
+    spawn: () => child
+  });
+  const notifications = [];
+  const serverRequests = [];
+  transport.onNotification((message) => notifications.push(message));
+  transport.onServerRequest(async (message) => {
+    serverRequests.push(message);
+    return { decision: "cancel" };
+  });
+
+  const response = transport.request("initialize", { clientInfo: { name: "test" } });
+  assert.deepEqual(JSON.parse(child.stdinWrites[0]), {
+    id: 1,
+    method: "initialize",
+    params: { clientInfo: { name: "test" } }
+  });
+
+  child.stdout.write(`${JSON.stringify({ method: "turn/started", params: { threadId: "thread_1" } })}\n`);
+  child.stdout.write(`${JSON.stringify({
+    id: 99,
+    method: "item/commandExecution/requestApproval",
+    params: { threadId: "thread_1", turnId: "turn_1" }
+  })}\n`);
+  child.stdout.write(`${JSON.stringify({ id: 1, result: { userAgent: "codex-cli/0.125.0" } })}\n`);
+
+  assert.deepEqual(await response, { userAgent: "codex-cli/0.125.0" });
+  assert.equal(notifications[0].method, "turn/started");
+  assert.equal(serverRequests[0].method, "item/commandExecution/requestApproval");
+  assert.deepEqual(JSON.parse(child.stdinWrites[1]), { id: 99, result: { decision: "cancel" } });
+
+  await transport.close();
+});
+
+test("app-server transport rejects pending requests on malformed protocol messages", async () => {
+  const child = new FakeChildProcess();
+  const transport = launchCodexAppServerTransport({
+    command: "codex",
+    args: ["app-server"],
+    cwd: "/tmp/card-workspace",
+    spawn: () => child
+  });
+
+  const response = assert.rejects(
+    transport.request("initialize", {}),
+    /Malformed Codex app-server JSONL message/u
+  );
+  child.stdout.write("{not json}\n");
+  await response;
+
+  await transport.close();
+});
+
+test("app-server transport includes bounded stderr when the process exits during a request", async () => {
+  const child = new FakeChildProcess();
+  const transport = launchCodexAppServerTransport({
+    command: "codex",
+    args: ["app-server"],
+    cwd: "/tmp/card-workspace",
+    spawn: () => child,
+    maxStderrBytes: 64
+  });
+
+  const response = assert.rejects(
+    transport.request("initialize", {}),
+    (error) => {
+      assert.equal(error.code, "APP_SERVER_EXITED");
+      assert.match(error.message, /boom/u);
+      return true;
+    }
+  );
+  child.stderr.write("boom from app-server\n");
+  child.exit(17, null);
+  await response;
+
+  await transport.close();
+});
+
+class FakeChildProcess extends EventEmitter {
+  constructor() {
+    super();
+    this.pid = 12345;
+    this.stdout = new PassThrough();
+    this.stderr = new PassThrough();
+    this.stdinWrites = [];
+    this.killSignals = [];
+    this.exitCode = null;
+    this.signalCode = null;
+    this.stdin = new Writable({
+      write: (chunk, _encoding, callback) => {
+        this.stdinWrites.push(String(chunk).trim());
+        callback();
+      }
+    });
+  }
+
+  kill(signal = "SIGTERM") {
+    this.killSignals.push(signal);
+    return true;
+  }
+
+  exit(code = 0, signal = null) {
+    this.exitCode = code;
+    this.signalCode = signal;
+    this.emit("exit", code, signal);
+  }
+}

--- a/test/codex-cli-app-server-runner.test.js
+++ b/test/codex-cli-app-server-runner.test.js
@@ -38,7 +38,7 @@ test("Codex CLI app-server runner detects command/version and validates with ini
     protocol: {
       source: "codex app-server generate-ts",
       version: "0.125.0",
-      methods: ["initialize", "thread/start", "turn/start", "turn/interrupt", "thread/unsubscribe", "thread/archive"]
+      methods: ["initialize", "thread/start", "turn/start", "turn/interrupt", "thread/unsubscribe"]
     }
   });
 
@@ -117,6 +117,7 @@ test("Codex CLI app-server runner starts sessions and turns in the prepared work
   assert.equal(transport.requests[1].params.approvalPolicy, "on-request");
   assert.equal(transport.requests[1].params.approvalsReviewer, "user");
   assert.equal(transport.requests[1].params.sandbox, "workspace-write");
+  assert.equal(transport.requests[1].params.sessionStartSource, "clear");
 
   assert.equal(transport.requests[2].method, "turn/start");
   assert.deepEqual(transport.requests[2].params.input, [{ type: "text", text: "Implement the card.", text_elements: [] }]);
@@ -216,11 +217,11 @@ test("Codex CLI app-server runner cancels, stops sessions, and only terminates o
     session_id: "thread_1",
     thread_id: "thread_1"
   });
-  assert.deepEqual(transport.requests.slice(-3).map((request) => request.method), [
+  assert.deepEqual(transport.requests.slice(-2).map((request) => request.method), [
     "turn/interrupt",
-    "thread/unsubscribe",
-    "thread/archive"
+    "thread/unsubscribe"
   ]);
+  assert.equal(transport.closed, true);
 
   const terminatingTransport = cancellableTransport();
   const terminatingRunner = createCodexCliAppServerRunner({ transportFactory: () => terminatingTransport });
@@ -245,8 +246,7 @@ function cancellableTransport() {
     "thread/start": () => threadStartResult(),
     "turn/start": () => turnStartResult(),
     "turn/interrupt": () => ({}),
-    "thread/unsubscribe": () => ({ status: "unsubscribed" }),
-    "thread/archive": () => ({})
+    "thread/unsubscribe": () => ({ status: "unsubscribed" })
   });
 }
 

--- a/test/codex-cli-app-server-runner.test.js
+++ b/test/codex-cli-app-server-runner.test.js
@@ -1,0 +1,371 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createCodexCliAppServerRunner } from "../src/runner-contract.js";
+
+test("Codex CLI app-server runner detects command/version and validates with initialize handshake", async () => {
+  const transports = [];
+  const runner = createCodexCliAppServerRunner({
+    versionProbe: async (command) => ({ ok: true, command_path: `/usr/bin/${command}`, version: "codex-cli 0.125.0" }),
+    transportFactory: (options) => {
+      const transport = new FakeTransport(options, {
+        "initialize": () => ({
+          userAgent: "fizzy-symphony/0.125.0",
+          codexHome: "/home/test/.codex",
+          platformFamily: "unix",
+          platformOs: "linux"
+        })
+      });
+      transports.push(transport);
+      return transport;
+    }
+  });
+  const config = {
+    preferred: "cli_app_server",
+    fallback: "cli_app_server",
+    cli_app_server: { command: "codex", args: ["app-server"] }
+  };
+  const workspace = { path: "/tmp/card-workspace" };
+
+  assert.deepEqual(await runner.detect(config), {
+    kind: "cli_app_server",
+    implementation: "CodexCliAppServerRunner",
+    available: true,
+    command: "codex",
+    argv: ["codex", "app-server"],
+    command_path: "/usr/bin/codex",
+    version: "codex-cli 0.125.0",
+    protocol: {
+      source: "codex app-server generate-ts",
+      version: "0.125.0",
+      methods: ["initialize", "thread/start", "turn/start", "turn/interrupt", "thread/unsubscribe", "thread/archive"]
+    }
+  });
+
+  const validation = await runner.validate(config, workspace);
+  assert.equal(validation.ok, true);
+  assert.equal(validation.kind, "cli_app_server");
+  assert.equal(validation.workspace, "/tmp/card-workspace");
+  assert.deepEqual(validation.argv, ["codex", "app-server"]);
+  assert.equal(validation.handshake.ok, true);
+  assert.equal(transports[0].options.cwd, "/tmp/card-workspace");
+  assert.equal(transports[0].requests[0].method, "initialize");
+  assert.equal(transports[0].closed, true);
+});
+
+test("Codex CLI app-server runner starts sessions and turns in the prepared workspace", async () => {
+  const transport = new FakeTransport({}, {
+    "initialize": () => ({
+      userAgent: "fizzy-symphony/0.125.0",
+      codexHome: "/home/test/.codex",
+      platformFamily: "unix",
+      platformOs: "linux"
+    }),
+    "thread/start": (_params) => ({
+      thread: {
+        id: "thread_1",
+        cwd: "/tmp/card-workspace",
+        status: "running",
+        turns: []
+      },
+      model: "gpt-5.4",
+      modelProvider: "openai",
+      serviceTier: null,
+      cwd: "/tmp/card-workspace",
+      instructionSources: [],
+      approvalPolicy: "on-request",
+      approvalsReviewer: "user",
+      sandbox: { type: "workspaceWrite" },
+      permissionProfile: null,
+      reasoningEffort: null
+    }),
+    "turn/start": (_params) => ({
+      turn: {
+        id: "turn_1",
+        status: "inProgress",
+        items: [],
+        error: null,
+        startedAt: 1,
+        completedAt: null,
+        durationMs: null
+      }
+    })
+  });
+  const runner = createCodexCliAppServerRunner({
+    versionProbe: async () => ({ ok: true, version: "codex-cli 0.125.0" }),
+    transportFactory: () => transport,
+    now: () => "2026-04-29T19:15:00.000Z"
+  });
+  const config = runnerConfig();
+
+  const session = await runner.startSession("/tmp/card-workspace", { config, route: { model: "gpt-5.4" } }, { run_id: "run_1" });
+  const turn = await runner.startTurn(session, "Implement the card.", { run_id: "run_1", attempt_number: 2 });
+
+  assert.equal(session.session_id, "thread_1");
+  assert.equal(session.thread_id, "thread_1");
+  assert.equal(session.workspace, "/tmp/card-workspace");
+  assert.equal(session.process_owned, true);
+  assert.equal(session.process_id, 4321);
+  assert.equal(turn.turn_id, "turn_1");
+  assert.equal(turn.thread_id, "thread_1");
+  assert.equal(turn.workspace, "/tmp/card-workspace");
+  assert.equal(turn.prompt_digest.length, 64);
+
+  assert.equal(transport.requests[1].method, "thread/start");
+  assert.equal(transport.requests[1].params.cwd, "/tmp/card-workspace");
+  assert.equal(transport.requests[1].params.model, "gpt-5.4");
+  assert.equal(transport.requests[1].params.approvalPolicy, "on-request");
+  assert.equal(transport.requests[1].params.approvalsReviewer, "user");
+  assert.equal(transport.requests[1].params.sandbox, "workspace-write");
+
+  assert.equal(transport.requests[2].method, "turn/start");
+  assert.deepEqual(transport.requests[2].params.input, [{ type: "text", text: "Implement the card.", text_elements: [] }]);
+  assert.equal(transport.requests[2].params.cwd, "/tmp/card-workspace");
+  assert.equal(transport.requests[2].params.sandboxPolicy.type, "workspaceWrite");
+  assert.deepEqual(transport.requests[2].params.sandboxPolicy.writableRoots, ["/tmp/card-workspace"]);
+});
+
+test("Codex CLI app-server runner streams normalized activity and final turn result", async () => {
+  const transport = new FakeTransport({}, {
+    "initialize": () => initializeResult(),
+    "thread/start": () => threadStartResult(),
+    "turn/start": () => turnStartResult()
+  });
+  const runner = createCodexCliAppServerRunner({ transportFactory: () => transport });
+  const session = await runner.startSession("/tmp/card-workspace", { config: runnerConfig() }, { run_id: "run_1" });
+  const turn = await runner.startTurn(session, "prompt", { run_id: "run_1", attempt_number: 1 });
+  const streamed = [];
+
+  const resultPromise = runner.stream(turn, (event) => streamed.push(event));
+  transport.emitNotification({ method: "turn/started", params: { threadId: "thread_1", turn: { id: "turn_1", status: "inProgress" } } });
+  transport.emitNotification({ method: "item/agentMessage/delta", params: { threadId: "thread_1", turnId: "turn_1", delta: "done" } });
+  transport.emitNotification({
+    method: "turn/completed",
+    params: {
+      threadId: "thread_1",
+      turn: { id: "turn_1", status: "completed", items: [], error: null, startedAt: 1, completedAt: 2, durationMs: 1000 }
+    }
+  });
+
+  const result = await resultPromise;
+  assert.equal(result.type, "TurnResult");
+  assert.equal(result.success, true);
+  assert.equal(result.status, "completed");
+  assert.equal(result.session_id, "thread_1");
+  assert.equal(result.thread_id, "thread_1");
+  assert.equal(result.turn_id, "turn_1");
+  assert.deepEqual(streamed.map((event) => event.type), ["turn.started", "assistant.delta", "turn.completed"]);
+  assert.equal(streamed[1].text, "done");
+});
+
+test("Codex CLI app-server runner treats approval and input requests as controlled unattended failures", async () => {
+  const transport = new FakeTransport({}, {
+    "initialize": () => initializeResult(),
+    "thread/start": () => threadStartResult(),
+    "turn/start": () => turnStartResult(),
+    "turn/interrupt": () => ({})
+  });
+  const runner = createCodexCliAppServerRunner({ transportFactory: () => transport });
+  const session = await runner.startSession("/tmp/card-workspace", { config: runnerConfig() }, { run_id: "run_1" });
+  const turn = await runner.startTurn(session, "prompt", { run_id: "run_1" });
+  const streamed = [];
+
+  const resultPromise = runner.stream(turn, (event) => streamed.push(event));
+  await transport.emitServerRequest({
+    id: 42,
+    method: "item/commandExecution/requestApproval",
+    params: { threadId: "thread_1", turnId: "turn_1", itemId: "item_1", command: "deploy" }
+  });
+
+  const result = await resultPromise;
+  assert.equal(result.status, "failed");
+  assert.equal(result.failure_kind, "input_required");
+  assert.equal(result.error.code, "RUNNER_INPUT_REQUIRED");
+  assert.equal(result.error.retryable, false);
+  assert.match(result.error.remediation, /approval/i);
+  assert.equal(streamed[0].type, "runner.input_required");
+  assert.deepEqual(transport.responses[0], { id: 42, result: { decision: "cancel" } });
+  assert.deepEqual(transport.requests.at(-1), {
+    method: "turn/interrupt",
+    params: { threadId: "thread_1", turnId: "turn_1" }
+  });
+});
+
+test("Codex CLI app-server runner cancels, stops sessions, and only terminates owned app-server processes", async () => {
+  const transport = cancellableTransport();
+  const runner = createCodexCliAppServerRunner({ transportFactory: () => transport });
+  const session = await runner.startSession("/tmp/card-workspace", { config: runnerConfig() }, { run_id: "run_1" });
+  const turn = await runner.startTurn(session, "prompt", { run_id: "run_1" });
+
+  assert.deepEqual(await runner.cancel(turn, "card_closed"), {
+    type: "CancelResult",
+    status: "cancelled",
+    success: true,
+    interrupted: true,
+    session_stopped: false,
+    process_killed: false,
+    session_id: "thread_1",
+    thread_id: "thread_1",
+    turn_id: "turn_1",
+    reason: "card_closed"
+  });
+  assert.deepEqual(await runner.stopSession(session), {
+    type: "StopSessionResult",
+    status: "stopped",
+    success: true,
+    session_id: "thread_1",
+    thread_id: "thread_1"
+  });
+  assert.deepEqual(transport.requests.slice(-3).map((request) => request.method), [
+    "turn/interrupt",
+    "thread/unsubscribe",
+    "thread/archive"
+  ]);
+
+  const terminatingTransport = cancellableTransport();
+  const terminatingRunner = createCodexCliAppServerRunner({ transportFactory: () => terminatingTransport });
+  const terminatingSession = await terminatingRunner.startSession("/tmp/card-workspace", { config: runnerConfig() }, { run_id: "run_2" });
+
+  assert.deepEqual(await terminatingRunner.terminateOwnedProcess({ ...terminatingSession, process_owned: false }), {
+    type: "TerminateProcessResult",
+    status: "unknown_ownership",
+    success: false,
+    session_id: "thread_1",
+    thread_id: "thread_1",
+    remediation: "Process ownership is unknown; preserve the workspace and terminate manually after inspection."
+  });
+
+  assert.equal((await terminatingRunner.terminateOwnedProcess(terminatingSession)).status, "terminated");
+  assert.deepEqual(terminatingTransport.terminations[0], { termTimeoutMs: 5000, killTimeoutMs: 2000 });
+});
+
+function cancellableTransport() {
+  return new FakeTransport({}, {
+    "initialize": () => initializeResult(),
+    "thread/start": () => threadStartResult(),
+    "turn/start": () => turnStartResult(),
+    "turn/interrupt": () => ({}),
+    "thread/unsubscribe": () => ({ status: "unsubscribed" }),
+    "thread/archive": () => ({})
+  });
+}
+
+function runnerConfig(overrides = {}) {
+  return {
+    runner: {
+      preferred: "cli_app_server",
+      fallback: "cli_app_server",
+      cli_app_server: { command: "codex", args: ["app-server"] },
+      codex: {
+        approval_policy: { mode: "reject" },
+        interactive: false,
+        thread_sandbox: "workspace-write",
+        turn_sandbox_policy: { type: "workspaceWrite" }
+      },
+      ...overrides.runner
+    },
+    agent: {
+      default_model: "",
+      ...overrides.agent
+    }
+  };
+}
+
+function initializeResult() {
+  return {
+    userAgent: "fizzy-symphony/0.125.0",
+    codexHome: "/home/test/.codex",
+    platformFamily: "unix",
+    platformOs: "linux"
+  };
+}
+
+function threadStartResult() {
+  return {
+    thread: { id: "thread_1", cwd: "/tmp/card-workspace", status: "running", turns: [] },
+    model: "gpt-5.4",
+    modelProvider: "openai",
+    serviceTier: null,
+    cwd: "/tmp/card-workspace",
+    instructionSources: [],
+    approvalPolicy: "on-request",
+    approvalsReviewer: "user",
+    sandbox: { type: "workspaceWrite" },
+    permissionProfile: null,
+    reasoningEffort: null
+  };
+}
+
+function turnStartResult() {
+  return {
+    turn: {
+      id: "turn_1",
+      status: "inProgress",
+      items: [],
+      error: null,
+      startedAt: 1,
+      completedAt: null,
+      durationMs: null
+    }
+  };
+}
+
+class FakeTransport {
+  constructor(options = {}, handlers = {}) {
+    this.options = options;
+    this.handlers = handlers;
+    this.requests = [];
+    this.responses = [];
+    this.notifications = [];
+    this.terminations = [];
+    this.closed = false;
+    this.child = { pid: 4321 };
+  }
+
+  async request(method, params) {
+    this.requests.push({ method, params });
+    const handler = this.handlers[method];
+    if (!handler) throw new Error(`Unexpected request ${method}`);
+    return handler(params);
+  }
+
+  onNotification(handler) {
+    this.notificationHandler = handler;
+    return () => {
+      this.notificationHandler = null;
+    };
+  }
+
+  onServerRequest(handler) {
+    this.serverRequestHandler = handler;
+    return () => {
+      this.serverRequestHandler = null;
+    };
+  }
+
+  respond(id, result) {
+    this.responses.push({ id, result });
+  }
+
+  respondError(id, error) {
+    this.responses.push({ id, error });
+  }
+
+  emitNotification(message) {
+    this.notifications.push(message);
+    this.notificationHandler?.(message);
+  }
+
+  async emitServerRequest(message) {
+    await this.serverRequestHandler?.(message);
+  }
+
+  async close() {
+    this.closed = true;
+  }
+
+  async terminate(options) {
+    this.terminations.push(options);
+    return { status: "terminated", signal: "SIGTERM" };
+  }
+}

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -86,6 +86,14 @@ function minimalConfig() {
       allow_fallback: true,
       sdk: { package: "", smoke_test: false },
       cli_app_server: { command: "codex", args: ["app-server"] },
+      initialize_timeout_ms: 10000,
+      request_timeout_ms: 60000,
+      cancel_timeout_ms: 10000,
+      stop_session_timeout_ms: 10000,
+      terminate_timeout_ms: 5000,
+      kill_timeout_ms: 2000,
+      stream_timeout_ms: 3600000,
+      max_stderr_bytes: 65536,
       health: { enabled: true, interval_ms: 60000 },
       codex: {
         approval_policy: {


### PR DESCRIPTION
## Summary
- Adds a JSONL stdio transport for `codex app-server` launched with explicit argv and `shell: false`.
- Adds `CodexCliAppServerRunner` behind the existing SDK-shaped runner contract while preserving the fake runner seam.
- Normalizes app-server lifecycle/activity, handles unattended approval/input requests as controlled failures, and supports cancel, stopSession, and owned-process termination with timeouts.
- Documents runner timeout config and updates project status/coverage notes.

## Test Plan
- `codex app-server generate-ts --out /tmp/fizzy-symphony-codex-schema-card-285`
- `node --test test/codex-app-server-transport.test.js test/codex-cli-app-server-runner.test.js`
- `node --test test/codex-app-server-transport.test.js test/codex-cli-app-server-runner.test.js test/config.test.js test/runner-contract.test.js test/validation.test.js test/reconciler.test.js test/active-reconciliation.test.js`
- `npm test`
- Non-mutating real Codex app-server initialize validation via `createCodexCliAppServerRunner().validate(...)`