### PR TITLE
Replace daemon stub with runnable reconciliation loop

### DIFF
--- a/bin/fizzy-symphony.js
+++ b/bin/fizzy-symphony.js
@@ -3,6 +3,7 @@
 import { fileURLToPath } from "node:url";
 
 import { loadConfig, writeAnnotatedConfig } from "../src/config.js";
+import { startDaemon } from "../src/daemon.js";
 import { isFizzySymphonyError } from "../src/errors.js";
 import { runStatusCommand } from "../src/status-cli.js";
 import { discoverStatusEndpoints } from "../src/status-discovery.js";
@@ -16,7 +17,7 @@ export async function main(args = process.argv.slice(2), io = defaultIo()) {
     } else if (command === "validate") {
       await validateCommand(args.slice(1), io);
     } else if (command === "daemon") {
-      daemonCommand(io);
+      await daemonCommand(args.slice(1), io);
     } else if (command === "status") {
       if (args.includes("--config")) {
         await statusDiscoveryCommand(args.slice(1), io);
@@ -73,13 +74,25 @@ async function validateCommand(args, io) {
   io.stdout.write(`${JSON.stringify({ ok: true, mode: "parse-only" })}\n`);
 }
 
-function daemonCommand(io) {
+async function daemonCommand(args, io) {
+  const configPath = optionValue(args, "--config") ?? ".fizzy-symphony/config.json";
+  const daemon = await startDaemon({
+    configPath,
+    env: io.env ?? process.env,
+    signalProcess: io.signalProcess ?? process,
+    ...(io.daemonOptions ?? {})
+  });
+
   io.stdout.write(`${JSON.stringify({
     ok: true,
     command: "daemon",
-    status: "stub",
-    message: "Later tasks implement the daemon loop."
+    status: "running",
+    instance_id: daemon.status.status().instance.id,
+    endpoint: daemon.endpoint
   })}\n`);
+
+  await io.daemonStarted?.(daemon);
+  await daemon.stopped;
 }
 
 function optionValue(args, name) {
@@ -93,7 +106,7 @@ function usage(exitCode, io) {
     "Usage:",
     "  fizzy-symphony setup --template-only [--config path]",
     "  fizzy-symphony validate --parse-only [--config path]",
-    "  fizzy-symphony daemon",
+    "  fizzy-symphony daemon [--config path]",
     "  fizzy-symphony status [--config path] [--instance id]",
     "  fizzy-symphony status [--registry-dir path] [--endpoint url]"
   ].join("\n");

--- a/src/config.js
+++ b/src/config.js
@@ -628,5 +628,5 @@ function parseYamlScalar(value) {
 }
 
 function isFizzySymphonyError(error) {
-  return error instanceof FizzySymphonyError || Boolean(error?.code);
+  return error instanceof FizzySymphonyError;
 }

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -1,0 +1,484 @@
+import { loadConfig } from "./config.js";
+import { FizzySymphonyError } from "./errors.js";
+import { startLocalInstance } from "./instance-registry.js";
+import { createLocalHttpHandler, createWebhookHintQueue } from "./server.js";
+import { createStatusStore } from "./status.js";
+import { validateStartup } from "./validation.js";
+import { performStartupRecovery } from "./recovery.js";
+import { createReconciliationScheduler } from "./scheduler.js";
+import { runReconciliationTick } from "./reconciler.js";
+import { routeCard } from "./router.js";
+import { createBoardClaimStore } from "./claims.js";
+import { createOrchestratorState } from "./orchestrator-state.js";
+import { loadWorkflow } from "./workflow.js";
+import {
+  prepareWorkspace,
+  resolveWorkspaceIdentity
+} from "./workspace.js";
+import { createFakeCodexRunner } from "./runner-contract.js";
+
+export async function startDaemon(options = {}) {
+  const {
+    configPath = ".fizzy-symphony/config.json",
+    env = process.env,
+    dependencies = {},
+    schedulerOptions = {},
+    signalProcess = null,
+    now = () => new Date()
+  } = options;
+
+  const config = await loadConfig(configPath, { env });
+  const webhookHints = dependencies.webhookHints ?? createWebhookHintQueue();
+  let status = null;
+  const statusProxy = {
+    health: () => status?.health?.() ?? { live: true, status: "live", ready: false },
+    ready: () => status?.ready?.() ?? { ready: false, status: "not_ready", blockers: [] },
+    status: () => status?.status?.() ?? {}
+  };
+
+  const requestListener = createLocalHttpHandler({
+    config,
+    status: statusProxy,
+    enqueueWebhookHint: webhookHints.enqueue,
+    now,
+    logger: dependencies.logger
+  });
+  const instance = await startLocalInstance(config, {
+    configPath,
+    requestListener,
+    now: currentDate(now),
+    pid: signalProcess?.pid ?? process.pid,
+    isProcessLive: dependencies.isProcessLive
+  });
+
+  let scheduler = null;
+  let uninstallSignals = () => {};
+  let stopping = false;
+  let resolveStopped;
+  let rejectStopped;
+  const stopped = new Promise((resolve, reject) => {
+    resolveStopped = resolve;
+    rejectStopped = reject;
+  });
+
+  try {
+    status = createStatusStore({
+      config,
+      instance: {
+        ...instance.identity,
+        endpoint: instance.endpoint
+      },
+      pid: signalProcess?.pid ?? process.pid,
+      startedAt: currentDate(now)
+    });
+
+    const fizzy = await callFactory(dependencies.fizzyFactory, { config, status }) ?? createDefaultFizzy(config);
+    const rawRunner = await callFactory(dependencies.runnerFactory, { config, status }) ?? createFakeCodexRunner();
+    const runner = createCancellableRunner(rawRunner);
+    const validation = await validateStartup({ config, fizzy, runner });
+    status.recordStartupValidation(validation);
+    status.updateRunnerHealth(validation.runnerHealth ?? { status: "unknown", kind: config.runner?.preferred ?? "unknown" });
+    status.setRoutes(validation.routes ?? []);
+
+    if (!validation.ok) {
+      await writeSnapshot(status, config);
+      await instance.cleanup();
+      const error = new FizzySymphonyError("STARTUP_VALIDATION_FAILED", "Startup validation failed.", {
+        errors: validation.errors,
+        warnings: validation.warnings
+      });
+      throw error;
+    }
+
+    const claims = await callFactory(dependencies.claimsFactory, { config, fizzy, status }) ??
+      createDefaultClaims({ config, fizzy, status });
+    const workspaceManager = await callFactory(dependencies.workspaceManagerFactory, { config, status }) ??
+      createDefaultWorkspaceManager();
+    const workflowLoader = await callFactory(dependencies.workflowLoaderFactory, { config, status }) ??
+      createDefaultWorkflowLoader();
+    const router = await callFactory(dependencies.routerFactory, { config, status }) ??
+      createDefaultRouter({ config, routes: () => status.status().routes });
+    const orchestratorState = await callFactory(dependencies.orchestratorStateFactory, { config, claims, runner }) ??
+      createOrchestratorState({ config, claims, runner });
+
+    const recoveryRunner = dependencies.recoveryFactory
+      ? await dependencies.recoveryFactory({ config, status, fizzy, orchestratorState })
+      : performStartupRecovery;
+    const recovery = await recoveryRunner({
+      config,
+      status,
+      inspectInstances: async () => instance.registryReport
+    });
+    status.recordStartupRecovery(recovery);
+    if ((recovery.errors ?? []).length > 0) {
+      await writeSnapshot(status, config);
+      await instance.cleanup();
+      const error = new FizzySymphonyError("STARTUP_RECOVERY_FAILED", "Startup recovery failed.", {
+        errors: recovery.errors,
+        warnings: recovery.warnings
+      });
+      throw error;
+    }
+
+    scheduler = createReconciliationScheduler({
+      intervalMs: config.polling?.interval_ms,
+      immediate: schedulerOptions.immediate,
+      timers: schedulerOptions.timers,
+      hints: webhookHints,
+      runTick: ({ webhookEvents }) => runReconciliationTick({
+        config,
+        status,
+        fizzy,
+        router,
+        claims,
+        workspaceManager,
+        workflowLoader,
+        runner,
+        orchestratorState,
+        routes: status.status().routes,
+        webhookEvents,
+        now
+      }),
+      snapshot: () => writeSnapshot(status, config)
+    });
+
+    async function stop(reason = "shutdown") {
+      if (stopping) return stopped;
+      stopping = true;
+      uninstallSignals();
+      await scheduler.stop({ wait: false });
+      await cancelActiveRuns({
+        config,
+        status,
+        claims,
+        workspaceManager,
+        runner,
+        orchestratorState,
+        reason: "shutdown",
+        now
+      });
+      status.recordShutdown({ reason, stopped_at: currentIso(now) });
+      await writeSnapshot(status, config);
+      await instance.cleanup();
+      resolveStopped({ reason });
+      return stopped;
+    }
+
+    const daemon = {
+      config,
+      status,
+      endpoint: instance.endpoint,
+      instance,
+      scheduler,
+      fizzy,
+      runner,
+      orchestratorState,
+      stop,
+      stopped
+    };
+
+    uninstallSignals = installSignalHandlers(signalProcess, (signal) => {
+      void stop(`signal:${signal}`).catch((error) => {
+        rejectStopped(error);
+      });
+    });
+
+    scheduler.start({ immediate: schedulerOptions.immediate });
+    await writeSnapshot(status, config);
+    return daemon;
+  } catch (error) {
+    if (!stopping) {
+      try {
+        await scheduler?.stop?.({ wait: false });
+        await instance.cleanup();
+      } catch {
+        // Startup failure should preserve the original error.
+      }
+    }
+    throw error;
+  }
+}
+
+function createDefaultClaims({ config, fizzy, status }) {
+  if (config.diagnostics?.no_dispatch) {
+    return {
+      async acquire() {
+        return { acquired: false, reason: "dispatch_disabled" };
+      },
+      async release() {
+        return { released: true };
+      }
+    };
+  }
+  return createBoardClaimStore({ fizzy, status });
+}
+
+function createDefaultWorkspaceManager() {
+  return {
+    async resolveIdentity({ config, card, route }) {
+      return resolveWorkspaceIdentity({ config, card, route });
+    },
+    async prepare({ config, identity, card, route, claim, decision }) {
+      return prepareWorkspace({
+        config,
+        identity,
+        metadata: {
+          card_id: card?.id,
+          route_id: route?.id,
+          claim_id: claim?.claim_id ?? claim?.id,
+          decision_reason: decision?.reason
+        }
+      });
+    },
+    async preserve({ run }) {
+      return {
+        status: "preserved",
+        workspace_path: run.workspace_path ?? run.workspace?.path
+      };
+    }
+  };
+}
+
+function createDefaultWorkflowLoader() {
+  return {
+    async load({ config, workspace }) {
+      return loadWorkflow({ config, workspace });
+    }
+  };
+}
+
+function createDefaultRouter({ config, routes }) {
+  return {
+    async validateCandidate({ card }) {
+      return routeCard({
+        board: { id: card.board_id ?? card.board?.id },
+        card,
+        routes: routes(),
+        config
+      });
+    }
+  };
+}
+
+async function cancelActiveRuns(options = {}) {
+  const {
+    config,
+    status,
+    claims,
+    workspaceManager,
+    runner,
+    orchestratorState,
+    reason,
+    now
+  } = options;
+  const snapshot = status.status();
+  const activeRuns = snapshot.runs?.running ?? [];
+
+  for (const run of activeRuns) {
+    const cancellation = {
+      final_status: "cancelled",
+      reason,
+      requested_at: currentIso(now),
+      states: {
+        cancel_requested: { status: "done", at: currentIso(now) },
+        runner_cancel_sent: { status: "skipped" },
+        claim_cancelled: { status: "pending" },
+        workspace_preserved: { status: "pending" }
+      },
+      workspace_preserved: false
+    };
+
+    if (run.turn) {
+      try {
+        const cancelResult = await runner.cancel?.(run.turn, reason);
+        cancellation.runner_cancel = cancelResult;
+        cancellation.states.runner_cancel_sent = { status: "succeeded", at: currentIso(now), result: cancelResult };
+      } catch (error) {
+        cancellation.states.runner_cancel_sent = { status: "failed", at: currentIso(now), error: normalizeError(error) };
+      }
+    }
+
+    try {
+      const release = await claims?.release?.({ config, claim: run.claim ?? { ...run, status: "claimed" }, run, status: "cancelled", now: currentDate(now), reason });
+      cancellation.claim_release = release;
+      cancellation.states.claim_cancelled = { status: release?.released === false ? "failed" : "succeeded", at: currentIso(now), result: release };
+    } catch (error) {
+      cancellation.states.claim_cancelled = { status: "failed", at: currentIso(now), error: normalizeError(error) };
+    }
+
+    try {
+      const preservation = await workspaceManager?.preserve?.({ config, run, reason, finalStatus: "cancelled" });
+      cancellation.workspace_preserved = true;
+      cancellation.workspace_preservation = preservation;
+      cancellation.states.workspace_preserved = { status: "preserved", at: currentIso(now), result: preservation };
+    } catch (error) {
+      cancellation.states.workspace_preserved = { status: "failed", at: currentIso(now), error: normalizeError(error) };
+    }
+
+    const cancelled = status.cancelRun(run.id, cancellation, { final_status: "cancelled", cancellation });
+    await status.writeRunAttemptRecord?.(cancelled ?? { ...run, cancellation, status: "cancelled" });
+  }
+
+  for (const run of orchestratorState?.snapshot?.().active_runs ?? []) {
+    await orchestratorState.cancelRun?.(run, reason, { retry: false });
+  }
+  recordLifecycle(status, orchestratorState);
+}
+
+function createCancellableRunner(runner) {
+  const cancellations = new Map();
+  const cancelled = new Set();
+
+  function entryFor(turn = {}) {
+    const key = turn.turn_id ?? turn.id;
+    if (!key) return null;
+    if (!cancellations.has(key)) {
+      let resolve;
+      const promise = new Promise((resolved) => {
+        resolve = resolved;
+      });
+      cancellations.set(key, { promise, resolve });
+    }
+    return cancellations.get(key);
+  }
+
+  return {
+    ...runner,
+    async stream(turn, onEvent) {
+      const key = turn?.turn_id ?? turn?.id;
+      const entry = entryFor(turn);
+      const stream = runner.stream?.(turn, onEvent) ?? Promise.resolve({ status: "completed" });
+      const cancellation = entry?.promise.then((reason) => ({
+        status: "failed",
+        failure_kind: "cancelled",
+        error: {
+          code: "RUN_CANCELLED",
+          message: `Run cancelled: ${reason}`
+        }
+      }));
+      const result = cancellation ? await Promise.race([stream, cancellation]) : await stream;
+      if (key && cancelled.has(key) && result?.status === "completed") {
+        return {
+          status: "failed",
+          failure_kind: "cancelled",
+          error: {
+            code: "RUN_CANCELLED",
+            message: "Run cancelled before completion was accepted."
+          }
+        };
+      }
+      return result;
+    },
+    async cancel(turn, reason = "cancelled") {
+      const key = turn?.turn_id ?? turn?.id;
+      if (key) {
+        cancelled.add(key);
+        entryFor(turn)?.resolve(reason);
+      }
+      if (runner.cancel) return runner.cancel(turn, reason);
+      return { status: "cancelled", success: true, reason };
+    }
+  };
+}
+
+function installSignalHandlers(signalProcess, onSignal) {
+  if (!signalProcess?.on) return () => {};
+  const handler = (signal) => onSignal(signal);
+  signalProcess.on("SIGINT", handler);
+  signalProcess.on("SIGTERM", handler);
+  return () => {
+    signalProcess.off?.("SIGINT", handler);
+    signalProcess.off?.("SIGTERM", handler);
+  };
+}
+
+async function callFactory(factory, args) {
+  if (typeof factory !== "function") return null;
+  return factory(args);
+}
+
+async function writeSnapshot(status, config) {
+  const snapshotPath = config.observability?.status_snapshot_path;
+  if (!snapshotPath) return null;
+  return status.writeSnapshot(snapshotPath);
+}
+
+function createDefaultFizzy(config) {
+  return config.diagnostics?.no_dispatch ? createNoopFizzy() : createUnavailableFizzy();
+}
+
+function createNoopFizzy() {
+  return {
+    async getIdentity() {
+      return { user: { id: "unknown" } };
+    },
+    async listUsers() {
+      return [];
+    },
+    async listTags() {
+      return [];
+    },
+    async getEntropy() {
+      return { warnings: [] };
+    },
+    async getBoard(boardId) {
+      return { id: boardId, columns: [], cards: [] };
+    },
+    async discoverCandidates() {
+      return [];
+    },
+    etagStats() {
+      return { hits: 0, misses: 0, invalid: 0 };
+    }
+  };
+}
+
+function createUnavailableFizzy() {
+  async function unavailable() {
+    throw new FizzySymphonyError(
+      "FIZZY_CLIENT_UNAVAILABLE",
+      "No Fizzy client factory was provided for daemon startup.",
+      { inject: "dependencies.fizzyFactory" }
+    );
+  }
+
+  return {
+    getIdentity: unavailable,
+    listUsers: unavailable,
+    listTags: unavailable,
+    getEntropy: unavailable,
+    getBoard: unavailable,
+    discoverCandidates: unavailable
+  };
+}
+
+function recordLifecycle(status, orchestratorState) {
+  if (!status?.recordLifecycleSnapshot || !orchestratorState?.snapshot) return;
+  const snapshot = orchestratorState.snapshot();
+  status.recordLifecycleSnapshot({
+    active_runs: snapshot.active_runs ?? [],
+    claims: snapshot.claims ?? [],
+    claim_renewals: snapshot.claim_renewals ?? [],
+    retry_queue: snapshot.retry_queue ?? [],
+    stalled_runs: snapshot.stalled_runs ?? [],
+    cancellations: snapshot.cancellations ?? [],
+    recent_failures: snapshot.recent_failures ?? []
+  });
+}
+
+function currentDate(now) {
+  const value = typeof now === "function" ? now() : now;
+  return value instanceof Date ? value : new Date(value);
+}
+
+function currentIso(now) {
+  return currentDate(now).toISOString();
+}
+
+function normalizeError(error = {}) {
+  return {
+    code: error.code ?? "ERROR",
+    message: error.message ?? String(error),
+    details: error.details ?? {}
+  };
+}

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -29,6 +29,7 @@ export async function startDaemon(options = {}) {
 
   const config = await loadConfig(configPath, { env });
   const webhookHints = dependencies.webhookHints ?? createWebhookHintQueue();
+  let scheduler = null;
   let status = null;
   const statusProxy = {
     health: () => status?.health?.() ?? { live: true, status: "live", ready: false },
@@ -39,7 +40,7 @@ export async function startDaemon(options = {}) {
   const requestListener = createLocalHttpHandler({
     config,
     status: statusProxy,
-    enqueueWebhookHint: webhookHints.enqueue,
+    enqueueWebhookHint: (hint) => scheduler?.enqueueWebhookHint?.(hint) ?? webhookHints.enqueue(hint),
     now,
     logger: dependencies.logger
   });
@@ -51,7 +52,6 @@ export async function startDaemon(options = {}) {
     isProcessLive: dependencies.isProcessLive
   });
 
-  let scheduler = null;
   let uninstallSignals = () => {};
   let stopping = false;
   let resolveStopped;
@@ -147,6 +147,7 @@ export async function startDaemon(options = {}) {
       stopping = true;
       uninstallSignals();
       await scheduler.stop({ wait: false });
+      await instance.listener.close();
       await cancelActiveRuns({
         config,
         status,
@@ -320,7 +321,15 @@ async function cancelActiveRuns(options = {}) {
   }
 
   for (const run of orchestratorState?.snapshot?.().active_runs ?? []) {
-    await orchestratorState.cancelRun?.(run, reason, { retry: false });
+    try {
+      await orchestratorState.cancelRun?.(run, reason, { retry: false });
+    } catch (error) {
+      status.recordError?.({
+        code: "ORCHESTRATOR_CANCEL_FAILED",
+        message: "Orchestrator active run cancellation failed during shutdown.",
+        details: { run_id: run.run_id ?? run.id, error: normalizeError(error) }
+      });
+    }
   }
   recordLifecycle(status, orchestratorState);
 }

--- a/src/orchestrator-state.js
+++ b/src/orchestrator-state.js
@@ -54,6 +54,19 @@ export function createOrchestratorState(options = {}) {
     return clone(failure);
   }
 
+  function completeRun(runId, details = {}) {
+    const run = activeRuns.get(runId);
+    if (!run) return null;
+    activeRuns.delete(runId);
+    clearRunTimers(run);
+    return clone({
+      ...run,
+      ...details,
+      status: "completed",
+      completed_at: nowIso(clock)
+    });
+  }
+
   function recordRunnerActivity(runId, activity = {}) {
     const run = activeRuns.get(runId);
     if (!run) return null;
@@ -209,10 +222,12 @@ export function createOrchestratorState(options = {}) {
 
   return {
     startRun,
+    completeRun,
     recordFailure,
     recordRunnerActivity,
     renewClaimNow,
     reconcileActiveCards,
+    cancelRun,
     recoverStartup,
     snapshot
   };

--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -69,6 +69,13 @@ export async function runReconciliationTick(options = {}) {
     result.discovered = candidates.length;
     recordEtagStats(status, candidatesResult, fizzy);
 
+    if (config.diagnostics?.no_dispatch) {
+      result.ignored += candidates.length;
+      recordLifecycle(status, orchestratorState);
+      status?.recordPoll?.({ completedAt: startedAt, error: null });
+      return result;
+    }
+
     const capacity = Math.max(0, (config.agent?.max_concurrent ?? 1) - (status?.activeRunCount?.() ?? 0));
     let dispatchesRemaining = capacity;
 
@@ -778,7 +785,8 @@ function runnerFailure(result) {
 
 function isRetryableRunnerError(error = {}) {
   return !String(error.code ?? "").startsWith("COMPLETION_") &&
-    error.code !== "STALE_ROUTE_FINGERPRINT";
+    error.code !== "STALE_ROUTE_FINGERPRINT" &&
+    error.code !== "RUN_CANCELLED";
 }
 
 async function withOptionalTimeout(promise, timeoutMs) {

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -1,0 +1,109 @@
+import { createWebhookHintQueue } from "./server.js";
+
+const DEFAULT_INTERVAL_MS = 30000;
+
+export function createReconciliationScheduler(options = {}) {
+  const {
+    intervalMs = DEFAULT_INTERVAL_MS,
+    runTick,
+    snapshot = async () => null,
+    timers = globalThis,
+    hints = createWebhookHintQueue()
+  } = options;
+
+  let stopped = false;
+  let started = false;
+  let running = false;
+  let pendingReason = null;
+  let timer = null;
+  let activePromise = null;
+
+  function start(startOptions = {}) {
+    if (started) return;
+    started = true;
+    stopped = false;
+    if (startOptions.immediate !== false && options.immediate !== false) {
+      schedule("startup", 0);
+    } else {
+      schedule("interval", intervalMs);
+    }
+  }
+
+  function stop(stopOptions = {}) {
+    stopped = true;
+    if (timer) {
+      timers.clearTimeout?.(timer);
+      timer = null;
+    }
+    if (stopOptions.wait === false) return Promise.resolve();
+    return activePromise ?? Promise.resolve();
+  }
+
+  function enqueueWebhookHint(hint) {
+    hints.enqueue(hint);
+    void tickNow("webhook");
+  }
+
+  function tickNow(reason = "manual") {
+    if (stopped) return Promise.resolve({ ignored: true, reason: "stopped" });
+    if (running) {
+      pendingReason = pendingReason === "webhook" ? "webhook" : reason;
+      return activePromise?.then(() => activePromise ?? Promise.resolve({ queued: true })) ?? Promise.resolve({ queued: true });
+    }
+
+    activePromise = runOnce(reason);
+    return activePromise;
+  }
+
+  async function runOnce(reason) {
+    running = true;
+    if (timer) {
+      timers.clearTimeout?.(timer);
+      timer = null;
+    }
+
+    try {
+      const webhookEvents = hints.drain();
+      const result = await runTick?.({ reason, webhookEvents });
+      await snapshot?.({ reason, result });
+      return result;
+    } finally {
+      running = false;
+      activePromise = null;
+      if (pendingReason && !stopped) {
+        const nextReason = hints.size > 0 ? "webhook" : pendingReason;
+        pendingReason = null;
+        activePromise = runOnce(nextReason);
+      } else if (!stopped && started) {
+        schedule("interval", intervalMs);
+      }
+    }
+  }
+
+  function schedule(reason, delay) {
+    if (stopped || timer) return;
+    timer = timers.setTimeout?.(async () => {
+      timer = null;
+      try {
+        await tickNow(reason);
+      } catch {
+        if (!stopped && started) schedule("interval", intervalMs);
+      }
+    }, delay);
+    timer?.unref?.();
+  }
+
+  return {
+    start,
+    stop,
+    tickNow,
+    enqueueWebhookHint,
+    hints,
+    get running() {
+      return running;
+    },
+    get stopped() {
+      return stopped;
+    }
+  };
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,282 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const DEFAULT_WEBHOOK_PATH = "/webhook";
+const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
+
+export function createLocalHttpHandler(deps = {}) {
+  const {
+    config = {},
+    status,
+    enqueueWebhookHint = () => null,
+    now = () => new Date(),
+    logger,
+    maxBodyBytes = DEFAULT_MAX_BODY_BYTES,
+    seenWebhookEventIds = new Set()
+  } = deps;
+  const webhookPath = normalizePath(config.webhook?.path ?? DEFAULT_WEBHOOK_PATH);
+
+  return async function localHttpHandler(request, response) {
+    try {
+      const pathname = requestPathname(request);
+
+      if (pathname === "/health") {
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        return writeJson(response, 200, callStatus(status, "health", { live: true, status: "live" }));
+      }
+
+      if (pathname === "/ready") {
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        const readiness = callStatus(status, "ready", { ready: false, status: "not_ready", blockers: [] });
+        return writeJson(response, readiness.ready ? 200 : 503, readiness);
+      }
+
+      if (pathname === "/status") {
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        return writeJson(response, 200, callStatus(status, "status", {}));
+      }
+
+      const cardStatusMatch = pathname.match(/^\/status\/cards\/([^/]+)$/u);
+      if (cardStatusMatch) {
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        const cardStatus = selectCardStatus(callStatus(status, "status", {}), decodeURIComponent(cardStatusMatch[1]));
+        return writeJson(response, cardStatus.found ? 200 : 404, cardStatus);
+      }
+
+      if (pathname === webhookPath) {
+        if (config.webhook?.enabled === false) {
+          return writeError(response, 404, "WEBHOOK_DISABLED", "Webhook intake is disabled.");
+        }
+        if (request.method !== "POST") return methodNotAllowed(response, ["POST"]);
+        return await handleWebhook(request, response, {
+          config,
+          enqueueWebhookHint,
+          now,
+          maxBodyBytes,
+          seenWebhookEventIds
+        });
+      }
+
+      return writeError(response, 404, "NOT_FOUND", "Route not found.");
+    } catch (error) {
+      logger?.error?.({ error }, "local HTTP handler failed");
+      return writeError(response, 500, "HTTP_HANDLER_ERROR", "Local HTTP handler failed.");
+    }
+  };
+}
+
+export function createWebhookHintQueue(options = {}) {
+  const limit = options.limit ?? 1000;
+  const queue = [];
+
+  return {
+    enqueue(hint = {}) {
+      const normalized = clone(hint);
+      queue.push(normalized);
+      while (queue.length > limit) queue.shift();
+      return clone(normalized);
+    },
+    drain() {
+      return queue.splice(0).map(clone);
+    },
+    snapshot() {
+      return queue.map(clone);
+    },
+    get size() {
+      return queue.length;
+    }
+  };
+}
+
+async function handleWebhook(request, response, options = {}) {
+  const {
+    config = {},
+    enqueueWebhookHint,
+    now,
+    maxBodyBytes,
+    seenWebhookEventIds
+  } = options;
+
+  let rawBody;
+  try {
+    rawBody = await readRawBody(request, { maxBodyBytes });
+  } catch (error) {
+    if (error.code === "WEBHOOK_BODY_TOO_LARGE") {
+      return writeError(response, 413, error.code, "Webhook request body is too large.");
+    }
+    throw error;
+  }
+
+  const secret = config.webhook?.secret ? String(config.webhook.secret) : "";
+  if (secret) {
+    const supplied = request.headers["x-webhook-signature"];
+    if (!supplied) {
+      return writeError(response, 401, "WEBHOOK_SIGNATURE_REQUIRED", "Webhook signature is required.");
+    }
+    if (!verifyWebhookSignature(rawBody, supplied, secret)) {
+      return writeError(response, 401, "WEBHOOK_SIGNATURE_INVALID", "Webhook signature is invalid.");
+    }
+  }
+
+  let event;
+  try {
+    event = JSON.parse(rawBody.toString("utf8"));
+  } catch {
+    return writeError(response, 400, "INVALID_WEBHOOK_PAYLOAD", "Webhook payload must be valid JSON.");
+  }
+
+  const hint = candidateHintFromWebhookEvent(event, { now });
+  if (!hint.card_id) {
+    return writeError(response, 400, "INVALID_WEBHOOK_PAYLOAD", "Webhook payload must identify a candidate card.");
+  }
+
+  if (hint.event_id && seenWebhookEventIds.has(hint.event_id)) {
+    return writeJson(response, 200, {
+      ok: true,
+      status: "duplicate",
+      hint: publicHint(hint),
+      signature_verification: secret ? "enabled" : "disabled",
+      webhook_management: config.webhook?.manage ? "managed" : "unmanaged"
+    });
+  }
+
+  if (hint.event_id) seenWebhookEventIds.add(hint.event_id);
+  await enqueueWebhookHint(hint);
+
+  return writeJson(response, 202, {
+    ok: true,
+    status: "accepted",
+    hint: publicHint(hint),
+    signature_verification: secret ? "enabled" : "disabled",
+    webhook_management: config.webhook?.manage ? "managed" : "unmanaged"
+  });
+}
+
+function selectCardStatus(snapshot = {}, cardId) {
+  const runs = snapshot.runs ?? {};
+  const selectedRuns = {};
+  for (const bucket of ["queued", "running", "completed", "failed", "cancelled", "preempted"]) {
+    selectedRuns[bucket] = (runs[bucket] ?? []).filter((run) => run.card_id === cardId || run.card?.id === cardId);
+  }
+  const found = Object.values(selectedRuns).some((entries) => entries.length > 0);
+  return {
+    found,
+    card_id: cardId,
+    runs: selectedRuns,
+    claims: (snapshot.claims ?? []).filter((claim) => claim.card_id === cardId),
+    workpads: (snapshot.workpads ?? []).filter((workpad) => workpad.card_id === cardId || workpad.id === cardId)
+  };
+}
+
+function readRawBody(request, { maxBodyBytes = DEFAULT_MAX_BODY_BYTES } = {}) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let bytes = 0;
+    let tooLarge = false;
+
+    request.on("data", (chunk) => {
+      bytes += chunk.length;
+      if (bytes > maxBodyBytes) {
+        tooLarge = true;
+        return;
+      }
+      chunks.push(chunk);
+    });
+    request.on("end", () => {
+      if (tooLarge) {
+        const error = new Error("Webhook request body is too large.");
+        error.code = "WEBHOOK_BODY_TOO_LARGE";
+        reject(error);
+        return;
+      }
+      resolve(Buffer.concat(chunks));
+    });
+    request.on("error", reject);
+  });
+}
+
+function verifyWebhookSignature(rawBody, signatureHeader, secret) {
+  const supplied = normalizeSignature(signatureHeader);
+  if (!/^[a-f0-9]{64}$/iu.test(supplied)) return false;
+
+  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+  const suppliedBytes = Buffer.from(supplied, "hex");
+  const expectedBytes = Buffer.from(expected, "hex");
+  return suppliedBytes.length === expectedBytes.length && timingSafeEqual(suppliedBytes, expectedBytes);
+}
+
+function normalizeSignature(signatureHeader) {
+  const raw = Array.isArray(signatureHeader) ? signatureHeader[0] : signatureHeader;
+  const value = String(raw ?? "").trim();
+  return value.startsWith("sha256=") ? value.slice("sha256=".length) : value;
+}
+
+function candidateHintFromWebhookEvent(event, { now = () => new Date() } = {}) {
+  if (!event || typeof event !== "object" || Array.isArray(event)) return {};
+
+  const card = event.card ?? event.data?.card ?? event.payload?.card ?? {};
+  const board = event.board ?? event.data?.board ?? event.payload?.board ?? {};
+  const cardId = event.card_id ?? event.cardId ?? card.id ?? card.card_id;
+  const boardId = event.board_id ?? event.boardId ?? board.id ?? board.board_id ?? card.board_id ?? card.boardId;
+
+  return omitUndefined({
+    source: "webhook",
+    event_id: event.event_id ?? event.eventId ?? event.id,
+    card_id: cardId,
+    board_id: boardId,
+    received_at: toIso(typeof now === "function" ? now() : now)
+  });
+}
+
+function publicHint(hint = {}) {
+  return omitUndefined({
+    event_id: hint.event_id,
+    card_id: hint.card_id,
+    board_id: hint.board_id
+  });
+}
+
+function callStatus(status, method, fallback) {
+  return typeof status?.[method] === "function" ? status[method]() : fallback;
+}
+
+function requestPathname(request) {
+  return new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+}
+
+function normalizePath(path) {
+  const value = String(path || DEFAULT_WEBHOOK_PATH);
+  return value.startsWith("/") ? value : `/${value}`;
+}
+
+function methodNotAllowed(response, allowed) {
+  return writeError(response, 405, "METHOD_NOT_ALLOWED", "Method not allowed.", {}, {
+    allow: allowed.join(", ")
+  });
+}
+
+function writeError(response, statusCode, code, message, details = {}, headers = {}) {
+  return writeJson(response, statusCode, { ok: false, error: { code, message, details } }, headers);
+}
+
+function writeJson(response, statusCode, body, headers = {}) {
+  if (response.headersSent) return;
+  response.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8",
+    ...headers
+  });
+  response.end(`${JSON.stringify(body)}\n`);
+}
+
+function toIso(value) {
+  if (value instanceof Date) return value.toISOString();
+  return new Date(value).toISOString();
+}
+
+function omitUndefined(object) {
+  return Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined));
+}
+
+function clone(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}

--- a/src/status.js
+++ b/src/status.js
@@ -1,4 +1,5 @@
 import { mkdir, rename, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { basename, dirname, join } from "node:path";
 
 const HISTORY_LIMIT = 50;
@@ -53,6 +54,7 @@ export function createStatusStore(options = {}) {
       by_board: clone(config.webhook?.managed_webhook_ids_by_board ?? {}),
       recent_delivery_errors: []
     },
+    shutdown: null,
     etag_cache: { hits: 0, misses: 0, invalid: 0 },
     retry_queue: [],
     cleanup_state: { status: "not_started" },
@@ -78,7 +80,8 @@ export function createStatusStore(options = {}) {
   function ready() {
     const startupReady = state.validation.errors.length === 0;
     const startupRecoveryReady = (state.startup_recovery.errors ?? []).length === 0;
-    const runnerReady = state.runner_health?.status === "ready";
+    const dispatchEnabled = state.config.diagnostics?.no_dispatch !== true;
+    const runnerReady = dispatchEnabled ? state.runner_health?.status === "ready" : true;
     const blockers = [];
 
     if (!startupRecoveryReady) {
@@ -97,6 +100,13 @@ export function createStatusStore(options = {}) {
       });
     }
 
+    if (!dispatchEnabled) {
+      blockers.push({
+        code: "DISPATCH_DISABLED",
+        message: "diagnostics.no_dispatch is enabled; runner dispatch is disabled."
+      });
+    }
+
     if (!runnerReady) {
       blockers.push({
         code: "RUNNER_NOT_READY",
@@ -111,7 +121,8 @@ export function createStatusStore(options = {}) {
       checks: {
         startup_recovery: startupRecoveryReady,
         startup: startupReady,
-        runner: runnerReady
+        runner: runnerReady,
+        dispatch_enabled: dispatchEnabled
       },
       blockers,
       runner_health: clone(state.runner_health),
@@ -135,6 +146,7 @@ export function createStatusStore(options = {}) {
         recent_delivery_errors: clone(state.managed_webhooks.recent_delivery_errors)
       },
       managed_webhooks: clone(state.managed_webhooks),
+      shutdown: clone(state.shutdown),
       etag_cache: clone(state.etag_cache),
       runner: {
         kind: state.runner_health?.kind ?? state.config.runner?.preferred ?? "unknown"
@@ -180,7 +192,7 @@ export function createStatusStore(options = {}) {
     const body = `${JSON.stringify(status(), null, 2)}\n`;
     const directory = dirname(snapshotPath);
     await mkdir(directory, { recursive: true });
-    const tmpPath = join(directory, `.${basename(snapshotPath)}.${process.pid}.${Date.now()}.tmp`);
+    const tmpPath = join(directory, `.${basename(snapshotPath)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`);
     await writeFile(tmpPath, body, "utf8");
     await rename(tmpPath, snapshotPath);
     return {
@@ -205,7 +217,7 @@ export function createStatusStore(options = {}) {
     const body = `${JSON.stringify(record, null, 2)}\n`;
 
     await mkdir(runsDir, { recursive: true });
-    const tmpPath = join(runsDir, `.${fileName}.${process.pid}.${Date.now()}.tmp`);
+    const tmpPath = join(runsDir, `.${fileName}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`);
     await writeFile(tmpPath, body, "utf8");
     await rename(tmpPath, recordPath);
     return {
@@ -319,6 +331,14 @@ export function createStatusStore(options = {}) {
     touch();
   }
 
+  function recordShutdown(report = {}) {
+    state.shutdown = {
+      ...clone(report),
+      stopped_at: report.stopped_at ?? new Date().toISOString()
+    };
+    touch();
+  }
+
   function queueRun(run) {
     return putRun("queued", run, { status: "queued" });
   }
@@ -330,6 +350,7 @@ export function createStatusStore(options = {}) {
 
   function completeRun(runOrId, details = {}) {
     const run = runFrom(runOrId);
+    if (isCancelled(run)) return clone(run);
     const completed = putRun("completed", { ...run, ...details }, { status: "completed" });
     state.recent_completions.push({
       run_id: completed.id,
@@ -343,6 +364,7 @@ export function createStatusStore(options = {}) {
 
   function failRun(runOrId, error = {}) {
     const run = runFrom(runOrId);
+    if (isCancelled(run)) return clone(run);
     const failed = putRun("failed", { ...run, last_error: normalizeError(error) }, { status: "failed" });
     state.recent_failures.push({
       run_id: failed.id,
@@ -479,6 +501,7 @@ export function createStatusStore(options = {}) {
     recordTokenRateLimit,
     recordRetryQueue,
     recordCleanupState,
+    recordShutdown,
     queueRun,
     startRun,
     completeRun,
@@ -594,6 +617,10 @@ function endpointFromConfig(config) {
 
 function bucketValues(bucket) {
   return [...bucket.values()].map(clone);
+}
+
+function isCancelled(run) {
+  return run?.status === "cancelled" || run?.status === "preempted";
 }
 
 function normalizeError(error = {}) {

--- a/src/validation.js
+++ b/src/validation.js
@@ -188,6 +188,7 @@ export async function validateStartup({ config, fizzy, runner }) {
   const errors = [];
   const warnings = [];
   const routes = [];
+  let runnerHealth = { status: "unknown", kind: config.runner?.preferred ?? "unknown" };
 
   validateLocalConfig(config, errors);
 
@@ -267,11 +268,12 @@ export async function validateStartup({ config, fizzy, runner }) {
   await validateWorkflowFiles(config, errors);
 
   try {
-    const runnerHealth = await validateRunner(config, runner);
+    runnerHealth = await validateRunner(config, runner);
     if (runnerHealth.status !== "ready" && !config.diagnostics?.no_dispatch) {
       errors.push(issue("RUNNER_UNAVAILABLE", "Configured Codex runner is not ready.", runnerHealth));
     }
   } catch (error) {
+    runnerHealth = { status: "unavailable", kind: config.runner?.preferred ?? "unknown", error: error.message };
     errors.push(issue(error.code ?? "RUNNER_INVALID", error.message, error.details ?? {}));
   }
 
@@ -280,7 +282,8 @@ export async function validateStartup({ config, fizzy, runner }) {
     errors,
     warnings,
     routes,
-    resolvedTags
+    resolvedTags,
+    runnerHealth
   };
 }
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -332,7 +332,7 @@ test("loadConfig reads JSON and generated YAML config files for the CLI", async 
   assert.equal(loadedYaml.webhook.secret, "webhook-secret");
 });
 
-test("CLI exposes setup template generation, parse-only validation, and daemon stub commands", async () => {
+test("CLI exposes setup template generation and parse-only validation commands", async () => {
   const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-cli-"));
   const templatePath = join(dir, "config.yml");
   const jsonPath = join(dir, "config.json");
@@ -359,14 +359,6 @@ test("CLI exposes setup template generation, parse-only validation, and daemon s
   assert.equal(validate.exitCode, 0);
   assert.deepEqual(JSON.parse(validate.stdout), { ok: true, mode: "parse-only" });
 
-  const daemon = await runCli(["daemon"]);
-  assert.equal(daemon.exitCode, 0);
-  assert.deepEqual(JSON.parse(daemon.stdout), {
-    ok: true,
-    command: "daemon",
-    status: "stub",
-    message: "Later tasks implement the daemon loop."
-  });
 });
 
 async function runCli(args, options = {}) {

--- a/test/daemon.test.js
+++ b/test/daemon.test.js
@@ -111,6 +111,55 @@ test("startDaemon wires startup, HTTP status, scheduler ticks, recovery, and sta
   }
 });
 
+test("daemon webhooks enqueue through the scheduler and trigger reconciliation", async () => {
+  const root = await tempProject("fizzy-symphony-daemon-webhook-");
+  const configPath = await writeConfig(root);
+  const calls = [];
+  const seenHints = [];
+  const daemon = await startDaemon({
+    configPath,
+    env: { ...process.env, FIZZY_API_TOKEN: "token" },
+    schedulerOptions: { immediate: false },
+    dependencies: {
+      ...daemonDependencies({ calls }),
+      fizzyFactory: () => ({
+        ...fakeFizzy(),
+        async discoverCandidates({ hints }) {
+          calls.push("discover");
+          seenHints.push(hints);
+          return [];
+        },
+        async refreshActiveCards() {
+          calls.push("refreshActiveCards");
+          return [];
+        }
+      })
+    }
+  });
+
+  try {
+    const response = await fetchJson(`${daemon.endpoint.base_url}/webhook`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        event_id: "event_1",
+        card: { id: "card_1", board_id: "board_1" }
+      })
+    });
+
+    assert.equal(response.response.status, 202);
+    await waitFor(() => calls.includes("discover"));
+    assert.deepEqual(seenHints[0], [{
+      event_id: "event_1",
+      card_id: "card_1",
+      board_id: "board_1"
+    }]);
+    assert.equal(calls.includes("startSession"), false);
+  } finally {
+    await daemon.stop("test");
+  }
+});
+
 test("SIGTERM shutdown stops scheduling, cancels active work, preserves workspace, closes server, and removes own registry", async () => {
   const root = await tempProject("fizzy-symphony-daemon-signal-");
   const configPath = await writeConfig(root);

--- a/test/daemon.test.js
+++ b/test/daemon.test.js
@@ -1,0 +1,510 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { main as cliMain } from "../bin/fizzy-symphony.js";
+import { startDaemon } from "../src/daemon.js";
+
+test("CLI daemon reports config load errors as structured failures", async () => {
+  const result = await runCli(["daemon", "--config", "/tmp/fizzy-symphony-missing-config.json"]);
+
+  assert.equal(result.exitCode, 2);
+  assert.equal(JSON.parse(result.stderr).code, "CONFIG_PARSE_ERROR");
+});
+
+test("CLI daemon reports startup validation blockers and cleans the owned registry file", async () => {
+  const root = await tempProject("fizzy-symphony-daemon-cli-blocked-");
+  const configPath = await writeConfig(root, { workflow: { fallback_enabled: false, fallback_path: "" } });
+
+  const result = await runCli(["daemon", "--config", configPath], {
+    env: { ...process.env, FIZZY_API_TOKEN: "token" },
+    daemonOptions: {
+      dependencies: {
+        fizzyFactory: () => fakeFizzy({
+          board: boardFixture({
+            cards: [{ id: "golden_1", golden: true, column_id: "col_ready", tags: ["agent-instructions"] }]
+          })
+        }),
+        runnerFactory: () => fakeRunner()
+      }
+    }
+  });
+
+  assert.equal(result.exitCode, 2);
+  const error = JSON.parse(result.stderr);
+  assert.equal(error.code, "STARTUP_VALIDATION_FAILED");
+  assert.deepEqual(error.details.errors.map((entry) => entry.code), ["MISSING_COMPLETION_POLICY"]);
+  assert.deepEqual(await readDirOrEmpty(join(root, ".fizzy-symphony", "run", "instances")), []);
+});
+
+test("daemon no-dispatch mode starts, exposes degraded readiness, and does not claim or run work", async () => {
+  const root = await tempProject("fizzy-symphony-daemon-no-dispatch-");
+  const configPath = await writeConfig(root, { diagnostics: { no_dispatch: true } });
+  const calls = [];
+
+  const result = await runCli(["daemon", "--config", configPath], {
+    env: { ...process.env, FIZZY_API_TOKEN: "token" },
+    daemonOptions: {
+      schedulerOptions: { immediate: false },
+      dependencies: daemonDependencies({
+        calls,
+        cards: [{ id: "card_1", number: 1, board_id: "board_1", column_id: "col_ready", title: "Ready" }],
+        runner: fakeRunner({ status: "unavailable", reason: "diagnostic runner missing" })
+      })
+    },
+    async daemonStarted(daemon) {
+      const health = await fetchJson(`${daemon.endpoint.base_url}/health`);
+      const ready = await fetchJson(`${daemon.endpoint.base_url}/ready`);
+      await daemon.scheduler.tickNow("test");
+      await daemon.stop("test");
+
+      assert.equal(health.response.status, 200);
+      assert.equal(health.body.live, true);
+      assert.equal(ready.response.status, 503);
+      assert.equal(ready.body.blockers[0].code, "DISPATCH_DISABLED");
+    }
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(JSON.parse(result.stdout).status, "running");
+  assert.ok(calls.includes("discover"));
+  assert.equal(calls.includes("claim"), false);
+  assert.equal(calls.includes("prepareWorkspace"), false);
+  assert.equal(calls.includes("startSession"), false);
+});
+
+test("startDaemon wires startup, HTTP status, scheduler ticks, recovery, and status snapshots", async () => {
+  const root = await tempProject("fizzy-symphony-daemon-start-");
+  const configPath = await writeConfig(root);
+  const calls = [];
+  const daemon = await startDaemon({
+    configPath,
+    env: { ...process.env, FIZZY_API_TOKEN: "token" },
+    schedulerOptions: { immediate: false },
+    dependencies: daemonDependencies({
+      calls,
+      cards: [{ id: "card_1", number: 1, board_id: "board_1", column_id: "col_ready", title: "Ready" }]
+    })
+  });
+
+  try {
+    assert.equal(daemon.endpoint.host, "127.0.0.1");
+    const health = await fetchJson(`${daemon.endpoint.base_url}/health`);
+    const ready = await fetchJson(`${daemon.endpoint.base_url}/ready`);
+    assert.equal(health.body.live, true);
+    assert.equal(ready.body.ready, true);
+
+    await daemon.scheduler.tickNow("test");
+    const status = await fetchJson(`${daemon.endpoint.base_url}/status`);
+    assert.deepEqual(status.body.routes.map((route) => route.id), ["board:board_1:column:col_ready:golden:golden_ready"]);
+    assert.equal(status.body.runs.completed[0].card_id, "card_1");
+
+    const snapshot = JSON.parse(await readFile(join(root, ".fizzy-symphony", "run", "status", "latest.json"), "utf8"));
+    assert.equal(snapshot.instance.id, "instance-a");
+    assert.equal(snapshot.runs.completed[0].card_id, "card_1");
+    assert.ok(calls.includes("startupRecovery"));
+  } finally {
+    await daemon.stop("test");
+  }
+});
+
+test("SIGTERM shutdown stops scheduling, cancels active work, preserves workspace, closes server, and removes own registry", async () => {
+  const root = await tempProject("fizzy-symphony-daemon-signal-");
+  const configPath = await writeConfig(root);
+  const signalProcess = new EventEmitter();
+  signalProcess.pid = 12345;
+  const calls = [];
+  let releaseStream;
+  const streamGate = new Promise((resolve) => {
+    releaseStream = resolve;
+  });
+  const daemon = await startDaemon({
+    configPath,
+    env: { ...process.env, FIZZY_API_TOKEN: "token" },
+    signalProcess,
+    schedulerOptions: { immediate: false },
+      dependencies: daemonDependencies({
+      calls,
+      cards: [{ id: "card_1", number: 1, board_id: "board_1", column_id: "col_ready", title: "Ready" }],
+      runner: fakeRunner({ streamGate, calls })
+    })
+  });
+
+  const tick = daemon.scheduler.tickNow("test");
+  try {
+    await waitFor(() => calls.includes("stream"));
+    signalProcess.emit("SIGTERM", "SIGTERM");
+    await daemon.stopped;
+    releaseStream();
+    await tick;
+
+    const snapshot = daemon.status.status();
+    assert.equal(snapshot.runs.cancelled[0].card_id, "card_1");
+    assert.equal(snapshot.runs.cancelled[0].cancellation_reason, "shutdown");
+    assert.equal(snapshot.shutdown.reason, "signal:SIGTERM");
+    assert.ok(calls.includes("cancel"));
+    assert.ok(calls.includes("releaseClaim:cancelled"));
+    assert.ok(calls.includes("preserveWorkspace"));
+    assert.deepEqual(await readDirOrEmpty(join(root, ".fizzy-symphony", "run", "instances")), []);
+
+    await assert.rejects(
+      () => fetch(`${daemon.endpoint.base_url}/health`),
+      (error) => error.name === "TypeError" || error.code === "ECONNREFUSED"
+    );
+  } finally {
+    releaseStream();
+    await tick.catch(() => {});
+    await daemon.stop("test-cleanup").catch(() => {});
+  }
+});
+
+function daemonDependencies({ calls, cards = [], runner = fakeRunner() } = {}) {
+  return {
+    fizzyFactory: () => ({
+      ...fakeFizzy(),
+      async discoverCandidates() {
+        calls?.push("discover");
+        return cards;
+      },
+      async refreshActiveCards() {
+        calls?.push("refreshActiveCards");
+        return cards;
+      },
+      async postResultComment() {
+        calls?.push("postResult");
+        return { id: "comment_1" };
+      },
+      async recordCompletionMarker() {
+        calls?.push("completionMarker");
+        return { id: "marker_1" };
+      }
+    }),
+    runnerFactory: () => runner,
+    claimsFactory: () => ({
+      async acquire({ card }) {
+        calls?.push("claim");
+        return {
+          acquired: true,
+          claim: {
+            id: `claim_${card.id}`,
+            claim_id: `claim_${card.id}`,
+            run_id: `run_${card.id}`,
+            attempt_id: `attempt_${card.id}`
+          }
+        };
+      },
+      async release({ status }) {
+        calls?.push(`releaseClaim:${status}`);
+        return { released: true };
+      }
+    }),
+    workspaceManagerFactory: () => ({
+      async resolveIdentity() {
+        calls?.push("resolveWorkspace");
+        return { workspace_key: "workspace_card_1", workspace_identity_digest: "sha256:workspace" };
+      },
+      async prepare() {
+        calls?.push("prepareWorkspace");
+        return { key: "workspace_card_1", path: "/tmp/workspace-card-1", identity_digest: "sha256:workspace" };
+      },
+      async preserve() {
+        calls?.push("preserveWorkspace");
+        return { status: "preserved", workspace_path: "/tmp/workspace-card-1" };
+      }
+    }),
+    workflowLoaderFactory: () => ({
+      async load() {
+        calls?.push("loadWorkflow");
+        return { body: "Do the work", front_matter: {} };
+      }
+    }),
+    recoveryFactory: () => async (options) => {
+      calls?.push("startupRecovery");
+      options.status?.recordStartupRecovery?.({ warnings: [], errors: [] });
+      return { warnings: [], errors: [] };
+    }
+  };
+}
+
+function fakeRunner(options = {}) {
+  return {
+    async detect() {
+      return { kind: "cli_app_server", available: true };
+    },
+    async validate() {
+      return { ok: true, kind: "cli_app_server" };
+    },
+    async health() {
+      return options.status
+        ? { status: options.status, reason: options.reason, kind: "cli_app_server" }
+        : { status: "ready", kind: "cli_app_server" };
+    },
+    async startSession() {
+      options.calls?.push("startSession");
+      return { session_id: "session_1", process_owned: true };
+    },
+    async startTurn(session) {
+      return { turn_id: "turn_1", session_id: session.session_id };
+    },
+    async stream(turn, onEvent) {
+      options.calls?.push("stream");
+      onEvent?.({ type: "turn.started", turn_id: turn.turn_id });
+      if (options.streamGate) await options.streamGate;
+      return { status: "completed", turn_id: turn.turn_id, no_code_change: true };
+    },
+    async cancel() {
+      options.calls?.push("cancel");
+      return { status: "cancelled", success: true };
+    },
+    async stopSession() {
+      options.calls?.push("stopSession");
+      return { status: "stopped", success: true };
+    }
+  };
+}
+
+function fakeFizzy(options = {}) {
+  const board = options.board ?? boardFixture();
+  return {
+    async getIdentity() {
+      return { user: { id: "user_1" } };
+    },
+    async listUsers() {
+      return [{ id: "bot_1" }];
+    },
+    async listTags() {
+      return [
+        { id: "tag_agent", name: "agent-instructions" },
+        { id: "tag_comment", name: "comment-once" }
+      ];
+    },
+    async getEntropy() {
+      return { warnings: [] };
+    },
+    async getBoard() {
+      return board;
+    }
+  };
+}
+
+function boardFixture(overrides = {}) {
+  return {
+    id: "board_1",
+    name: "Agents",
+    columns: [{ id: "col_ready", name: "Ready" }],
+    cards: [{
+      id: "golden_ready",
+      title: "Ready Route",
+      golden: true,
+      column_id: "col_ready",
+      tags: ["agent-instructions", "comment-once"]
+    }],
+    ...overrides
+  };
+}
+
+async function writeConfig(root, overrides = {}) {
+  await writeFile(join(root, "WORKFLOW.md"), "# Workflow\n", "utf8");
+  const config = mergeConfig(baseConfig(root), overrides);
+  const configPath = join(root, "config.json");
+  await writeFile(configPath, JSON.stringify(config), "utf8");
+  return configPath;
+}
+
+function baseConfig(root) {
+  return {
+    instance: { id: "instance-a", label: "local" },
+    fizzy: {
+      token: "$FIZZY_API_TOKEN",
+      account: "acct",
+      api_url: "https://app.fizzy.do",
+      bot_user_id: ""
+    },
+    boards: {
+      entries: [{
+        id: "board_1",
+        label: "Agents",
+        enabled: true,
+        routing_mode: "column_scoped",
+        defaults: {
+          backend: "codex",
+          model: "",
+          workspace: "app",
+          persona: "repo-agent",
+          unknown_managed_tag_policy: "fail",
+          allowed_card_overrides: {
+            backend: false,
+            model: false,
+            workspace: false,
+            persona: false,
+            priority: true,
+            completion: false
+          },
+          concurrency: { max_concurrent: 1 }
+        }
+      }]
+    },
+    server: {
+      host: "127.0.0.1",
+      port: "auto",
+      port_allocation: "random",
+      base_port: 4567,
+      registry_dir: join(root, ".fizzy-symphony", "run", "instances"),
+      heartbeat_interval_ms: 5000
+    },
+    webhook: {
+      enabled: true,
+      path: "/webhook",
+      secret: "",
+      manage: false,
+      managed_webhook_ids_by_board: {},
+      callback_url: "",
+      subscribed_actions: ["comment_created"]
+    },
+    polling: { interval_ms: 30000, use_etags: true, use_api_filters: true },
+    agent: {
+      max_concurrent: 1,
+      max_concurrent_per_card: 1,
+      turn_timeout_ms: 3600000,
+      stall_timeout_ms: 300000,
+      max_turns: 20,
+      max_retry_backoff_ms: 300000,
+      default_backend: "codex",
+      default_model: "",
+      default_persona: "repo-agent"
+    },
+    runner: {
+      preferred: "cli_app_server",
+      fallback: "cli_app_server",
+      allow_fallback: true,
+      sdk: { package: "", contract: "", smoke_test: false },
+      cli_app_server: { command: "codex", args: ["app-server"] },
+      health: { enabled: true, interval_ms: 60000 },
+      codex: {
+        approval_policy: {
+          mode: "reject",
+          sandbox_approval: "reject",
+          command_approval: "reject",
+          tool_approval: "reject",
+          mcp_elicitation: "reject"
+        },
+        interactive: false,
+        thread_sandbox: "workspace-write",
+        turn_sandbox_policy: { type: "workspaceWrite" }
+      }
+    },
+    workspaces: {
+      root: join(root, ".fizzy-symphony", "workspaces"),
+      metadata_root: join(root, ".fizzy-symphony", "run", "workspaces"),
+      default_isolation: "git_worktree",
+      default_repo: root,
+      registry: {
+        app: {
+          repo: root,
+          isolation: "git_worktree",
+          base_ref: "main",
+          worktree_root: join(root, ".fizzy-symphony", "worktrees"),
+          branch_prefix: "fizzy",
+          workflow_path: "WORKFLOW.md",
+          require_clean_source: true
+        }
+      },
+      retry: { workspace_policy: "reuse" }
+    },
+    workflow: { create_starter_on_setup: false, fallback_enabled: false, fallback_path: "" },
+    routing: { allow_postponed_cards: false, rerun: { mode: "explicit_tag_only", agent_rerun_consumption: "remove_when_supported" } },
+    diagnostics: { no_dispatch: false },
+    claims: {
+      mode: "structured_comment",
+      tag_visibility: false,
+      tag: "agent-claimed",
+      assign_on_claim: false,
+      watch_on_claim: false,
+      lease_ms: 900000,
+      renew_interval_ms: 300000,
+      steal_grace_ms: 30000,
+      max_clock_skew_ms: 30000
+    },
+    completion: {
+      allow_card_completion_override: false,
+      markers: {
+        mode: "structured_comment_and_tag",
+        success_tag_prefix: "agent-completed",
+        failure_tag_prefix: "agent-completion-failed"
+      }
+    },
+    workpad: { enabled: false, mode: "single_comment", update_interval_ms: 30000 },
+    safety: {
+      allowed_roots: [root, join(root, ".fizzy-symphony")],
+      dirty_source_repo_policy: "fail",
+      cleanup: {
+        policy: "preserve",
+        require_proof_before_cleanup: true,
+        require_handoff_before_cleanup: true,
+        forbid_force_remove: true,
+        retention_ms: 604800000
+      }
+    },
+    observability: {
+      state_dir: join(root, ".fizzy-symphony", "run"),
+      log_dir: join(root, ".fizzy-symphony", "logs"),
+      status_snapshot_path: join(root, ".fizzy-symphony", "run", "status", "latest.json"),
+      status_retention_ms: 604800000,
+      log_format: "json"
+    }
+  };
+}
+
+function mergeConfig(base, overrides) {
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value && typeof value === "object" && !Array.isArray(value) && base[key] && typeof base[key] === "object") {
+      base[key] = mergeConfig({ ...base[key] }, value);
+    } else {
+      base[key] = value;
+    }
+  }
+  return base;
+}
+
+async function runCli(args, options = {}) {
+  let stdout = "";
+  let stderr = "";
+  const exitCode = await cliMain(args, {
+    env: options.env ?? process.env,
+    daemonOptions: options.daemonOptions,
+    daemonStarted: options.daemonStarted,
+    stdout: { write: (chunk) => { stdout += chunk; } },
+    stderr: { write: (chunk) => { stderr += chunk; } }
+  });
+  return { exitCode, stdout, stderr };
+}
+
+async function tempProject(prefix) {
+  return mkdtemp(join(tmpdir(), prefix));
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  return { response, body: text ? JSON.parse(text) : null };
+}
+
+async function readDirOrEmpty(path) {
+  try {
+    return await readdir(path);
+  } catch (error) {
+    if (error.code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+async function waitFor(predicate) {
+  for (let index = 0; index < 100; index += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("timed out waiting for predicate");
+}

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createReconciliationScheduler } from "../src/scheduler.js";
+
+test("scheduler drains webhook hints through non-overlapping reconciliation ticks", async () => {
+  const calls = [];
+  let releaseFirstTick;
+  const firstTickGate = new Promise((resolve) => {
+    releaseFirstTick = resolve;
+  });
+  const scheduler = createReconciliationScheduler({
+    intervalMs: 1000,
+    runTick: async ({ reason, webhookEvents }) => {
+      calls.push({ reason, webhookEvents });
+      if (calls.length === 1) await firstTickGate;
+      return { ok: true };
+    },
+    snapshot: async () => null
+  });
+
+  const first = scheduler.tickNow("manual");
+  scheduler.enqueueWebhookHint({ event_id: "event_1", card_id: "card_1" });
+  const second = scheduler.tickNow("manual-overlap");
+
+  assert.equal(calls.length, 1);
+  assert.equal(scheduler.running, true);
+
+  releaseFirstTick();
+  await first;
+  await second;
+
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0], { reason: "manual", webhookEvents: [] });
+  assert.deepEqual(calls[1], {
+    reason: "webhook",
+    webhookEvents: [{ event_id: "event_1", card_id: "card_1" }]
+  });
+  assert.equal(scheduler.running, false);
+  scheduler.stop();
+});
+
+test("scheduler starts immediate ticks, schedules periodic ticks, writes snapshots, and stops timers", async () => {
+  const timers = createManualTimers();
+  const calls = [];
+  const scheduler = createReconciliationScheduler({
+    intervalMs: 5000,
+    timers,
+    runTick: async ({ reason }) => {
+      calls.push(`tick:${reason}`);
+      return { ok: true };
+    },
+    snapshot: async () => {
+      calls.push("snapshot");
+    }
+  });
+
+  scheduler.start();
+  assert.equal(timers.pending.length, 1);
+  await timers.runNext();
+  assert.deepEqual(calls, ["tick:startup", "snapshot"]);
+
+  assert.equal(timers.pending.length, 1);
+  await timers.runNext();
+  assert.deepEqual(calls, ["tick:startup", "snapshot", "tick:interval", "snapshot"]);
+
+  scheduler.stop();
+  assert.equal(timers.pending.length, 0);
+});
+
+function createManualTimers() {
+  const pending = [];
+  return {
+    pending,
+    setTimeout(callback, delay) {
+      const timer = { callback, delay, cleared: false };
+      pending.push(timer);
+      return timer;
+    },
+    clearTimeout(timer) {
+      timer.cleared = true;
+      const index = pending.indexOf(timer);
+      if (index !== -1) pending.splice(index, 1);
+    },
+    async runNext() {
+      const timer = pending.shift();
+      assert.ok(timer, "expected a pending timer");
+      if (!timer.cleared) await timer.callback();
+    }
+  };
+}

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,188 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+
+import { createLocalHttpHandler, createWebhookHintQueue } from "../src/server.js";
+import { bindServerListener } from "../src/listener.js";
+
+test("local HTTP handler serves health, readiness, status, and card status JSON", async () => {
+  const statusSnapshot = {
+    schema_version: "fizzy-symphony-status-v1",
+    runs: {
+      queued: [],
+      running: [{ id: "run_1", card_id: "card_1" }],
+      completed: [],
+      failed: [],
+      cancelled: [],
+      preempted: []
+    }
+  };
+  const server = await bindServerListener(httpConfig().server, {
+    requestListener: createLocalHttpHandler({
+      config: httpConfig(),
+      status: {
+        health: () => ({ live: true, status: "live", ready: false }),
+        ready: () => ({
+          ready: false,
+          status: "not_ready",
+          blockers: [{ code: "DISPATCH_DISABLED", message: "Dispatch is disabled." }]
+        }),
+        status: () => statusSnapshot
+      }
+    })
+  });
+
+  try {
+    const health = await fetchJson(`${server.endpoint.base_url}/health`);
+    assert.equal(health.response.status, 200);
+    assert.deepEqual(health.body, { live: true, status: "live", ready: false });
+
+    const ready = await fetchJson(`${server.endpoint.base_url}/ready`);
+    assert.equal(ready.response.status, 503);
+    assert.equal(ready.body.blockers[0].code, "DISPATCH_DISABLED");
+
+    const status = await fetchJson(`${server.endpoint.base_url}/status`);
+    assert.equal(status.response.status, 200);
+    assert.deepEqual(status.body, statusSnapshot);
+
+    const cardStatus = await fetchJson(`${server.endpoint.base_url}/status/cards/card_1`);
+    assert.equal(cardStatus.response.status, 200);
+    assert.equal(cardStatus.body.card_id, "card_1");
+    assert.deepEqual(cardStatus.body.runs.running.map((run) => run.id), ["run_1"]);
+  } finally {
+    await server.close();
+  }
+});
+
+test("webhook verifies signatures, dedupes event IDs, and enqueues candidate hints only", async () => {
+  const config = httpConfig({
+    webhook: { enabled: true, path: "/webhook", secret: "webhook-secret" }
+  });
+  const queue = createWebhookHintQueue();
+  const server = await bindServerListener(config.server, {
+    requestListener: createLocalHttpHandler({
+      config,
+      status: readyStatus(),
+      enqueueWebhookHint: queue.enqueue,
+      now: () => new Date("2026-04-29T12:00:00.000Z")
+    })
+  });
+
+  try {
+    const body = JSON.stringify({
+      event_id: "event_1",
+      action: "card.updated",
+      card: { id: "card_1", board_id: "board_1" }
+    });
+    const accepted = await fetchJson(`${server.endpoint.base_url}/webhook`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-webhook-signature": signature(body, config.webhook.secret)
+      },
+      body
+    });
+
+    assert.equal(accepted.response.status, 202);
+    assert.equal(accepted.body.status, "accepted");
+    assert.deepEqual(accepted.body.hint, { event_id: "event_1", card_id: "card_1", board_id: "board_1" });
+    assert.deepEqual(queue.snapshot(), [{
+      source: "webhook",
+      event_id: "event_1",
+      card_id: "card_1",
+      board_id: "board_1",
+      received_at: "2026-04-29T12:00:00.000Z"
+    }]);
+
+    const duplicate = await fetchJson(`${server.endpoint.base_url}/webhook`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-webhook-signature": signature(body, config.webhook.secret)
+      },
+      body
+    });
+    assert.equal(duplicate.response.status, 200);
+    assert.equal(duplicate.body.status, "duplicate");
+    assert.equal(queue.size, 1);
+  } finally {
+    await server.close();
+  }
+});
+
+test("webhook rejects missing signatures and malformed payloads before enqueueing", async () => {
+  const hints = [];
+  const config = httpConfig({
+    webhook: { enabled: true, path: "/webhook", secret: "webhook-secret" }
+  });
+  const server = await bindServerListener(config.server, {
+    requestListener: createLocalHttpHandler({
+      config,
+      status: readyStatus(),
+      enqueueWebhookHint: (hint) => hints.push(hint)
+    })
+  });
+
+  try {
+    const missingSignature = await fetchJson(`${server.endpoint.base_url}/webhook`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ event_id: "event_1", card_id: "card_1" })
+    });
+    assert.equal(missingSignature.response.status, 401);
+    assert.equal(missingSignature.body.error.code, "WEBHOOK_SIGNATURE_REQUIRED");
+
+    const invalidJson = await fetchJson(`${server.endpoint.base_url}/webhook`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-webhook-signature": signature("{not json", config.webhook.secret)
+      },
+      body: "{not json"
+    });
+    assert.equal(invalidJson.response.status, 400);
+    assert.equal(invalidJson.body.error.code, "INVALID_WEBHOOK_PAYLOAD");
+    assert.deepEqual(hints, []);
+  } finally {
+    await server.close();
+  }
+});
+
+function httpConfig(overrides = {}) {
+  return {
+    server: {
+      host: "127.0.0.1",
+      port: "auto",
+      port_allocation: "random",
+      ...(overrides.server ?? {})
+    },
+    webhook: {
+      enabled: true,
+      path: "/webhook",
+      secret: "",
+      manage: false,
+      ...(overrides.webhook ?? {})
+    }
+  };
+}
+
+function readyStatus() {
+  return {
+    health: () => ({ live: true, status: "live", ready: true }),
+    ready: () => ({ ready: true, status: "ready", blockers: [] }),
+    status: () => ({ schema_version: "fizzy-symphony-status-v1", runs: {} })
+  };
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  return {
+    response,
+    body: text ? JSON.parse(text) : null
+  };
+}
+
+function signature(body, secret) {
+  return createHmac("sha256", secret).update(body).digest("hex");
+}


### PR DESCRIPTION
## Summary
- Replace the daemon CLI stub with a daemon supervisor that loads config, binds local HTTP status/webhook intake, validates startup, runs recovery, starts a non-overlapping reconciliation scheduler, writes snapshots, and handles graceful shutdown.
- Add local HTTP health/ready/status/card-status routes and signature-verified webhook hint intake.
- Add no-dispatch readiness semantics, shutdown cancellation/status handling, collision-proof status temp writes, and orchestrator completion cleanup for lifecycle timers.

## Tests
- npm test
