### PR TITLE
Normalize Fizzy comments and add build CI

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,0 +1,40 @@
+name: Build package asset
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 25
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Pack npm tarball
+        run: npm pack
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: fizzy-symphony-package
+          path: fizzy-symphony-*.tgz
+          if-no-files-found: error

--- a/bin/fizzy-symphony.js
+++ b/bin/fizzy-symphony.js
@@ -17,7 +17,9 @@ export async function main(args = process.argv.slice(2), io = defaultIo()) {
   const command = args[0];
 
   try {
-    if (command === "init") {
+    if (isHelpCommand(args)) {
+      return usage(0, io);
+    } else if (command === "init") {
       return await initCommand(args.slice(1), io);
     } else if (command === "setup") {
       return await setupCommand(args.slice(1), io);
@@ -333,6 +335,10 @@ function webhookOptions(args) {
     callback_url: callbackUrl ?? "",
     subscribed_actions: actions?.split(",").map((action) => action.trim()).filter(Boolean)
   };
+}
+
+function isHelpCommand(args) {
+  return args.length === 1 && (args[0] === "--help" || args[0] === "-h");
 }
 
 function usage(exitCode, io) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,16 @@
   "bin": {
     "fizzy-symphony": "./bin/fizzy-symphony.js"
   },
+  "files": [
+    "bin",
+    "config.example.yml",
+    "docs",
+    "README.md",
+    "SPEC.md",
+    "src"
+  ],
   "scripts": {
+    "build": "node --check bin/fizzy-symphony.js && for file in src/*.js; do node --check \"$file\"; done",
     "init": "node bin/fizzy-symphony.js init",
     "start": "node bin/fizzy-symphony.js start",
     "test": "node --test"

--- a/src/fizzy-client.js
+++ b/src/fizzy-client.js
@@ -3,6 +3,7 @@ import {
   FizzyApiError,
   createFetchTransport,
   createLegacyFizzyClient,
+  resultCommentBody,
   verifyWebhookRequest,
   verifyWebhookSignature
 } from "./fizzy-http-client.js";
@@ -11,6 +12,7 @@ export {
   FizzyApiError,
   createFetchTransport,
   createLegacyFizzyClient,
+  resultCommentBody,
   verifyWebhookRequest,
   verifyWebhookSignature
 };

--- a/src/fizzy-http-client.js
+++ b/src/fizzy-http-client.js
@@ -1190,9 +1190,24 @@ function isWebhookFresh(timestamp, { now = new Date(), toleranceSeconds = 300 } 
 
 export function resultCommentBody({ result = {}, proof } = {}) {
   const body = result.output_html ?? result.body ?? result.output ?? result.output_summary ?? result.summary;
-  if (body) return String(body);
+  if (body) return richCommentHtml(body);
   if (proof?.file) return `<p>Agent run completed. Proof: <code>${escapeHtml(proof.file)}</code></p>`;
   return "<p>Agent run completed.</p>";
+}
+
+function richCommentHtml(value) {
+  const body = String(value).trim();
+  if (!body) return "<p>Agent run completed.</p>";
+  if (looksLikeHtml(body)) return body;
+
+  return body
+    .split(/\n{2,}/u)
+    .map((block) => `<p>${escapeHtml(block).replace(/\n/gu, "<br>")}</p>`)
+    .join("\n");
+}
+
+function looksLikeHtml(value) {
+  return /<(?:p|br|strong|em|ul|ol|li|h[1-6]|pre|code|blockquote|a|div|span)\b[^>]*>/iu.test(value);
 }
 
 function escapeHtml(value) {

--- a/src/workflow.js
+++ b/src/workflow.js
@@ -68,6 +68,8 @@ export function renderPrompt({
   const frontMatter = parsedWorkflow.frontMatter ?? parsedWorkflow.front_matter ?? {};
 
   return compactSections([
+    "Fizzy result comment format",
+    "Return the final response as HTML suitable for a Fizzy rich-text comment. Use only ordinary content tags such as <p>, <strong>, <em>, <ul>/<li>, <ol>/<li>, <h3>, <pre><code>, and <blockquote>. Do not return Markdown fences unless they are inside <pre><code>.",
     `Workflow front matter:\n\`\`\`json\n${JSON.stringify(frontMatter, null, 2)}\n\`\`\``,
     "Workflow prompt body",
     renderedPolicy,

--- a/test/cli-production-clients.test.js
+++ b/test/cli-production-clients.test.js
@@ -55,6 +55,16 @@ test("public init creates a starter workflow, starter board config, and human ne
   assert.match(generatedConfig, /api_url: https:\/\/fizzy\.example\.test/u);
 });
 
+test("public help exits successfully", async () => {
+  for (const flag of ["--help", "-h"]) {
+    const result = await runCli([flag], { env: {} });
+
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.match(result.stdout, /Usage:/u);
+    assert.match(result.stdout, /fizzy-symphony start/u);
+  }
+});
+
 test("public setup constructs production clients when injected clients are absent", async () => {
   const dir = await setupWorkspace("fizzy-symphony-cli-setup-factory-");
   const configPath = join(dir, "config.yml");

--- a/test/fizzy-client.test.js
+++ b/test/fizzy-client.test.js
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import { createEtagCache } from "../src/etag-cache.js";
 import {
   createFizzyClient,
+  resultCommentBody,
   verifyWebhookRequest,
   verifyWebhookSignature
 } from "../src/fizzy-client.js";
@@ -126,6 +127,25 @@ test("Fizzy fetch transport sends bearer JSON headers on account-scoped Rails ro
   assert.equal(calls[0].init.headers.Authorization, "Bearer secret-token");
   assert.equal(calls[0].init.headers.Accept, "application/json");
   assert.equal(calls[0].init.headers["Content-Type"], "application/json");
+});
+
+test("result comments are normalized to Fizzy rich-text HTML", () => {
+  assert.equal(
+    resultCommentBody({ result: { output_summary: "Changed files\nRan tests" } }),
+    "<p>Changed files<br>Ran tests</p>"
+  );
+  assert.equal(
+    resultCommentBody({ result: { output: "Summary\n\n- item" } }),
+    "<p>Summary</p>\n<p>- item</p>"
+  );
+  assert.equal(
+    resultCommentBody({ result: { output_html: "<p><strong>Done</strong></p>" } }),
+    "<p><strong>Done</strong></p>"
+  );
+  assert.equal(
+    resultCommentBody({ result: { summary: "<script>alert(1)</script>" } }),
+    "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>"
+  );
 });
 
 test("Fizzy client normalizes account slugs before building account-scoped routes", async () => {

--- a/test/fizzy-sdk-adapter.test.js
+++ b/test/fizzy-sdk-adapter.test.js
@@ -360,7 +360,7 @@ test("SDK adapter completion helpers stay on SDK-backed comments and tags", asyn
     payload: { outcome: "ok" }
   });
 
-  assert.deepEqual(resultComment, { id: "comment_1", body: "run complete" });
+  assert.deepEqual(resultComment, { id: "comment_1", body: "<p>run complete</p>" });
   assert.deepEqual(marker, {
     id: "comment_1",
     body: "marker body",
@@ -370,7 +370,7 @@ test("SDK adapter completion helpers stay on SDK-backed comments and tags", asyn
   assert.deepEqual(
     sdk.calls.filter((call) => call[0] === "comments.create" || call[0] === "cards.tag"),
     [
-      ["comments.create", "https://app.fizzy.test/api/acct", 42, { body: "run complete" }],
+      ["comments.create", "https://app.fizzy.test/api/acct", 42, { body: "<p>run complete</p>" }],
       ["comments.create", "https://app.fizzy.test/api/acct", 42, { body: "marker body" }],
       ["cards.tag", "https://app.fizzy.test/api/acct", 42, { tagTitle: "agent-rerun" }]
     ]

--- a/test/workflow.test.js
+++ b/test/workflow.test.js
@@ -178,6 +178,8 @@ Route: {{route.id}}
     }
   });
 
+  assert.match(prompt, /Fizzy result comment format/);
+  assert.match(prompt, /Return the final response as HTML suitable for a Fizzy rich-text comment/);
   assert.match(prompt, /Workflow front matter:\n```json\n\{/);
   assert.match(prompt, /"name": "Repo Agent"/);
   assert.match(prompt, /"required_steps_block_completion": true/);


### PR DESCRIPTION
## Summary
- Normalize result comments to Fizzy rich-text HTML before posting.
- Prompt agents to return Fizzy-compatible HTML for result comments.
- Add package build CI, package file list, and clean --help behavior.

## Checks
- npm test
- npm run build
- npm pack --dry-run
- git diff --check