### PR TITLE
Wire setup and validate to live clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ cd /var/home/kdlocpanda/second_brain/Resources/virtualization/docker/37signals/a
 npm test
 node bin/fizzy-symphony.js setup --template-only --config .fizzy-symphony/config.yml
 node bin/fizzy-symphony.js validate --parse-only --config .fizzy-symphony/config.yml
+FIZZY_API_TOKEN=... node bin/fizzy-symphony.js validate --config .fizzy-symphony/config.yml
 node bin/fizzy-symphony.js daemon
 ```
 

--- a/bin/fizzy-symphony.js
+++ b/bin/fizzy-symphony.js
@@ -79,6 +79,7 @@ async function setupCommand(args, io) {
     runner,
     prompts: io.prompts,
     env,
+    apiUrl: dependencyConfig.fizzy.api_url,
     account: optionValue(args, "--account") ?? undefined,
     selectedBoardIds: boardValues(args),
     setupMode: optionValue(args, "--mode") ?? undefined,

--- a/bin/fizzy-symphony.js
+++ b/bin/fizzy-symphony.js
@@ -2,21 +2,23 @@
 
 import { fileURLToPath } from "node:url";
 
+import { createCliFizzyClient, createCliRunner, resolveFizzyClientConfig } from "../src/client-factories.js";
 import { loadConfig, writeAnnotatedConfig } from "../src/config.js";
 import { startDaemon } from "../src/daemon.js";
 import { isFizzySymphonyError } from "../src/errors.js";
 import { runSetup } from "../src/setup.js";
 import { runStatusCommand } from "../src/status-cli.js";
 import { discoverStatusEndpoints } from "../src/status-discovery.js";
+import { validateStartup } from "../src/validation.js";
 
 export async function main(args = process.argv.slice(2), io = defaultIo()) {
   const command = args[0];
 
   try {
     if (command === "setup") {
-      await setupCommand(args.slice(1), io);
+      return await setupCommand(args.slice(1), io);
     } else if (command === "validate") {
-      await validateCommand(args.slice(1), io);
+      return await validateCommand(args.slice(1), io);
     } else if (command === "daemon") {
       await daemonCommand(args.slice(1), io);
     } else if (command === "status") {
@@ -60,19 +62,23 @@ async function setupCommand(args, io) {
   if (args.includes("--template-only")) {
     await writeAnnotatedConfig(configPath, { runnerPreferred: "cli_app_server" });
     io.stdout.write(`wrote annotated config: ${configPath}\n`);
-    return;
+    return 0;
   }
 
-  if (!io.fizzy) {
-    throw new Error("Live setup requires an injected Fizzy client. Use --template-only to write a template config.");
-  }
+  const env = io.env ?? process.env;
+  const dependencyConfig = resolveFizzyClientConfig({
+    config: { runner: { preferred: "cli_app_server" } },
+    env
+  });
+  const fizzy = await createFizzyDependency({ io, config: dependencyConfig, env });
+  const runner = await createRunnerDependency({ io, config: dependencyConfig, env });
 
   const result = await runSetup({
     configPath,
-    fizzy: io.fizzy,
-    runner: io.runner,
+    fizzy,
+    runner,
     prompts: io.prompts,
-    env: io.env ?? process.env,
+    env,
     account: optionValue(args, "--account") ?? undefined,
     selectedBoardIds: boardValues(args),
     setupMode: optionValue(args, "--mode") ?? undefined,
@@ -89,16 +95,52 @@ async function setupCommand(args, io) {
     runner: result.runner.kind,
     warnings: result.warnings.map((warning) => warning.code)
   })}\n`);
