### PR TITLE
Build operator setup validation flow

### DIFF
--- a/bin/fizzy-symphony.js
+++ b/bin/fizzy-symphony.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import { loadConfig, writeAnnotatedConfig } from "../src/config.js";
 import { isFizzySymphonyError } from "../src/errors.js";
+import { runSetup } from "../src/setup.js";
 import { runStatusCommand } from "../src/status-cli.js";
 import { discoverStatusEndpoints } from "../src/status-discovery.js";
 
@@ -55,12 +56,38 @@ async function statusDiscoveryCommand(args, io) {
 
 async function setupCommand(args, io) {
   const configPath = optionValue(args, "--config") ?? ".fizzy-symphony/config.yml";
-  if (!args.includes("--template-only")) {
-    throw new Error("Task 1 CLI setup supports --template-only. Validating live Fizzy setup uses injected clients in src/setup.js.");
+  if (args.includes("--template-only")) {
+    await writeAnnotatedConfig(configPath, { runnerPreferred: "cli_app_server" });
+    io.stdout.write(`wrote annotated config: ${configPath}\n`);
+    return;
   }
 
-  await writeAnnotatedConfig(configPath, { runnerPreferred: "cli_app_server" });
-  io.stdout.write(`wrote annotated config: ${configPath}\n`);
+  if (!io.fizzy) {
+    throw new Error("Live setup requires an injected Fizzy client. Use --template-only to write a template config.");
+  }
+
+  const result = await runSetup({
+    configPath,
+    fizzy: io.fizzy,
+    runner: io.runner,
+    prompts: io.prompts,
+    env: io.env ?? process.env,
+    account: optionValue(args, "--account") ?? undefined,
+    selectedBoardIds: boardValues(args),
+    setupMode: optionValue(args, "--mode") ?? undefined,
+    workspaceRepo: optionValue(args, "--workspace-repo") ?? ".",
+    botUserId: optionValue(args, "--bot-user-id") ?? undefined,
+    webhook: webhookOptions(args)
+  });
+
+  io.stdout.write(`${JSON.stringify({
+    ok: true,
+    path: result.path,
+    account: result.account,
+    boards: result.boards.map((board) => board.id),
+    runner: result.runner.kind,
+    warnings: result.warnings.map((warning) => warning.code)
+  })}\n`);
 }
 
 async function validateCommand(args, io) {
@@ -88,10 +115,43 @@ function optionValue(args, name) {
   return args[index + 1] ?? null;
 }
 
+function optionValues(args, name) {
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === name && args[index + 1]) values.push(args[index + 1]);
+  }
+  return values;
+}
+
+function boardValues(args) {
+  const repeated = optionValues(args, "--board");
+  const commaSeparated = optionValue(args, "--boards");
+  const values = [
+    ...repeated,
+    ...(commaSeparated ? commaSeparated.split(",") : [])
+  ].map((value) => value.trim()).filter(Boolean);
+  return values.length > 0 ? values : undefined;
+}
+
+function webhookOptions(args) {
+  const manage = args.includes("--manage-webhooks");
+  const callbackUrl = optionValue(args, "--webhook-callback-url");
+  const actions = optionValue(args, "--webhook-actions");
+
+  if (!manage && !callbackUrl && !actions) return {};
+
+  return {
+    manage,
+    callback_url: callbackUrl ?? "",
+    subscribed_actions: actions?.split(",").map((action) => action.trim()).filter(Boolean)
+  };
+}
+
 function usage(exitCode, io) {
   const text = [
     "Usage:",
     "  fizzy-symphony setup --template-only [--config path]",
+    "  fizzy-symphony setup [--config path] [--account id] [--board id] [--boards id,id] [--workspace-repo path]",
     "  fizzy-symphony validate --parse-only [--config path]",
     "  fizzy-symphony daemon",
     "  fizzy-symphony status [--config path] [--instance id]",

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, extname, isAbsolute, join, resolve } from "node:path";
+import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 
 import { FizzySymphonyError } from "./errors.js";
 
@@ -212,10 +212,15 @@ export function generateAnnotatedConfig(options = {}) {
     sdkContract = "",
     botUserId = "",
     webhook = {},
-    managedWebhookIdsByBoard = webhook.managed_webhook_ids_by_board ?? {}
+    managedWebhookIdsByBoard = webhook.managed_webhook_ids_by_board ?? {},
+    configDir = ".",
+    workspaceRepo = ".",
+    allowedRoots
   } = options;
 
   const boardEntries = boards?.length ? boards : [board];
+  const workspaceRepoPath = relativePathForConfig(configDir, workspaceRepo);
+  const safetyAllowedRoots = allowedRoots?.length ? allowedRoots : uniqueStrings([workspaceRepoPath, "."]);
   let template = readFileSync(TEMPLATE_PATH, "utf8");
   template = template.replace(/account: my-account/u, `account: ${yamlScalar(account)}`);
   template = template.replace(
@@ -229,6 +234,12 @@ export function generateAnnotatedConfig(options = {}) {
   template = template.replace(/package: ""/u, `package: ${yamlScalar(sdkPackage)}`);
   template = template.replace(/contract: ""/u, `contract: ${yamlScalar(sdkContract)}`);
   template = template.replace(/secret: \$FIZZY_WEBHOOK_SECRET/u, `secret: ${yamlScalar(webhook.secret_env ? `$${webhook.secret_env}` : "")}`);
+  template = template.replace(/default_repo: \./u, `default_repo: ${yamlScalar(workspaceRepoPath)}`);
+  template = template.replace(/\n      repo: \.\n/u, `\n      repo: ${yamlScalar(workspaceRepoPath)}\n`);
+  template = template.replace(
+    /  allowed_roots:\n(?:    - .+\n)+/u,
+    `  allowed_roots:\n${renderStringList(safetyAllowedRoots, 4)}\n`
+  );
 
   if (Object.hasOwn(webhook, "manage")) {
     template = template.replace(/manage: false/u, `manage: ${Boolean(webhook.manage)}`);
@@ -248,7 +259,10 @@ export function generateAnnotatedConfig(options = {}) {
 
 export async function writeAnnotatedConfig(configPath, options = {}) {
   await mkdir(dirname(configPath), { recursive: true });
-  const generated = generateAnnotatedConfig(options);
+  const generated = generateAnnotatedConfig({
+    ...options,
+    configDir: options.configDir ?? dirname(configPath)
+  });
   await writeFile(configPath, generated, "utf8");
   return { path: configPath, bytes: Buffer.byteLength(generated) };
 }
@@ -466,6 +480,11 @@ function renderStringMap(map, indent) {
     .join("\n");
 }
 
+function renderStringList(values, indent) {
+  const padding = " ".repeat(indent);
+  return values.map((value) => `${padding}- ${yamlScalar(value)}`).join("\n");
+}
+
 function isOptionalEnvironmentReference(path) {
   return path === "webhook.secret";
 }
@@ -500,6 +519,11 @@ function resolveFrom(base, value) {
   return isAbsolute(value) ? value : resolve(base, value);
 }
 
+function relativePathForConfig(configDir, path) {
+  const relativePath = relative(resolve(configDir), resolve(path));
+  return relativePath === "" ? "." : relativePath;
+}
+
 function isValidPortValue(value) {
   return value === "auto" || isTcpPort(value);
 }
@@ -516,6 +540,10 @@ function setPath(object, parts, value) {
     target = target[part];
   }
   target[parts.at(-1)] = value;
+}
+
+function uniqueStrings(values) {
+  return [...new Set(values.filter(Boolean))];
 }
 
 function yamlScalar(value) {

--- a/src/config.js
+++ b/src/config.js
@@ -203,32 +203,44 @@ export function generateAnnotatedConfig(options = {}) {
   const {
     account = "my-account",
     board = { id: "board_123", label: "Agent Playground" },
+    boards,
+    agentMaxConcurrent = 2,
+    boardMaxConcurrent = agentMaxConcurrent,
     runnerPreferred = "cli_app_server",
     runnerFallback = "cli_app_server",
     sdkPackage = "",
     sdkContract = "",
     botUserId = "",
-    webhook = {}
+    webhook = {},
+    managedWebhookIdsByBoard = webhook.managed_webhook_ids_by_board ?? {}
   } = options;
 
+  const boardEntries = boards?.length ? boards : [board];
   let template = readFileSync(TEMPLATE_PATH, "utf8");
   template = template.replace(/account: my-account/u, `account: ${yamlScalar(account)}`);
-  template = template.replace(/id: board_123/u, `id: ${yamlScalar(board.id)}`);
-  template = template.replace(/label: Agent Playground/u, `label: ${yamlScalar(board.label)}`);
+  template = template.replace(
+    /  entries:\n[\s\S]*?\nserver:/u,
+    `  entries:\n${renderBoardEntries(boardEntries, boardMaxConcurrent)}\nserver:`
+  );
+  template = template.replace(/\n  max_concurrent: 2\n/u, `\n  max_concurrent: ${agentMaxConcurrent}\n`);
   template = template.replace(/bot_user_id: ""/u, `bot_user_id: ${yamlScalar(botUserId)}`);
   template = template.replace(/preferred: sdk/u, `preferred: ${yamlScalar(runnerPreferred)}`);
   template = template.replace(/fallback: cli_app_server/u, `fallback: ${yamlScalar(runnerFallback)}`);
   template = template.replace(/package: ""/u, `package: ${yamlScalar(sdkPackage)}`);
   template = template.replace(/contract: ""/u, `contract: ${yamlScalar(sdkContract)}`);
+  template = template.replace(/secret: \$FIZZY_WEBHOOK_SECRET/u, `secret: ${yamlScalar(webhook.secret_env ? `$${webhook.secret_env}` : "")}`);
 
   if (Object.hasOwn(webhook, "manage")) {
     template = template.replace(/manage: false/u, `manage: ${Boolean(webhook.manage)}`);
   }
+  if (Object.keys(managedWebhookIdsByBoard).length > 0) {
+    template = template.replace(
+      /managed_webhook_ids_by_board: \{\}/u,
+      `managed_webhook_ids_by_board:\n${renderStringMap(managedWebhookIdsByBoard, 4)}`
+    );
+  }
   if (webhook.callback_url) {
     template = template.replace(/callback_url: ""/u, `callback_url: ${yamlScalar(webhook.callback_url)}`);
-  }
-  if (webhook.secret) {
-    template = template.replace(/secret: \$FIZZY_WEBHOOK_SECRET/u, `secret: ${yamlScalar(webhook.secret)}`);
   }
 
   return template;
@@ -408,6 +420,9 @@ function resolveEnvironmentReferences(value, env, path = "") {
     if (match) {
       const variable = match[1];
       if (!Object.hasOwn(env, variable)) {
+        if (isOptionalEnvironmentReference(path)) {
+          return "";
+        }
         throw new FizzySymphonyError("CONFIG_MISSING_ENV", `Missing environment variable ${variable}`, {
           variable,
           path
@@ -418,6 +433,41 @@ function resolveEnvironmentReferences(value, env, path = "") {
   }
 
   return value;
+}
+
+function renderBoardEntries(boards, maxConcurrent) {
+  return boards.map((board) => [
+    `    - id: ${yamlScalar(board.id)}`,
+    `      label: ${yamlScalar(board.label ?? board.name ?? board.id)}`,
+    "      enabled: true",
+    "      routing_mode: column_scoped",
+    "      defaults:",
+    "        backend: codex",
+    "        model: \"\"",
+    "        workspace: app",
+    "        persona: repo-agent",
+    "        unknown_managed_tag_policy: fail",
+    "        allowed_card_overrides:",
+    "          backend: false",
+    "          model: false",
+    "          workspace: false",
+    "          persona: false",
+    "          priority: true",
+    "          completion: false",
+    "        concurrency:",
+    `          max_concurrent: ${maxConcurrent}`
+  ].join("\n")).join("\n");
+}
+
+function renderStringMap(map, indent) {
+  const padding = " ".repeat(indent);
+  return Object.entries(map)
+    .map(([key, value]) => `${padding}${yamlScalar(key)}: ${yamlScalar(value)}`)
+    .join("\n");
+}
+
+function isOptionalEnvironmentReference(path) {
+  return path === "webhook.secret";
 }
 
 function resolveRelativePaths(config, configDir) {

--- a/src/setup.js
+++ b/src/setup.js
@@ -102,6 +102,7 @@ export async function runSetup(options = {}) {
     sdkPackage: runnerReport.kind === "sdk" ? runnerReport.package : "",
     sdkContract: runnerReport.kind === "sdk" ? runnerReport.contract : "",
     botUserId: options.botUserId ?? "",
+    workspaceRepo,
     webhook,
     managedWebhookIdsByBoard: Object.fromEntries(
       Object.entries(managedWebhooks).map(([boardId, managedWebhook]) => [boardId, managedWebhook.id])

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,9 +1,23 @@
 import { access } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join, resolve } from "node:path";
 
 import { writeAnnotatedConfig } from "./config.js";
 import { FizzySymphonyError } from "./errors.js";
 import { discoverGoldenTicketRoutes, isSupportedSdkRunner, managedTagsUsedByBoards, resolveManagedTags } from "./validation.js";
+
+const DEFAULT_WEBHOOK_ACTIONS = [
+  "card_assigned",
+  "card_closed",
+  "card_postponed",
+  "card_auto_postponed",
+  "card_board_changed",
+  "card_published",
+  "card_reopened",
+  "card_sent_back_to_triage",
+  "card_triaged",
+  "card_unassigned",
+  "comment_created"
+];
 
 export async function runSetup(options = {}) {
   const {
@@ -12,23 +26,39 @@ export async function runSetup(options = {}) {
     runner,
     env = process.env,
     workspaceRepo = ".",
-    webhook = {}
+    webhook = {},
+    prompts
   } = options;
 
   const identity = await validateIdentity(fizzy);
-  const account = selectAccount(identity, options.account);
+  const account = await selectAccount(identity, options.account, prompts);
 
   const boards = await fizzy.listBoards(account);
   const users = await fizzy.listUsers(account);
   const tags = await fizzy.listTags(account);
-  const selectedBoardIds = options.selectedBoardIds ?? boards.slice(0, 1).map((board) => board.id);
-  const entropy = await fizzy.getEntropy?.(account, selectedBoardIds);
   const runnerReport = await detectRunner(runner);
 
+  const setupMode = await selectSetupMode(options, prompts);
   const selectedBoards = [];
-  for (const boardId of selectedBoardIds) {
-    selectedBoards.push(await fizzy.getBoard(boardId));
+  let selectedBoardIds = [];
+  let starter = { created: false };
+
+  if (setupMode === "create_starter") {
+    const starterBoard = await createStarterBoard({ fizzy, account, workspaceRepo, options });
+    selectedBoards.push(starterBoard);
+    selectedBoardIds = [starterBoard.id];
+    starter = { created: true, board_id: starterBoard.id };
+  } else {
+    selectedBoardIds = await selectBoardIds(boards, options, prompts);
+    for (const boardId of selectedBoardIds) {
+      selectedBoards.push(await fizzy.getBoard(boardId));
+    }
+    if (setupMode === "adopt_starter") {
+      starter = { created: false, board_id: selectedBoardIds[0] };
+    }
   }
+
+  const entropy = await fizzy.getEntropy?.(account, selectedBoardIds);
   const resolvedTags = resolveManagedTags(tags, {
     required: ["agent-instructions", ...managedTagsUsedByBoards(selectedBoards)]
   });
@@ -40,31 +70,42 @@ export async function runSetup(options = {}) {
   });
 
   const managedWebhooks = {};
+  const warnings = (entropy?.warnings ?? []).map((warning) => ({
+    code: warning.code ?? "ENTROPY_WARNING",
+    message: warning.message ?? "Fizzy entropy warning.",
+    details: warning
+  }));
+
   if (webhook.manage) {
-    validateWebhookSetup(webhook);
+    warnings.push(...validateWebhookSetup(webhook));
     for (const boardId of selectedBoardIds) {
-      managedWebhooks[boardId] = await fizzy.ensureWebhook({
+      managedWebhooks[boardId] = await manageWebhookForBoard(fizzy, {
         account,
         board_id: boardId,
         callback_url: webhook.callback_url,
         secret: webhook.secret,
-        subscribed_actions: webhook.subscribed_actions
+        subscribed_actions: webhookActions(webhook)
       });
     }
   }
 
   await writeAnnotatedConfig(configPath, {
     account,
-    board: {
-      id: selectedBoards[0]?.id ?? "board_123",
-      label: selectedBoards[0]?.name ?? selectedBoards[0]?.label ?? "Agent Playground"
-    },
+    boards: selectedBoards.map((board) => ({
+      id: board.id,
+      label: board.name ?? board.label ?? board.id
+    })),
+    agentMaxConcurrent: starter.created || setupMode === "adopt_starter" ? 1 : 2,
+    boardMaxConcurrent: starter.created || setupMode === "adopt_starter" ? 1 : 2,
     runnerPreferred: runnerReport.kind === "sdk" ? "sdk" : "cli_app_server",
     runnerFallback: "cli_app_server",
     sdkPackage: runnerReport.kind === "sdk" ? runnerReport.package : "",
     sdkContract: runnerReport.kind === "sdk" ? runnerReport.contract : "",
     botUserId: options.botUserId ?? "",
-    webhook
+    webhook,
+    managedWebhookIdsByBoard: Object.fromEntries(
+      Object.entries(managedWebhooks).map(([boardId, managedWebhook]) => [boardId, managedWebhook.id])
+    )
   });
 
   return {
@@ -77,12 +118,9 @@ export async function runSetup(options = {}) {
     resolvedTags,
     routes,
     runner: runnerReport,
-    warnings: (entropy?.warnings ?? []).map((warning) => ({
-      code: warning.code ?? "ENTROPY_WARNING",
-      message: warning.message ?? "Fizzy entropy warning.",
-      details: warning
-    })),
+    warnings,
     managedWebhooks,
+    starter,
     env_used: {
       fizzy_token: Boolean(env.FIZZY_API_TOKEN)
     }
@@ -99,7 +137,7 @@ async function validateIdentity(fizzy) {
   }
 }
 
-function selectAccount(identity, requestedAccount) {
+async function selectAccount(identity, requestedAccount, prompts) {
   const accounts = identity.accounts ?? [];
   if (requestedAccount) {
     const match = accounts.find((account) => account.id === requestedAccount || account.name === requestedAccount);
@@ -115,7 +153,74 @@ function selectAccount(identity, requestedAccount) {
   if (!first) {
     throw new FizzySymphonyError("FIZZY_ACCOUNT_UNAVAILABLE", "Fizzy identity did not include any accounts.");
   }
-  return first.id ?? first.name;
+  const prompted = await prompts?.selectAccount?.(accounts);
+  if (prompted && typeof prompted === "object") return prompted.id ?? prompted.name;
+  return prompted ?? first.id ?? first.name;
+}
+
+async function selectSetupMode(options, prompts) {
+  if (options.setupMode) return options.setupMode;
+  return (await prompts?.selectSetupMode?.(["existing", "create_starter", "adopt_starter"])) ?? "existing";
+}
+
+async function selectBoardIds(boards, options, prompts) {
+  if (options.selectedBoardIds) return options.selectedBoardIds;
+  const prompted = await prompts?.selectBoards?.(boards);
+  if (prompted?.length) {
+    return prompted.map((board) => typeof board === "object" ? board.id : board);
+  }
+  const selected = boards.slice(0, 1).map((board) => board.id);
+  if (selected.length === 0) {
+    throw new FizzySymphonyError("FIZZY_BOARD_UNAVAILABLE", "Setup requires at least one selected Fizzy board.");
+  }
+  return selected;
+}
+
+async function createStarterBoard({ fizzy, account, workspaceRepo, options }) {
+  const name = options.starterBoardName ?? `Agent Playground: ${basename(resolve(workspaceRepo))}`;
+  const plan = {
+    account,
+    name,
+    columns: ["Ready for Agents", "Done"],
+    golden_ticket: {
+      title: "Repo Agent",
+      column: "Ready for Agents",
+      golden: true,
+      tags: ["agent-instructions", "codex", "move-to-done"]
+    },
+    smoke_test: Boolean(options.createSmokeTestCard)
+  };
+
+  if (fizzy.createStarterBoard) {
+    const created = await fizzy.createStarterBoard(plan);
+    const boardId = created.board?.id ?? created.id ?? created.board_id;
+    if (!boardId) {
+      throw new FizzySymphonyError("STARTER_BOARD_UNAVAILABLE", "Starter board creation did not return a board ID.");
+    }
+    return await fizzy.getBoard(boardId);
+  }
+
+  if (!fizzy.createBoard || !fizzy.createColumn || !fizzy.createCard) {
+    throw new FizzySymphonyError("STARTER_BOARD_UNAVAILABLE", "Fizzy client cannot create starter board resources.");
+  }
+
+  const board = await fizzy.createBoard({ account, name });
+  const ready = await fizzy.createColumn({ account, board_id: board.id, name: "Ready for Agents" });
+  await fizzy.createColumn({ account, board_id: board.id, name: "Done" });
+  const golden = await fizzy.createCard({
+    account,
+    board_id: board.id,
+    column_id: ready.id,
+    title: "Repo Agent",
+    tags: ["agent-instructions", "codex", "move-to-done"],
+    golden: true
+  });
+
+  if (fizzy.markGolden) {
+    await fizzy.markGolden({ account, board_id: board.id, card_id: golden.id });
+  }
+
+  return await fizzy.getBoard(board.id);
 }
 
 function validateBotUser(botUserId, users) {
@@ -162,6 +267,8 @@ async function detectRunner(runner) {
 }
 
 function validateWebhookSetup(webhook) {
+  const warnings = [];
+
   try {
     const url = new URL(webhook.callback_url);
     if (url.protocol !== "https:" || ["localhost", "127.0.0.1", "::1"].includes(url.hostname)) {
@@ -175,6 +282,66 @@ function validateWebhookSetup(webhook) {
   }
 
   if (!webhook.secret) {
-    throw new FizzySymphonyError("MANAGED_WEBHOOK_MISCONFIGURED", "Managed webhooks require a signing secret.");
+    warnings.push({
+      code: "WEBHOOK_SECRET_NOT_CONFIGURED",
+      message: "Managed webhook setup will continue without signature verification because no signing secret was configured.",
+      details: { manage: Boolean(webhook.manage), callback_url: webhook.callback_url }
+    });
   }
+
+  return warnings;
+}
+
+async function manageWebhookForBoard(fizzy, request) {
+  if (fizzy.ensureWebhook) {
+    return fizzy.ensureWebhook(request);
+  }
+
+  if (!fizzy.listWebhooks || !fizzy.createWebhook) {
+    throw new FizzySymphonyError("MANAGED_WEBHOOK_UNAVAILABLE", "Fizzy client cannot manage webhooks.");
+  }
+
+  const existing = await fizzy.listWebhooks({ account: request.account, board_id: request.board_id });
+  const match = (existing ?? []).find((webhook) => webhook.callback_url === request.callback_url);
+
+  if (!match) {
+    return fizzy.createWebhook(omitUndefined(request));
+  }
+
+  if (match.active === false || match.status === "inactive") {
+    if (!fizzy.reactivateWebhook) {
+      throw new FizzySymphonyError("MANAGED_WEBHOOK_UNAVAILABLE", "Fizzy client cannot reactivate inactive managed webhooks.");
+    }
+    return fizzy.reactivateWebhook({
+      ...omitUndefined(request),
+      webhook_id: match.id
+    });
+  }
+
+  if (!sameActions(match.subscribed_actions, request.subscribed_actions)) {
+    if (!fizzy.updateWebhook) {
+      throw new FizzySymphonyError("MANAGED_WEBHOOK_UNAVAILABLE", "Fizzy client cannot update managed webhook subscriptions.");
+    }
+    return fizzy.updateWebhook({
+      ...omitUndefined(request),
+      webhook_id: match.id
+    });
+  }
+
+  return match;
+}
+
+function webhookActions(webhook) {
+  return webhook.subscribed_actions?.length ? webhook.subscribed_actions : DEFAULT_WEBHOOK_ACTIONS;
+}
+
+function sameActions(left = [], right = []) {
+  const normalizedLeft = [...left].sort();
+  const normalizedRight = [...right].sort();
+  return normalizedLeft.length === normalizedRight.length &&
+    normalizedLeft.every((action, index) => action === normalizedRight[index]);
+}
+
+function omitUndefined(object) {
+  return Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined && value !== ""));
 }

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,6 +1,6 @@
 import { access } from "node:fs/promises";
 import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { FizzySymphonyError, issue } from "./errors.js";
 
@@ -262,8 +262,9 @@ export async function validateStartup({ config, fizzy, runner }) {
     }
   }
 
-  validateManagedWebhook(config, errors);
+  validateManagedWebhook(config, errors, warnings);
 
+  await validateWorkspaceRoots(config, errors);
   await validateWorkflowFiles(config, errors);
 
   try {
@@ -390,7 +391,7 @@ function validateLocalConfig(config, errors) {
   }
 }
 
-function validateManagedWebhook(config, errors) {
+function validateManagedWebhook(config, errors, warnings) {
   if (!config.webhook?.manage) return;
   const callback = config.webhook.callback_url ?? "";
   const secret = config.webhook.secret ?? "";
@@ -406,11 +407,57 @@ function validateManagedWebhook(config, errors) {
     validUrl = false;
   }
 
-  if (!validUrl || !secret) {
-    errors.push(issue("MANAGED_WEBHOOK_MISCONFIGURED", "Managed webhooks require a public HTTPS callback_url and secret.", {
+  if (!validUrl) {
+    errors.push(issue("MANAGED_WEBHOOK_MISCONFIGURED", "Managed webhooks require a public HTTPS callback_url.", {
       callback_url: callback,
       has_secret: Boolean(secret)
     }));
+  }
+
+  if (validUrl && !secret) {
+    warnings.push(issue(
+      "WEBHOOK_SECRET_NOT_CONFIGURED",
+      "Managed webhook setup has no signing secret; webhook signature verification will be disabled.",
+      { callback_url: callback }
+    ));
+  }
+}
+
+async function validateWorkspaceRoots(config, errors) {
+  const allowedRoots = (config.safety?.allowed_roots ?? []).filter(Boolean).map((root) => resolve(root));
+  const registry = config.workspaces?.registry ?? {};
+
+  if (allowedRoots.length > 0) {
+    const paths = [
+      ["workspaces.root", config.workspaces?.root],
+      ["workspaces.metadata_root", config.workspaces?.metadata_root],
+      ...Object.entries(registry).flatMap(([name, workspace]) => [
+        [`workspaces.registry.${name}.repo`, workspace.repo],
+        [`workspaces.registry.${name}.worktree_root`, workspace.worktree_root]
+      ])
+    ];
+
+    for (const [path, value] of paths) {
+      if (value && !isInsideAnyRoot(value, allowedRoots)) {
+        errors.push(issue("UNSAFE_WORKSPACE_ROOT", "Configured workspace path is outside safety.allowed_roots.", {
+          path,
+          value,
+          allowed_roots: allowedRoots
+        }));
+      }
+    }
+  }
+
+  for (const [name, workspace] of Object.entries(registry)) {
+    if (!workspace.repo) continue;
+    try {
+      await access(workspace.repo);
+    } catch {
+      errors.push(issue("SOURCE_REPO_UNAVAILABLE", "Configured source repository is not accessible.", {
+        workspace: name,
+        repo: workspace.repo
+      }));
+    }
   }
 }
 
@@ -704,6 +751,14 @@ function enabledBoardEntries(config) {
 function validPort(port) {
   if (port === "auto") return true;
   return Number.isInteger(port) && port > 0 && port <= 65535;
+}
+
+function isInsideAnyRoot(path, allowedRoots) {
+  const resolvedPath = resolve(path);
+  return allowedRoots.some((root) => {
+    const relativePath = relative(root, resolvedPath);
+    return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+  });
 }
 
 function normalizedTags(card) {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -179,7 +179,10 @@ function minimalConfig() {
 test("generateAnnotatedConfig returns the full commented template with Task 1 fields", () => {
   const generated = generateAnnotatedConfig({
     account: "team",
-    board: { id: "board_ready", label: "Ready Board" },
+    boards: [
+      { id: "board_ready", label: "Ready Board" },
+      { id: "board_docs", label: "Docs Board" }
+    ],
     runnerPreferred: "cli_app_server"
   });
 
@@ -193,6 +196,25 @@ test("generateAnnotatedConfig returns the full commented template with Task 1 fi
   assert.match(generated, /preferred: cli_app_server/);
   assert.match(generated, /id: board_ready/);
   assert.match(generated, /label: Ready Board/);
+  assert.match(generated, /id: board_docs/);
+  assert.match(generated, /label: Docs Board/);
+  assert.match(generated, /secret: ""/);
+});
+
+test("generateAnnotatedConfig never writes raw webhook secrets and keeps webhook secret optional", () => {
+  const generated = generateAnnotatedConfig({
+    account: "team",
+    board: { id: "board_ready", label: "Ready Board" },
+    webhook: {
+      manage: true,
+      callback_url: "https://example.test/fizzy",
+      secret: "do-not-write-me"
+    }
+  });
+
+  assert.doesNotMatch(generated, /do-not-write-me/);
+  assert.match(generated, /secret: ""/);
+  assert.match(generated, /callback_url: https:\/\/example.test\/fizzy/);
 });
 
 test("writeAnnotatedConfig creates parent directories and writes the generated template", async () => {
@@ -322,14 +344,14 @@ test("loadConfig reads JSON and generated YAML config files for the CLI", async 
 
   const loaded = await loadConfig(jsonPath, { env: { FIZZY_API_TOKEN: "x" } });
   const loadedYaml = await loadConfig(yamlPath, {
-    env: { FIZZY_API_TOKEN: "x", FIZZY_WEBHOOK_SECRET: "webhook-secret" }
+    env: { FIZZY_API_TOKEN: "x" }
   });
 
   assert.equal(loaded.fizzy.token, "x");
   assert.equal(loadedYaml.fizzy.account, "acct");
   assert.equal(loadedYaml.boards.entries[0].id, "board_1");
   assert.equal(loadedYaml.runner.preferred, "cli_app_server");
-  assert.equal(loadedYaml.webhook.secret, "webhook-secret");
+  assert.equal(loadedYaml.webhook.secret, "");
 });
 
 test("CLI exposes setup template generation, parse-only validation, and daemon stub commands", async () => {
@@ -369,15 +391,100 @@ test("CLI exposes setup template generation, parse-only validation, and daemon s
   });
 });
 
+test("CLI setup runs the live injected-client setup path", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-cli-live-"));
+  await writeFile(join(dir, "WORKFLOW.md"), "# Workflow\n", "utf8");
+  const configPath = join(dir, "config.yml");
+
+  const setup = await runCli([
+    "setup",
+    "--config",
+    configPath,
+    "--account",
+    "acct_1",
+    "--board",
+    "board_1",
+    "--workspace-repo",
+    dir
+  ], {
+    env: { ...process.env, FIZZY_API_TOKEN: "token" },
+    fizzy: fakeLiveSetupFizzy(),
+    runner: fakeLiveSetupRunner()
+  });
+
+  assert.equal(setup.exitCode, 0);
+  const payload = JSON.parse(setup.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.account, "acct_1");
+  assert.deepEqual(payload.boards, ["board_1"]);
+  assert.match(await readFile(configPath, "utf8"), /id: board_1/);
+});
+
 async function runCli(args, options = {}) {
   let stdout = "";
   let stderr = "";
   const exitCode = await cliMain(args, {
     env: options.env ?? process.env,
+    fizzy: options.fizzy,
+    runner: options.runner,
+    prompts: options.prompts,
     stdout: { write: (chunk) => { stdout += chunk; } },
     stderr: { write: (chunk) => { stderr += chunk; } }
   });
   return { exitCode, stdout, stderr };
+}
+
+function fakeLiveSetupFizzy() {
+  const board = {
+    id: "board_1",
+    name: "Agents",
+    columns: [
+      { id: "col_ready", name: "Ready for Agents" },
+      { id: "col_done", name: "Done" }
+    ],
+    cards: [
+      {
+        id: "golden_1",
+        title: "Repo Agent",
+        golden: true,
+        column_id: "col_ready",
+        tags: ["agent-instructions", "codex", "move-to-done"]
+      }
+    ]
+  };
+
+  return {
+    async getIdentity() {
+      return { accounts: [{ id: "acct_1", name: "Team Account" }], user: { id: "user_1" } };
+    },
+    async listBoards() {
+      return [board];
+    },
+    async listUsers() {
+      return [{ id: "user_1", name: "Human" }];
+    },
+    async listTags() {
+      return [
+        { id: "tag_agent", name: "agent-instructions" },
+        { id: "tag_codex", name: "codex" },
+        { id: "tag_done", name: "move-to-done" }
+      ];
+    },
+    async getBoard() {
+      return board;
+    },
+    async getEntropy() {
+      return { warnings: [] };
+    }
+  };
+}
+
+function fakeLiveSetupRunner() {
+  return {
+    async detect() {
+      return { kind: "cli_app_server", available: true, command: "codex" };
+    }
+  };
 }
 
 export { minimalConfig };

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -4,7 +4,9 @@ import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
+import { loadConfig } from "../src/config.js";
 import { runSetup } from "../src/setup.js";
+import { validateStartup } from "../src/validation.js";
 
 function boardFixture(overrides = {}) {
   return {
@@ -301,6 +303,34 @@ test("runSetup writes every selected board to the generated config", async () =>
   assert.match(written, /label: Agent Board/);
   assert.match(written, /id: board_2/);
   assert.match(written, /label: Docs Board/);
+});
+
+test("runSetup writes default config paths that resolve to the selected workspace repo", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-default-config-paths-"));
+  await writeFile(join(dir, "WORKFLOW.md"), "# Workflow\n", "utf8");
+  const configPath = join(dir, ".fizzy-symphony", "config.yml");
+
+  await runSetup({
+    configPath,
+    fizzy: fakeFizzy(),
+    runner: fakeRunner(),
+    account: "acct_1",
+    selectedBoardIds: ["board_1"],
+    workspaceRepo: dir,
+    env: { FIZZY_API_TOKEN: "token" }
+  });
+
+  const config = await loadConfig(configPath, { env: { FIZZY_API_TOKEN: "token" } });
+  assert.equal(config.workspaces.default_repo, dir);
+  assert.equal(config.workspaces.registry.app.repo, dir);
+  assert.ok(config.safety.allowed_roots.includes(dir));
+
+  const startup = await validateStartup({
+    config,
+    fizzy: fakeFizzy(),
+    runner: fakeRunner()
+  });
+  assert.equal(startup.ok, true, JSON.stringify(startup.errors));
 });
 
 test("runSetup manages webhooks by listing, creating, updating, and reactivating without requiring an optional secret", async () => {

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 
 import { runSetup } from "../src/setup.js";
 
-function boardFixture() {
+function boardFixture(overrides = {}) {
   return {
     id: "board_1",
     name: "Agent Board",
@@ -23,13 +23,35 @@ function boardFixture() {
         tags: ["agent-instructions", "backend-codex", "move-to-done"]
       }
     ],
-    entropy: { auto_postpone_enabled: true, auto_postpone_after_ms: 3600000 }
+    entropy: { auto_postpone_enabled: true, auto_postpone_after_ms: 3600000 },
+    ...overrides
+  };
+}
+
+function secondBoardFixture(overrides = {}) {
+  return {
+    id: "board_2",
+    name: "Docs Board",
+    columns: [
+      { id: "col_docs_ready", name: "Ready for Agents" },
+      { id: "col_docs_done", name: "Done" }
+    ],
+    cards: [
+      {
+        id: "golden_docs",
+        title: "Docs Agent",
+        golden: true,
+        column_id: "col_docs_ready",
+        tags: ["agent-instructions", "codex", "move-to-done"]
+      }
+    ],
+    ...overrides
   };
 }
 
 function fakeFizzy(overrides = {}) {
   const calls = [];
-  const board = overrides.board ?? boardFixture();
+  const boards = overrides.boards ?? [overrides.board ?? boardFixture()];
   return {
     calls,
     async getIdentity() {
@@ -42,7 +64,7 @@ function fakeFizzy(overrides = {}) {
     },
     async listBoards(account) {
       calls.push(["listBoards", account]);
-      return [board];
+      return boards;
     },
     async listUsers(account) {
       calls.push(["listUsers", account]);
@@ -52,9 +74,94 @@ function fakeFizzy(overrides = {}) {
       calls.push(["listTags", account]);
       return overrides.tags ?? [
         { id: "tag_agent", name: "agent-instructions" },
+        { id: "tag_codex_alias", name: "codex" },
         { id: "tag_codex", name: "backend-codex" },
         { id: "tag_done", name: "move-to-done" }
       ];
+    },
+    async getBoard(boardId) {
+      calls.push(["getBoard", boardId]);
+      const board = boards.find((candidate) => candidate.id === boardId);
+      if (!board) throw new Error(`missing board ${boardId}`);
+      return board;
+    },
+    async getEntropy(account, boardIds) {
+      calls.push(["getEntropy", account, boardIds]);
+      return {
+        warnings: [
+          { code: "ENTROPY_AUTO_POSTPONE", message: "Board auto-postpone is enabled", board_id: boards[0]?.id }
+        ]
+      };
+    },
+    async ensureWebhook(request) {
+      calls.push(["ensureWebhook", request]);
+      return { id: "webhook_1", status: "active" };
+    }
+  };
+}
+
+function fakeStarterFizzy() {
+  const calls = [];
+  const board = {
+    id: "starter_board",
+    name: "Agent Playground: repo",
+    columns: [],
+    cards: []
+  };
+
+  return {
+    calls,
+    async getIdentity() {
+      calls.push(["getIdentity"]);
+      return {
+        user: { id: "user_current" },
+        accounts: [{ id: "acct_1", name: "Team Account" }]
+      };
+    },
+    async listBoards(account) {
+      calls.push(["listBoards", account]);
+      return [];
+    },
+    async listUsers(account) {
+      calls.push(["listUsers", account]);
+      return [{ id: "bot_1", name: "Bot" }, { id: "user_current", name: "Human" }];
+    },
+    async listTags(account) {
+      calls.push(["listTags", account]);
+      return [
+        { id: "tag_agent", name: "agent-instructions" },
+        { id: "tag_codex", name: "codex" },
+        { id: "tag_done", name: "move-to-done" }
+      ];
+    },
+    async createBoard(request) {
+      calls.push(["createBoard", request]);
+      return { id: board.id, name: request.name };
+    },
+    async createColumn(request) {
+      calls.push(["createColumn", request]);
+      const id = request.name === "Ready for Agents" ? "starter_ready" : "starter_done";
+      const column = { id, name: request.name };
+      board.columns.push(column);
+      return column;
+    },
+    async createCard(request) {
+      calls.push(["createCard", request]);
+      const card = {
+        id: "starter_golden",
+        title: request.title,
+        golden: Boolean(request.golden),
+        column_id: request.column_id,
+        tags: request.tags
+      };
+      board.cards.push(card);
+      return card;
+    },
+    async markGolden(request) {
+      calls.push(["markGolden", request]);
+      const card = board.cards.find((candidate) => candidate.id === request.card_id);
+      if (card) card.golden = true;
+      return { ok: true };
     },
     async getBoard(boardId) {
       calls.push(["getBoard", boardId]);
@@ -62,15 +169,7 @@ function fakeFizzy(overrides = {}) {
     },
     async getEntropy(account, boardIds) {
       calls.push(["getEntropy", account, boardIds]);
-      return {
-        warnings: [
-          { code: "ENTROPY_AUTO_POSTPONE", message: "Board auto-postpone is enabled", board_id: board.id }
-        ]
-      };
-    },
-    async ensureWebhook(request) {
-      calls.push(["ensureWebhook", request]);
-      return { id: "webhook_1", status: "active" };
+      return { warnings: [] };
     }
   };
 }
@@ -112,7 +211,7 @@ test("runSetup validates Fizzy identity, lists setup inputs, validates board rou
   assert.equal(result.warnings[0].code, "ENTROPY_AUTO_POSTPONE");
   assert.deepEqual(
     fizzy.calls.map((call) => call[0]),
-    ["getIdentity", "listBoards", "listUsers", "listTags", "getEntropy", "getBoard"]
+    ["getIdentity", "listBoards", "listUsers", "listTags", "getBoard", "getEntropy"]
   );
 
   const written = await readFile(configPath, "utf8");
@@ -120,6 +219,176 @@ test("runSetup validates Fizzy identity, lists setup inputs, validates board rou
   assert.match(written, /account: acct_1/);
   assert.match(written, /id: board_1/);
   assert.match(written, /preferred: cli_app_server/);
+});
+
+test("runSetup creates a starter board with native golden route defaults and writes max concurrency one", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-starter-create-"));
+  await writeFile(join(dir, "WORKFLOW.md"), "# Workflow\n", "utf8");
+  const configPath = join(dir, ".fizzy-symphony", "config.yml");
+  const fizzy = fakeStarterFizzy();
+
+  const result = await runSetup({
+    configPath,
+    fizzy,
+    runner: fakeRunner(),
+    account: "acct_1",
+    setupMode: "create_starter",
+    starterBoardName: "Agent Playground: repo",
+    workspaceRepo: dir,
+    env: { FIZZY_API_TOKEN: "token" }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.starter.created, true);
+  assert.equal(result.boards[0].id, "starter_board");
+  assert.deepEqual(result.boards[0].columns.map((column) => column.name), ["Ready for Agents", "Done"]);
+  assert.deepEqual(result.boards[0].cards[0], {
+    id: "starter_golden",
+    title: "Repo Agent",
+    golden: true,
+    column_id: "starter_ready",
+    tags: ["agent-instructions", "codex", "move-to-done"]
+  });
+  assert.deepEqual(
+    fizzy.calls.filter((call) => ["createBoard", "createColumn", "createCard", "markGolden"].includes(call[0])).map((call) => call[0]),
+    ["createBoard", "createColumn", "createColumn", "createCard", "markGolden"]
+  );
+
+  const written = await readFile(configPath, "utf8");
+  assert.match(written, /id: starter_board/);
+  assert.match(written, /max_concurrent: 1/);
+});
+
+test("runSetup adopts an existing starter board and keeps starter concurrency defaults", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-starter-adopt-"));
+  await writeFile(join(dir, "WORKFLOW.md"), "# Workflow\n", "utf8");
+  const configPath = join(dir, "config.yml");
+
+  const result = await runSetup({
+    configPath,
+    fizzy: fakeFizzy(),
+    runner: fakeRunner(),
+    account: "acct_1",
+    setupMode: "adopt_starter",
+    selectedBoardIds: ["board_1"],
+    workspaceRepo: dir,
+    env: { FIZZY_API_TOKEN: "token" }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.starter.created, false);
+  assert.equal(result.routes[0].completion.policy, "move_to_column");
+  assert.match(await readFile(configPath, "utf8"), /max_concurrent: 1/);
+});
+
+test("runSetup writes every selected board to the generated config", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-multiboard-"));
+  await writeFile(join(dir, "WORKFLOW.md"), "# Workflow\n", "utf8");
+  const configPath = join(dir, ".fizzy-symphony", "config.yml");
+
+  await runSetup({
+    configPath,
+    fizzy: fakeFizzy({ boards: [boardFixture(), secondBoardFixture()] }),
+    runner: fakeRunner(),
+    account: "acct_1",
+    selectedBoardIds: ["board_1", "board_2"],
+    workspaceRepo: dir,
+    env: { FIZZY_API_TOKEN: "token" }
+  });
+
+  const written = await readFile(configPath, "utf8");
+  assert.match(written, /id: board_1/);
+  assert.match(written, /label: Agent Board/);
+  assert.match(written, /id: board_2/);
+  assert.match(written, /label: Docs Board/);
+});
+
+test("runSetup manages webhooks by listing, creating, updating, and reactivating without requiring an optional secret", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-managed-webhooks-"));
+  await writeFile(join(dir, "WORKFLOW.md"), "# Workflow\n", "utf8");
+  const boards = [
+    boardFixture(),
+    secondBoardFixture(),
+    secondBoardFixture({ id: "board_3", name: "Third Board", cards: [
+      {
+        id: "golden_3",
+        title: "Third Agent",
+        golden: true,
+        column_id: "col_docs_ready",
+        tags: ["agent-instructions", "codex", "move-to-done"]
+      }
+    ] })
+  ];
+  const fizzy = fakeFizzy({ boards });
+  fizzy.ensureWebhook = undefined;
+  fizzy.listWebhooks = async (request) => {
+    fizzy.calls.push(["listWebhooks", request]);
+    if (request.board_id === "board_1") return [];
+    if (request.board_id === "board_2") {
+      return [{ id: "webhook_inactive", callback_url: "https://example.test/fizzy", active: false, subscribed_actions: ["comment_created"] }];
+    }
+    return [{ id: "webhook_stale", callback_url: "https://example.test/fizzy", active: true, subscribed_actions: ["card_closed"] }];
+  };
+  fizzy.createWebhook = async (request) => {
+    fizzy.calls.push(["createWebhook", request]);
+    return { id: `created_${request.board_id}`, active: true };
+  };
+  fizzy.updateWebhook = async (request) => {
+    fizzy.calls.push(["updateWebhook", request]);
+    return { id: request.webhook_id, active: true };
+  };
+  fizzy.reactivateWebhook = async (request) => {
+    fizzy.calls.push(["reactivateWebhook", request]);
+    return { id: request.webhook_id, active: true };
+  };
+
+  const result = await runSetup({
+    configPath: join(dir, "config.yml"),
+    fizzy,
+    runner: fakeRunner(),
+    account: "acct_1",
+    selectedBoardIds: ["board_1", "board_2", "board_3"],
+    workspaceRepo: dir,
+    webhook: {
+      manage: true,
+      callback_url: "https://example.test/fizzy",
+      subscribed_actions: ["comment_created"]
+    },
+    env: { FIZZY_API_TOKEN: "token" }
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(Object.keys(result.managedWebhooks), ["board_1", "board_2", "board_3"]);
+  assert.ok(result.warnings.some((warning) => warning.code === "WEBHOOK_SECRET_NOT_CONFIGURED"));
+  assert.deepEqual(
+    fizzy.calls.filter((call) => ["listWebhooks", "createWebhook", "updateWebhook", "reactivateWebhook"].includes(call[0])).map((call) => call[0]),
+    ["listWebhooks", "createWebhook", "listWebhooks", "reactivateWebhook", "listWebhooks", "updateWebhook"]
+  );
+});
+
+test("runSetup rejects unsafe existing golden-ticket structure before writing config", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-unsafe-golden-"));
+  await writeFile(join(dir, "WORKFLOW.md"), "# Workflow\n", "utf8");
+  const configPath = join(dir, "config.yml");
+
+  await assert.rejects(
+    () => runSetup({
+      configPath,
+      fizzy: fakeFizzy({
+        board: boardFixture({
+          cards: [{ id: "tag_only", golden: false, column_id: "col_ready", tags: ["agent-instructions", "move-to-done"] }]
+        })
+      }),
+      runner: fakeRunner(),
+      account: "acct_1",
+      selectedBoardIds: ["board_1"],
+      workspaceRepo: dir,
+      env: { FIZZY_API_TOKEN: "token" }
+    }),
+    (error) => error.code === "TAG_ONLY_INSTRUCTION_CARD"
+  );
+
+  await assert.rejects(() => readFile(configPath, "utf8"));
 });
 
 test("runSetup falls back to cli_app_server when SDK detection lacks an exact package and contract", async () => {

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -525,6 +525,22 @@ test("validateStartup returns structured errors for unsafe startup state", async
   assert.deepEqual(report.warnings.map((warning) => warning.code), ["ENTROPY_UNKNOWN"]);
 });
 
+test("validateStartup allows managed webhooks without an optional signing secret and reports the risk as a warning", async () => {
+  const { config } = await parsedConfig();
+  config.webhook.manage = true;
+  config.webhook.callback_url = "https://example.test/fizzy";
+  config.webhook.secret = "";
+
+  const report = await validateStartup({
+    config,
+    fizzy: fakeFizzy(),
+    runner: fakeRunner()
+  });
+
+  assert.equal(report.ok, true);
+  assert.ok(report.warnings.some((warning) => warning.code === "WEBHOOK_SECRET_NOT_CONFIGURED"));
+});
+
 test("validateStartup detects missing secrets, invalid Fizzy access, invalid bot user, managed webhook issues, bad server port, bad claim mode, and unsafe cleanup", async () => {
   const { config } = await parsedConfig();
   config.fizzy.token = "";
@@ -553,6 +569,24 @@ test("validateStartup detects missing secrets, invalid Fizzy access, invalid bot
     "INVALID_BOT_USER",
     "MANAGED_WEBHOOK_MISCONFIGURED"
   ]);
+});
+
+test("validateStartup rejects configured workspace repositories outside allowed roots", async () => {
+  const { config, dir } = await parsedConfig();
+  const outside = await mkdtemp(join(tmpdir(), "fizzy-symphony-outside-root-"));
+  await writeFile(join(outside, "WORKFLOW.md"), "# Workflow\n", "utf8");
+  config.safety.allowed_roots = [dir];
+  config.workspaces.registry.app.repo = outside;
+  config.workspaces.registry.app.worktree_root = join(outside, "worktrees");
+
+  const report = await validateStartup({
+    config,
+    fizzy: fakeFizzy(),
+    runner: fakeRunner()
+  });
+
+  assert.equal(report.ok, false);
+  assert.ok(errorCodes(report).includes("UNSAFE_WORKSPACE_ROOT"));
 });
 
 test("validateStartup reports missing WORKFLOW.md when fallback is disabled", async () => {


### PR DESCRIPTION
## Summary
- Extend injected setup to support existing-board validation, starter board creation/adoption, prompt-selectable accounts/boards, multi-board config generation, and managed webhook create/update/reactivate flows.
- Wire CLI setup to the live injected-client setup path while preserving --template-only generation.
- Keep webhook signing secrets optional and out of generated config while surfacing no-secret webhook warnings.
- Add startup validation for managed webhook warnings and workspace roots outside allowed safety roots.

## Checks
- npm test (157 tests)
- git diff --check