+  return 0;
 }
 
 async function validateCommand(args, io) {
   const configPath = optionValue(args, "--config") ?? ".fizzy-symphony/config.yml";
-  if (!args.includes("--parse-only")) {
-    throw new Error("Task 1 CLI validate supports --parse-only. Full startup validation requires injected Fizzy and runner clients.");
+  const env = io.env ?? process.env;
+  const config = await loadConfig(configPath, { env });
+  if (args.includes("--parse-only")) {
+    io.stdout.write(`${JSON.stringify({ ok: true, mode: "parse-only" })}\n`);
+    return 0;
   }
 
-  await loadConfig(configPath, { env: io.env ?? process.env });
-  io.stdout.write(`${JSON.stringify({ ok: true, mode: "parse-only" })}\n`);
+  const fizzy = await createFizzyDependency({ io, config, env });
+  const runner = await createRunnerDependency({ io, config, env });
+  const report = await validateStartup({ config, fizzy, runner });
+  io.stdout.write(`${JSON.stringify({
+    ok: report.ok,
+    mode: "startup",
+    errors: report.errors,
+    warnings: report.warnings,
+    routes: report.routes,
+    resolvedTags: report.resolvedTags,
+    runnerHealth: report.runnerHealth
+  })}\n`);
+  return report.ok ? 0 : 2;
+}
+
+async function createFizzyDependency({ io, config, env }) {
+  if (io.fizzy) return io.fizzy;
+  const factory = io.clientFactories?.createFizzyClient ?? ((options) => createCliFizzyClient({
+    ...options,
+    fetch: io.fetch,
+    transport: io.fizzyTransport,
+    normalize: io.fizzyNormalize,
+    etagCache: io.fizzyEtagCache
+  }));
+  return factory({ config, env });
+}
+
+async function createRunnerDependency({ io, config, env }) {
+  if (io.runner) return io.runner;
+  const factory = io.clientFactories?.createRunner ?? ((options) => createCliRunner({
+    ...options,
+    runnerOptions: io.runnerOptions
+  }));
+  return factory({ config, env });
 }
 
 async function daemonCommand(args, io) {
@@ -165,7 +207,7 @@ function usage(exitCode, io) {
     "Usage:",
     "  fizzy-symphony setup --template-only [--config path]",
     "  fizzy-symphony setup [--config path] [--account id] [--board id] [--boards id,id] [--workspace-repo path]",
-    "  fizzy-symphony validate --parse-only [--config path]",
+    "  fizzy-symphony validate [--parse-only] [--config path]",
     "  fizzy-symphony daemon [--config path]",
     "  fizzy-symphony status [--config path] [--instance id]",
     "  fizzy-symphony status [--registry-dir path] [--endpoint url]"

--- a/src/client-factories.js
+++ b/src/client-factories.js
@@ -1,0 +1,75 @@
+import { createCodexCliAppServerRunner } from "./codex-cli-app-server-runner.js";
+import { FizzySymphonyError } from "./errors.js";
+import { createFizzyClient } from "./fizzy-client.js";
+
+export const DEFAULT_FIZZY_API_URL = "https://app.fizzy.do";
+
+export function createCliFizzyClient(options = {}) {
+  const config = resolveFizzyClientConfig(options);
+  requireLiveFizzyConfig(config);
+  return createFizzyClient({
+    config,
+    fetch: options.fetch,
+    transport: options.transport,
+    normalize: options.normalize,
+    etagCache: options.etagCache
+  });
+}
+
+export function createCliRunner(options = {}) {
+  return createCodexCliAppServerRunner(options.runnerOptions ?? {});
+}
+
+export function resolveFizzyClientConfig(options = {}) {
+  const {
+    config = {},
+    env = process.env,
+    defaultApiUrl = DEFAULT_FIZZY_API_URL
+  } = options;
+  const fizzy = config.fizzy ?? {};
+  const token = firstNonEmpty(fizzy.token, env.FIZZY_API_TOKEN);
+  const apiUrl = firstNonEmpty(fizzy.api_url, env.FIZZY_API_URL, defaultApiUrl);
+
+  return {
+    ...config,
+    fizzy: {
+      ...fizzy,
+      token: token ?? "",
+      api_url: apiUrl ?? ""
+    }
+  };
+}
+
+export function requireLiveFizzyConfig(config = {}) {
+  if (!nonEmpty(config.fizzy?.token)) {
+    throw new FizzySymphonyError(
+      "FIZZY_CREDENTIALS_MISSING",
+      "Fizzy API credentials are required for live setup and startup validation.",
+      {
+        required: ["fizzy.token", "FIZZY_API_TOKEN"],
+        remediation: "Set FIZZY_API_TOKEN or configure fizzy.token, then rerun the command. Use setup --template-only only when you want a non-live config template."
+      }
+    );
+  }
+
+  if (!nonEmpty(config.fizzy?.api_url)) {
+    throw new FizzySymphonyError(
+      "FIZZY_API_URL_MISSING",
+      "A Fizzy API URL is required for live setup and startup validation.",
+      {
+        required: ["fizzy.api_url", "FIZZY_API_URL"],
+        remediation: `Set FIZZY_API_URL or configure fizzy.api_url. The default public API URL is ${DEFAULT_FIZZY_API_URL}.`
+      }
+    );
+  }
+
+  return config;
+}
+
+function firstNonEmpty(...values) {
+  return values.find(nonEmpty);
+}
+
+function nonEmpty(value) {
+  return typeof value === "string" ? value.trim().length > 0 : value !== undefined && value !== null;
+}

--- a/src/config.js
+++ b/src/config.js
@@ -479,7 +479,8 @@ function resolveEnvironmentReferences(value, env, path = "") {
         }
         throw new FizzySymphonyError("CONFIG_MISSING_ENV", `Missing environment variable ${variable}`, {
           variable,
-          path
+          path,
+          remediation: `Set ${variable} before running setup, validate, or daemon commands, or replace the config reference with an explicit non-secret value where appropriate.`
         });
       }
       return env[variable];

--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,7 @@ import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path
 import { FizzySymphonyError } from "./errors.js";
 
 const TEMPLATE_PATH = new URL("../config.example.yml", import.meta.url);
+const DEFAULT_FIZZY_API_URL = "https://app.fizzy.do";
 
 const allowedCardOverridesSchema = {
   backend: true,
@@ -219,6 +220,7 @@ export function generateAnnotatedConfig(options = {}) {
     runnerFallback = "cli_app_server",
     sdkPackage = "",
     sdkContract = "",
+    apiUrl = DEFAULT_FIZZY_API_URL,
     botUserId = "",
     webhook = {},
     managedWebhookIdsByBoard = webhook.managed_webhook_ids_by_board ?? {},
@@ -232,6 +234,7 @@ export function generateAnnotatedConfig(options = {}) {
   const safetyAllowedRoots = allowedRoots?.length ? allowedRoots : uniqueStrings([workspaceRepoPath, "."]);
   let template = readFileSync(TEMPLATE_PATH, "utf8");
   template = template.replace(/account: my-account/u, `account: ${yamlScalar(account)}`);
+  template = template.replace(/api_url: https:\/\/app\.fizzy\.do/u, `api_url: ${yamlScalar(apiUrl)}`);
   template = template.replace(
     /  entries:\n[\s\S]*?\nserver:/u,
     `  entries:\n${renderBoardEntries(boardEntries, boardMaxConcurrent)}\nserver:`

--- a/src/setup.js
+++ b/src/setup.js
@@ -2,7 +2,7 @@ import { access } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 
 import { writeAnnotatedConfig } from "./config.js";
-import { FizzySymphonyError } from "./errors.js";
+import { FizzySymphonyError, isFizzySymphonyError } from "./errors.js";
 import { discoverGoldenTicketRoutes, isSupportedSdkRunner, managedTagsUsedByBoards, resolveManagedTags } from "./validation.js";
 
 const DEFAULT_WEBHOOK_ACTIONS = [
@@ -33,9 +33,24 @@ export async function runSetup(options = {}) {
   const identity = await validateIdentity(fizzy);
   const account = await selectAccount(identity, options.account, prompts);
 
-  const boards = await fizzy.listBoards(account);
-  const users = await fizzy.listUsers(account);
-  const tags = await fizzy.listTags(account);
+  const boards = await callFizzySetupStep(
+    () => fizzy.listBoards(account),
+    "FIZZY_BOARDS_UNAVAILABLE",
+    "Unable to list Fizzy boards for setup.",
+    { account }
+  );
+  const users = await callFizzySetupStep(
+    () => fizzy.listUsers(account),
+    "FIZZY_USERS_UNAVAILABLE",
+    "Unable to list Fizzy users for setup.",
+    { account }
+  );
+  const tags = await callFizzySetupStep(
+    () => fizzy.listTags(account),
+    "FIZZY_TAGS_UNAVAILABLE",
+    "Unable to list Fizzy tags for setup.",
+    { account }
+  );
   const runnerReport = await detectRunner(runner);
 
   const setupMode = await selectSetupMode(options, prompts);
@@ -51,7 +66,12 @@ export async function runSetup(options = {}) {
   } else {
     selectedBoardIds = await selectBoardIds(boards, options, prompts);
     for (const boardId of selectedBoardIds) {
-      selectedBoards.push(await fizzy.getBoard(boardId));
+      selectedBoards.push(await callFizzySetupStep(
+        () => fizzy.getBoard(boardId),
+        "FIZZY_BOARD_UNAVAILABLE",
+        "Unable to read selected Fizzy board for setup.",
+        { account, board_id: boardId }
+      ));
     }
     if (setupMode === "adopt_starter") {
       starter = { created: false, board_id: selectedBoardIds[0] };
@@ -132,8 +152,22 @@ async function validateIdentity(fizzy) {
   try {
     return await fizzy.getIdentity();
   } catch (error) {
-    throw new FizzySymphonyError("FIZZY_IDENTITY_INVALID", "Unable to validate Fizzy identity.", {
-      cause: error.message
+    throw new FizzySymphonyError(
+      "FIZZY_IDENTITY_INVALID",
+      "Unable to validate Fizzy identity.",
+      fizzyAccessFailureDetails(error)
+    );
+  }
+}
+
+async function callFizzySetupStep(action, code, message, details = {}) {
+  try {
+    return await action();
+  } catch (error) {
+    if (isFizzySymphonyError(error)) throw error;
+    throw new FizzySymphonyError(code, message, {
+      ...details,
+      ...fizzyAccessFailureDetails(error)
     });
   }
 }
@@ -362,4 +396,17 @@ function sameActions(left = [], right = []) {
 
 function omitUndefined(object) {
   return Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined && value !== ""));
+}
+
+function fizzyAccessFailureDetails(error) {
+  const status = error.status ?? error.metadata?.status;
+  const authenticationFailure = status === 401 || status === 403;
+  return omitUndefined({
+    cause: error.message,
+    status,
+    request_id: error.metadata?.request_id,
+    remediation: authenticationFailure
+      ? "Check FIZZY_API_TOKEN and confirm the token can access the selected Fizzy account, then rerun setup."
+      : "Check FIZZY_API_URL, network access, and Fizzy API availability, then rerun setup."
+  });
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -25,6 +25,7 @@ export async function runSetup(options = {}) {
     fizzy,
     runner,
     env = process.env,
+    apiUrl,
     workspaceRepo = ".",
     webhook = {},
     prompts
@@ -67,7 +68,7 @@ export async function runSetup(options = {}) {
     selectedBoardIds = await selectBoardIds(boards, options, prompts);
     for (const boardId of selectedBoardIds) {
       selectedBoards.push(await callFizzySetupStep(
-        () => fizzy.getBoard(boardId),
+        () => fizzy.getBoard(boardId, { account }),
         "FIZZY_BOARD_UNAVAILABLE",
         "Unable to read selected Fizzy board for setup.",
         { account, board_id: boardId }
@@ -121,6 +122,7 @@ export async function runSetup(options = {}) {
     runnerFallback: "cli_app_server",
     sdkPackage: runnerReport.kind === "sdk" ? runnerReport.package : "",
     sdkContract: runnerReport.kind === "sdk" ? runnerReport.contract : "",
+    apiUrl,
     botUserId: options.botUserId ?? "",
     workspaceRepo,
     webhook,
@@ -249,7 +251,7 @@ async function createStarterBoard({ fizzy, account, workspaceRepo, options }) {
     if (!boardId) {
       throw new FizzySymphonyError("STARTER_BOARD_UNAVAILABLE", "Starter board creation did not return a board ID.");
     }
-    return await fizzy.getBoard(boardId);
+    return await fizzy.getBoard(boardId, { account });
   }
 
   if (!fizzy.createBoard || !fizzy.createColumn || !fizzy.createCard) {
@@ -272,7 +274,7 @@ async function createStarterBoard({ fizzy, account, workspaceRepo, options }) {
     await fizzy.markGolden({ account, board_id: board.id, card_id: golden.id });
   }
 
-  return await fizzy.getBoard(board.id);
+  return await fizzy.getBoard(board.id, { account });
 }
 
 function validateBotUser(botUserId, users) {

--- a/src/validation.js
+++ b/src/validation.js
@@ -197,7 +197,7 @@ export async function validateStartup({ config, fizzy, runner }) {
     await fizzy?.getIdentity?.();
     identityValid = true;
   } catch (error) {
-    errors.push(issue("FIZZY_IDENTITY_INVALID", "Fizzy identity validation failed.", { cause: error.message }));
+    errors.push(issue("FIZZY_IDENTITY_INVALID", "Fizzy identity validation failed.", fizzyAccessFailureDetails(error)));
   }
 
   let users = [];
@@ -205,7 +205,10 @@ export async function validateStartup({ config, fizzy, runner }) {
   try {
     users = await fizzy?.listUsers?.(config.fizzy?.account) ?? [];
   } catch (error) {
-    errors.push(issue("FIZZY_USERS_UNAVAILABLE", "Unable to list Fizzy users.", { cause: error.message }));
+    errors.push(issue("FIZZY_USERS_UNAVAILABLE", "Unable to list Fizzy users.", {
+      ...fizzyAccessFailureDetails(error),
+      account: config.fizzy?.account
+    }));
   }
 
   if (identityValid) {
@@ -213,7 +216,11 @@ export async function validateStartup({ config, fizzy, runner }) {
     try {
       tags = await fizzy?.listTags?.(config.fizzy?.account) ?? [];
     } catch (error) {
-      errors.push(issue(error.code ?? "FIZZY_TAGS_UNAVAILABLE", error.message, error.details ?? {}));
+      errors.push(issue(error.code ?? "FIZZY_TAGS_UNAVAILABLE", error.message, {
+        ...fizzyAccessFailureDetails(error),
+        ...(error.details ?? {}),
+        account: config.fizzy?.account
+      }));
     }
 
     try {
@@ -235,7 +242,7 @@ export async function validateStartup({ config, fizzy, runner }) {
       } catch (error) {
         errors.push(issue("BOARD_UNAVAILABLE", "Configured board is not accessible.", {
           board_id: entry.id,
-          cause: error.message
+          ...fizzyAccessFailureDetails(error)
         }));
       }
     }
@@ -271,7 +278,10 @@ export async function validateStartup({ config, fizzy, runner }) {
   try {
     runnerHealth = await validateRunner(config, runner);
     if (runnerHealth.status !== "ready" && !config.diagnostics?.no_dispatch) {
-      errors.push(issue("RUNNER_UNAVAILABLE", "Configured Codex runner is not ready.", runnerHealth));
+      errors.push(issue("RUNNER_UNAVAILABLE", "Configured Codex runner is not ready.", {
+        remediation: "Install or expose the Codex CLI, confirm `codex app-server --listen stdio://` starts, and rerun validation.",
+        ...runnerHealth
+      }));
     }
   } catch (error) {
     runnerHealth = { status: "unavailable", kind: config.runner?.preferred ?? "unknown", error: error.message };
@@ -367,7 +377,10 @@ export function parseCompletionFailureMarker(body) {
 
 function validateLocalConfig(config, errors) {
   if (!config.fizzy?.token) {
-    errors.push(issue("CONFIG_MISSING_SECRET", "fizzy.token must resolve to a non-empty value.", { path: "fizzy.token" }));
+    errors.push(issue("CONFIG_MISSING_SECRET", "fizzy.token must resolve to a non-empty value.", {
+      path: "fizzy.token",
+      remediation: "Set FIZZY_API_TOKEN or configure fizzy.token before running full startup validation."
+    }));
   }
 
   if (!validPort(config.server?.port) || !validPort(config.server?.base_port)) {
@@ -819,6 +832,19 @@ function shortRouteId(routeId) {
 
 function omitUndefined(object) {
   return Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined));
+}
+
+function fizzyAccessFailureDetails(error) {
+  const status = error.status ?? error.metadata?.status;
+  const authenticationFailure = status === 401 || status === 403;
+  return omitUndefined({
+    cause: error.message,
+    status,
+    request_id: error.metadata?.request_id,
+    remediation: authenticationFailure
+      ? "Check FIZZY_API_TOKEN and confirm the token can access the configured Fizzy account and boards, then rerun validation."
+      : "Check FIZZY_API_URL, network access, Fizzy API availability, and configured account or board access, then rerun validation."
+  });
 }
 
 function canonicalJson(value) {

--- a/test/cli-production-clients.test.js
+++ b/test/cli-production-clients.test.js
@@ -49,7 +49,9 @@ test("public setup constructs production clients when injected clients are absen
     runner: "cli_app_server",
     warnings: []
   });
-  assert.match(await readFile(configPath, "utf8"), /id: board_1/);
+  const generatedConfig = await readFile(configPath, "utf8");
+  assert.match(generatedConfig, /id: board_1/);
+  assert.match(generatedConfig, /api_url: https:\/\/app\.fizzy\.test/);
 });
 
 test("public validate constructs real Fizzy and runner clients in normal mode", async () => {
@@ -308,7 +310,8 @@ function fakeSetupFizzy() {
     async listTags() {
       return managedTags();
     },
-    async getBoard() {
+    async getBoard(_boardId, options = {}) {
+      assert.equal(options.account, "acct_1");
       return board;
     },
     async getEntropy() {

--- a/test/cli-production-clients.test.js
+++ b/test/cli-production-clients.test.js
@@ -1,0 +1,384 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { main as cliMain } from "../bin/fizzy-symphony.js";
+import { writeAnnotatedConfig } from "../src/config.js";
+
+test("public setup constructs production clients when injected clients are absent", async () => {
+  const dir = await setupWorkspace("fizzy-symphony-cli-setup-factory-");
+  const configPath = join(dir, "config.yml");
+  const calls = [];
+
+  const result = await runCli([
+    "setup",
+    "--config",
+    configPath,
+    "--account",
+    "acct_1",
+    "--board",
+    "board_1",
+    "--workspace-repo",
+    dir
+  ], {
+    env: { FIZZY_API_TOKEN: "token", FIZZY_API_URL: "https://app.fizzy.test" },
+    clientFactories: {
+      createFizzyClient({ config }) {
+        calls.push(["createFizzyClient", config.fizzy.api_url, Boolean(config.fizzy.token)]);
+        return fakeSetupFizzy();
+      },
+      createRunner({ config }) {
+        calls.push(["createRunner", config.runner?.preferred ?? "cli_app_server"]);
+        return fakeRunner();
+      }
+    }
+  });
+
+  assert.equal(result.exitCode, 0, result.stderr);
+  assert.deepEqual(calls, [
+    ["createFizzyClient", "https://app.fizzy.test", true],
+    ["createRunner", "cli_app_server"]
+  ]);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    ok: true,
+    path: configPath,
+    account: "acct_1",
+    boards: ["board_1"],
+    runner: "cli_app_server",
+    warnings: []
+  });
+  assert.match(await readFile(configPath, "utf8"), /id: board_1/);
+});
+
+test("public validate constructs real Fizzy and runner clients in normal mode", async () => {
+  const dir = await setupWorkspace("fizzy-symphony-cli-validate-factory-");
+  const configPath = await writeConfig(dir);
+  const calls = [];
+
+  const result = await runCli(["validate", "--config", configPath], {
+    env: { FIZZY_API_TOKEN: "token" },
+    clientFactories: {
+      createFizzyClient({ config }) {
+        calls.push(["createFizzyClient", config.fizzy.account]);
+        return fakeValidationFizzy();
+      },
+      createRunner({ config }) {
+        calls.push(["createRunner", config.runner.preferred]);
+        return fakeRunner({ calls });
+      }
+    }
+  });
+
+  assert.equal(result.exitCode, 0, result.stderr);
+  assert.deepEqual(calls, [
+    ["createFizzyClient", "acct"],
+    ["createRunner", "cli_app_server"],
+    ["runner.detect", "cli_app_server"],
+    ["runner.validate", "cli_app_server"],
+    ["runner.health", "cli_app_server"]
+  ]);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.mode, "startup");
+  assert.equal(payload.runnerHealth.status, "ready");
+  assert.deepEqual(payload.errors, []);
+});
+
+test("public validate parse-only stays config-only and does not construct external clients", async () => {
+  const dir = await setupWorkspace("fizzy-symphony-cli-parse-only-");
+  const configPath = await writeConfig(dir);
+
+  const result = await runCli(["validate", "--parse-only", "--config", configPath], {
+    env: { FIZZY_API_TOKEN: "token" },
+    clientFactories: {
+      createFizzyClient() {
+        throw new Error("parse-only should not construct a Fizzy client");
+      },
+      createRunner() {
+        throw new Error("parse-only should not construct a runner");
+      }
+    }
+  });
+
+  assert.equal(result.exitCode, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), { ok: true, mode: "parse-only" });
+});
+
+test("public validate does not use noop runner defaults when diagnostics.no_dispatch is set", async () => {
+  const dir = await setupWorkspace("fizzy-symphony-cli-no-dispatch-");
+  const configPath = await writeConfig(dir, { noDispatch: true });
+  const calls = [];
+
+  const result = await runCli(["validate", "--config", configPath], {
+    env: { FIZZY_API_TOKEN: "token" },
+    clientFactories: {
+      createFizzyClient() {
+        calls.push(["createFizzyClient"]);
+        return fakeValidationFizzy();
+      },
+      createRunner() {
+        calls.push(["createRunner"]);
+        return fakeRunner({
+          calls,
+          health: {
+            status: "unavailable",
+            kind: "cli_app_server",
+            remediation: "Install or expose the Codex CLI."
+          }
+        });
+      }
+    }
+  });
+
+  assert.equal(result.exitCode, 0, result.stderr);
+  assert.deepEqual(calls, [
+    ["createFizzyClient"],
+    ["createRunner"],
+    ["runner.detect", "cli_app_server"],
+    ["runner.validate", "cli_app_server"],
+    ["runner.health", "cli_app_server"]
+  ]);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.runnerHealth.status, "unavailable");
+});
+
+test("public setup reports missing Fizzy credentials with remediation", async () => {
+  const dir = await setupWorkspace("fizzy-symphony-cli-missing-token-");
+  const result = await runCli([
+    "setup",
+    "--config",
+    join(dir, "config.yml"),
+    "--workspace-repo",
+    dir
+  ], {
+    env: { FIZZY_API_URL: "https://app.fizzy.test" }
+  });
+
+  assert.equal(result.exitCode, 2);
+  const payload = JSON.parse(result.stderr);
+  assert.equal(payload.code, "FIZZY_CREDENTIALS_MISSING");
+  assert.match(payload.details.remediation, /FIZZY_API_TOKEN/);
+});
+
+test("public setup reports unreachable Fizzy API with remediation", async () => {
+  const dir = await setupWorkspace("fizzy-symphony-cli-api-down-");
+  const result = await runCli([
+    "setup",
+    "--config",
+    join(dir, "config.yml"),
+    "--workspace-repo",
+    dir
+  ], {
+    env: { FIZZY_API_TOKEN: "token", FIZZY_API_URL: "https://app.fizzy.test" },
+    fetch: async () => {
+      throw new TypeError("fetch failed");
+    }
+  });
+
+  assert.equal(result.exitCode, 2);
+  const payload = JSON.parse(result.stderr);
+  assert.equal(payload.code, "FIZZY_IDENTITY_INVALID");
+  assert.match(payload.details.remediation, /FIZZY_API_URL/);
+});
+
+test("public setup reports missing Codex runner with remediation", async () => {
+  const dir = await setupWorkspace("fizzy-symphony-cli-missing-runner-");
+  const result = await runCli([
+    "setup",
+    "--config",
+    join(dir, "config.yml"),
+    "--account",
+    "acct_1",
+    "--board",
+    "board_1",
+    "--workspace-repo",
+    dir
+  ], {
+    env: { FIZZY_API_TOKEN: "token", FIZZY_API_URL: "https://app.fizzy.test" },
+    clientFactories: {
+      createFizzyClient() {
+        return fakeSetupFizzy();
+      }
+    },
+    runnerOptions: {
+      versionProbe: async () => ({ ok: false, reason: "command_not_found", message: "spawn codex ENOENT" })
+    }
+  });
+
+  assert.equal(result.exitCode, 2);
+  const payload = JSON.parse(result.stderr);
+  assert.equal(payload.code, "RUNNER_UNAVAILABLE");
+  assert.match(payload.details.remediation, /Codex CLI/);
+});
+
+test("public validate reports missing Fizzy credentials with remediation", async () => {
+  const dir = await setupWorkspace("fizzy-symphony-cli-validate-missing-token-");
+  const configPath = await writeConfig(dir, { blankToken: true });
+
+  const result = await runCli(["validate", "--config", configPath], {
+    env: {}
+  });
+
+  assert.equal(result.exitCode, 2);
+  const payload = JSON.parse(result.stderr);
+  assert.equal(payload.code, "FIZZY_CREDENTIALS_MISSING");
+  assert.match(payload.details.remediation, /FIZZY_API_TOKEN/);
+});
+
+test("public validate reports missing Codex runner as structured startup failure", async () => {
+  const dir = await setupWorkspace("fizzy-symphony-cli-validate-missing-runner-");
+  const configPath = await writeConfig(dir);
+
+  const result = await runCli(["validate", "--config", configPath], {
+    env: { FIZZY_API_TOKEN: "token" },
+    clientFactories: {
+      createFizzyClient() {
+        return fakeValidationFizzy();
+      }
+    },
+    runnerOptions: {
+      versionProbe: async () => ({ ok: false, reason: "command_not_found", message: "spawn codex ENOENT" })
+    }
+  });
+
+  assert.equal(result.exitCode, 2);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.ok, false);
+  assert.equal(payload.mode, "startup");
+  assert.equal(payload.errors.at(-1).code, "RUNNER_DETECT_FAILED");
+  assert.match(payload.errors.at(-1).details.remediation, /Codex CLI/);
+});
+
+async function runCli(args, options = {}) {
+  let stdout = "";
+  let stderr = "";
+  const exitCode = await cliMain(args, {
+    env: options.env ?? process.env,
+    clientFactories: options.clientFactories,
+    runnerOptions: options.runnerOptions,
+    fetch: options.fetch,
+    stdout: { write: (chunk) => { stdout += chunk; } },
+    stderr: { write: (chunk) => { stderr += chunk; } }
+  });
+  return { exitCode, stdout, stderr };
+}
+
+async function setupWorkspace(prefix) {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  await writeFile(join(dir, "WORKFLOW.md"), "# Workflow\n", "utf8");
+  return dir;
+}
+
+async function writeConfig(dir, options = {}) {
+  const configPath = join(dir, "config.yml");
+  await writeAnnotatedConfig(configPath, {
+    account: "acct",
+    board: { id: "board_1", label: "Agents" },
+    runnerPreferred: "cli_app_server",
+    workspaceRepo: dir
+  });
+
+  if (options.noDispatch) {
+    const text = await readFile(configPath, "utf8");
+    await writeFile(configPath, text.replace(/no_dispatch: false/u, "no_dispatch: true"), "utf8");
+  }
+  if (options.blankToken) {
+    const text = await readFile(configPath, "utf8");
+    await writeFile(configPath, text.replace(/token: \$FIZZY_API_TOKEN/u, 'token: ""'), "utf8");
+  }
+
+  return configPath;
+}
+
+function fakeSetupFizzy() {
+  const board = boardFixture();
+  return {
+    async getIdentity() {
+      return { accounts: [{ id: "acct_1", name: "Team Account" }], user: { id: "user_1" } };
+    },
+    async listBoards() {
+      return [board];
+    },
+    async listUsers() {
+      return [{ id: "user_1", name: "Human" }];
+    },
+    async listTags() {
+      return managedTags();
+    },
+    async getBoard() {
+      return board;
+    },
+    async getEntropy() {
+      return { warnings: [] };
+    }
+  };
+}
+
+function fakeValidationFizzy() {
+  const board = boardFixture();
+  return {
+    async getIdentity() {
+      return { accounts: [{ id: "acct", name: "Team Account" }], user: { id: "user_1" } };
+    },
+    async listUsers() {
+      return [{ id: "user_1", name: "Human" }];
+    },
+    async listTags() {
+      return managedTags();
+    },
+    async getBoard() {
+      return board;
+    },
+    async getEntropy() {
+      return { warnings: [] };
+    }
+  };
+}
+
+function fakeRunner(options = {}) {
+  return {
+    async detect(config) {
+      options.calls?.push(["runner.detect", config.preferred]);
+      return { kind: "cli_app_server", available: true, command: "codex" };
+    },
+    async validate(config) {
+      options.calls?.push(["runner.validate", config.preferred]);
+      return { ok: true, kind: "cli_app_server" };
+    },
+    async health(config) {
+      options.calls?.push(["runner.health", config.preferred]);
+      return options.health ?? { status: "ready", kind: "cli_app_server" };
+    }
+  };
+}
+
+function boardFixture() {
+  return {
+    id: "board_1",
+    name: "Agents",
+    columns: [
+      { id: "col_ready", name: "Ready for Agents" },
+      { id: "col_done", name: "Done" }
+    ],
+    cards: [
+      {
+        id: "golden_1",
+        title: "Repo Agent",
+        golden: true,
+        column_id: "col_ready",
+        tags: ["agent-instructions", "codex", "move-to-done"]
+      }
+    ]
+  };
+}
+
+function managedTags() {
+  return [
+    { id: "tag_agent", name: "agent-instructions" },
+    { id: "tag_codex", name: "codex" },
+    { id: "tag_done", name: "move-to-done" }
+  ];
+}

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -81,8 +81,8 @@ function fakeFizzy(overrides = {}) {
         { id: "tag_done", name: "move-to-done" }
       ];
     },
-    async getBoard(boardId) {
-      calls.push(["getBoard", boardId]);
+    async getBoard(boardId, options = {}) {
+      calls.push(["getBoard", boardId, options.account]);
       const board = boards.find((candidate) => candidate.id === boardId);
       if (!board) throw new Error(`missing board ${boardId}`);
       return board;
@@ -165,8 +165,8 @@ function fakeStarterFizzy() {
       if (card) card.golden = true;
       return { ok: true };
     },
-    async getBoard(boardId) {
-      calls.push(["getBoard", boardId]);
+    async getBoard(boardId, options = {}) {
+      calls.push(["getBoard", boardId, options.account]);
       return board;
     },
     async getEntropy(account, boardIds) {
@@ -215,6 +215,7 @@ test("runSetup validates Fizzy identity, lists setup inputs, validates board rou
     fizzy.calls.map((call) => call[0]),
     ["getIdentity", "listBoards", "listUsers", "listTags", "getBoard", "getEntropy"]
   );
+  assert.deepEqual(fizzy.calls.find((call) => call[0] === "getBoard"), ["getBoard", "board_1", "acct_1"]);
 
   const written = await readFile(configPath, "utf8");
   assert.match(written, /# fizzy-symphony config/);


### PR DESCRIPTION
Summary
- Wire public setup and validate to production Fizzy/Codex client factories.
- Keep validate --parse-only config-only.
- Add remediation-focused CLI tests for missing credentials, unreachable API, and missing runner.

Checks
- npm test
- git diff --check