### PR TITLE
Spike v2 cockpit runtime

### DIFF
--- a/bin/fizzy-symphony.js
+++ b/bin/fizzy-symphony.js
@@ -62,6 +62,22 @@ export async function main(args = process.argv.slice(2), io = defaultIo()) {
       return runWorktreesCommand(commandArgs, io);
     } else if (command === "doctor") {
       return runDoctorCommand(commandArgs, io);
+    } else if (command === "cockpit") {
+      const { runCockpitCommand } = await import("../src/v2/cli/cockpit.ts");
+      return runCockpitCommand(commandArgs, {
+        stdout: io.stdout,
+        stderr: io.stderr,
+        env: io.env ?? process.env,
+        fetch: io.fetch,
+        stdoutIsTTY: Boolean(io.stdout?.isTTY)
+      });
+    } else if (command === "capabilities") {
+      const { runCapabilitiesCommand } = await import("../src/v2/cli/capabilities.ts");
+      return runCapabilitiesCommand(commandArgs, {
+        stdout: io.stdout,
+        stderr: io.stderr,
+        fetch: io.fetch
+      });
     } else {
       return usage(1, io);
     }
@@ -872,7 +888,9 @@ function usage(exitCode, io) {
     "  fizzy-symphony status [--config path] [--instance id]",
     "  fizzy-symphony status [--registry-dir path] [--endpoint url]",
     "  fizzy-symphony worktrees [--config path] [--json] [--dirty-only] [--card number]",
-    "  fizzy-symphony doctor --goal [--config path] [--json]"
+    "  fizzy-symphony doctor --goal [--config path] [--json]",
+    "  fizzy-symphony cockpit [--fixture path] [--endpoint url] [--once] [--json] [--select id]",
+    "  fizzy-symphony capabilities [--fixture path] [--endpoint url] [--json]"
   ].join("\n");
   io.stdout.write(`${text}\n`);
   return exitCode;

--- a/docs/v2/cockpit-contract.md
+++ b/docs/v2/cockpit-contract.md
@@ -1,0 +1,186 @@
+# v2 Cockpit Contract
+
+The cockpit is a thin, deterministic projection of a single source of truth — the
+`SymphonyStatus` document — plus a small, validated command vocabulary. This file
+is the contract every layer agrees on: daemon, ports, model, renderer, and CLI.
+
+All types referenced here are defined in
+[src/v2/core/types.ts](../../src/v2/core/types.ts).
+
+---
+
+## 1. Status document — `SymphonyStatus`
+
+The runtime's entire observable state. Schema-stamped with
+`STATUS_SCHEMA_VERSION = "fizzy-symphony-status-v2"`.
+
+| Field | Meaning |
+| --- | --- |
+| `instance` | Daemon identity, pid, endpoint. |
+| `readiness` | `state` ∈ `ready \| blocked \| locked \| unknown`, plus `blockers[]`, `dispatchPaused`. |
+| `capabilities` | What the build can do (see §4). |
+| `boards` / `routes` / `cards` | Board topology and per-card runtime state. |
+| `runs` | Bucketed by state: `queued/running/completed/failed/cancelled/preempted`. |
+| `claims` | Claim-marker lifecycle on cards. |
+| `worktrees` | Per-workspace dirty/preserved flags, dirty paths, last error. |
+| `retryQueue` | Pending retries with attempt/next-retry. |
+| `capacityRefusals` | Cards refused due to `--max-agents` capacity. |
+| `doctor` | `goalClosable` + blockers (goal-closing doctor). |
+| `warnings` / `recentEvents` | Diagnostics surface. |
+
+`normalizeStatus(raw)` ([core/status.ts](../../src/v2/core/status.ts)) is **pure**:
+it fills empty collections, stamps the schema, infers `readiness.state`
+(`blocked` when blockers exist, `locked` when `dispatchPaused`), and never mutates
+its input.
+
+### Derived factory state
+
+`deriveFactoryState(status)` maps readiness + activity to a Wonka-themed
+`FactoryState` (`open | running | blocked | locked | unknown`) for the header.
+
+---
+
+## 2. Cockpit model — `CockpitModel`
+
+`createCockpitModel(input: CockpitModelInput)`
+([cockpit/model.ts](../../src/v2/cockpit/model.ts)) is **pure**: no IO, no fetch,
+no mutation, no clock reads beyond what's in the status. Given a status (+ optional
+events, capabilities, selection, filter) it returns a fully resolved view:
+
+- `header` — instance, endpoint, readiness, factory state, counts.
+- `lanes[]` — one per route; each lane carries themed cards with a `hazard` flag.
+- `selected` — the selected item; `raw` holds the unembellished truth
+  (`boardId/cardId/runId/sessionId/workspacePath/error`) used to build commands.
+- `panels` — `activeRuns`, `worktrees`, `doctor`, `events`, `capabilities`.
+- `actions[]` — operator actions with `key`, `enabled`, and `disabledReason`.
+- `help` — keymap + capability list.
+
+**Selection order** (for keyboard navigation) is stable: cards (in lane order),
+then running runs, then worktrees.
+
+### Action enable/disable
+
+Actions are never hidden when unavailable — they are shown **disabled with a
+reason**, computed via `checkCommandAvailability` + `deriveCapabilities`. Examples:
+
+| Action | Key | Disabled reason example |
+| --- | --- | --- |
+| Lock factory (pause) | `p` | `Dispatch is already paused.` |
+| Unlock factory (resume) | `u` | `Dispatch is not paused.` |
+| Cancel selected run | `c` | `No run selected` |
+| Stop selected session | `s` | `Selected item has no active session` |
+| Request rerun of card | `R` | `No card selected` |
+
+The renderer never decides availability — it only displays what the model resolved.
+
+---
+
+## 3. Command vocabulary — `OperatorCommand`
+
+A closed union (no free-form commands):
+
+```
+dispatch.pause   { reason? }
+dispatch.resume  { reason? }
+run.cancel       { runId, reason }
+session.stop     { sessionId, reason }
+card.rerun       { cardId, reason }
+card.move        { cardId, targetColumnId, reason }
+worktree.preserve{ workspaceKey, reason }
+worktree.cleanup { workspaceKey, reason }
+```
+
+### Command pipeline (single choke point: `runtime.submitCommand`)
+
+1. **`validateCommand(payload)`** — shape/required-field check. Codes:
+   `INVALID_COMMAND`, `UNKNOWN_COMMAND`, `MISSING_FIELD`, `MISSING_REASON`.
+   Failure → `outcome: "rejected"`.
+2. **`checkCommandAvailability(command, status)`** — semantic availability against
+   current status. Codes: `NO_ACTIVE_RUN`, `NO_ACTIVE_SESSION`, `ALREADY_PAUSED`,
+   `NOT_PAUSED`, `UNKNOWN_CARD`, `CARD_RUNNING`, `UNKNOWN_WORKTREE`.
+   Failure → `outcome: "unavailable"`.
+3. **Apply.** If `applyCommands` is `false` (spike default), the command is
+   recorded as a `command.dry-run.<type>` event and returns `outcome: "dry-run"`.
+   If `true`, it emits `command.accepted.<type>` and returns `outcome: "accepted"`.
+
+`CommandResult.outcome` ∈ `accepted | rejected | unavailable | dry-run`.
+
+> No render or model path ever submits a command or mutates state. Commands flow
+> only through `submitCommand`.
+
+---
+
+## 4. Capabilities — honest feature advertisement
+
+`core/capabilities.ts` holds a catalogue of 14 capabilities across categories
+(`fizzy/codex/board/route/runner/worktree/doctor/control/webhook/diagnostics`).
+`deriveCapabilities(status)` disables those that cannot run *right now*, with a
+reason:
+
+- `codex.run` → `Runner not ready` when the runner isn't healthy.
+- `codex.cancel` / `session.stop` → `No active run` when nothing is running.
+
+`fizzy-symphony capabilities [--json] [--fixture|--endpoint]` prints this list so an
+operator can see, before touching anything, exactly what the build can and cannot
+do.
+
+---
+
+## 5. Local API — `/v2/...`
+
+`handleApiRequest(runtime, method, pathname, body)`
+([daemon/api.ts](../../src/v2/daemon/api.ts)) is a **pure router**; `createApiServer`
+wraps it in a real `http` server.
+
+| Method & path | Behavior |
+| --- | --- |
+| `GET /v2/health` | Liveness. |
+| `GET /v2/ready` | `503` when readiness ≠ ready. |
+| `GET /v2/status` | Full `SymphonyStatus`. |
+| `GET /v2/capabilities` | Derived capabilities. |
+| `GET /v2/events` | Recent runtime events. |
+| `GET /v2/runs` | Run buckets. |
+| `GET /v2/runs/:id` | `404` if unknown. |
+| `GET /v2/worktrees` | Worktree summaries. |
+| `POST /v2/commands` | `202` dry-run/accepted, `409` unavailable, `400` rejected. |
+
+The cockpit CLI can drive itself from a live endpoint (`--endpoint`) or a fixture
+(`--fixture`), proving the same model renders identically from either source.
+
+---
+
+## 6. Ports (translated at the edges)
+
+### `FizzyPort` — independent of `@37signals/fizzy`
+
+Hand-written board/card/comment/webhook interface. Implementations:
+- `createFakeFizzyPort(seed)` — deterministic, fixture-backed (`sdk: false`).
+- `createFizzyAdapter({ mode: "sdk" | "http" })` — boundary; live ops throw
+  `FIZZY_ADAPTER_NOT_WIRED` in the spike. `describe()` advertises the mode.
+
+### `CodexRunnerPort` — SDK-compatible lifecycle
+
+`detect / health / startSession / startTurn / streamTurn / cancelTurn /
+stopSession / terminateOwnedProcess`. Implementations:
+- `createFakeCodexRunner({ mode })` — deterministic streaming
+  (`completed | failed | input_required`), contract `codex-runner-fake-v2`.
+- `createCodexAdapter({ mode: "sdk" | "cli-app-server" })` — boundary; contracts
+  `codex-runner-sdk-v1` / `codex-runner-cli-app-server-v1`; live ops throw
+  `CODEX_ADAPTER_NOT_WIRED`; `health()` reports `ADAPTER_NOT_WIRED`.
+
+---
+
+## 7. Rendering
+
+- `renderCockpitText(model)` ([cockpit/renderer.ts](../../src/v2/cockpit/renderer.ts))
+  — pure string frame for non-TTY / `--once`. Sections: header, board/factory
+  lanes, selected detail, active runs, worktrees/doctor, activity, actions,
+  footer/keys.
+- `startInteractiveCockpit({ runtime, terminalFactory? })`
+  ([cockpit/interactive.ts](../../src/v2/cockpit/interactive.ts)) — Terminal Kit
+  loop (lazily imported). Keys: `q/ESC/Ctrl-C` quit, `r` refresh, `?` help,
+  arrows/`j`/`k` navigate, `a` actions, and `p/u/c/s/R` submit the corresponding
+  command (always via `runtime.submitCommand`).
+
+Hazards (dirty worktrees, failed runs, blocked doctor) are visually obvious in the
+rendered text — verified by `test/v2/fixtures-render.test.js`.

--- a/docs/v2/decision.md
+++ b/docs/v2/decision.md
@@ -1,0 +1,100 @@
+# v2 Cockpit Runtime Spike — Decisions & Assumptions
+
+> Scope: this document records the reasonable assumptions made while building the
+> v2 cockpit runtime spike. The brief was "do not ask for clarification; make
+> reasonable assumptions and document them here." Everything below is a spike-level
+> decision, reversible, and deliberately narrow.
+
+## 1. Language & runtime: TypeScript via Node native type stripping
+
+- **Decision:** The v2 core is written in `.ts` and executed directly by Node
+  (v26) using native type stripping. There is **no build pipeline, no `tsc`, no
+  bundler**.
+- **Why:** The brief asked for a TypeScript core. The repo already runs on Node
+  >= 25 with ESM. Node 26 strips types from `.ts` on import, and `.js` test files
+  can import `.ts` modules with no extra tooling. This keeps the spike a single
+  `node --test` run, identical to v1, while still giving us typed contracts.
+- **Constraint accepted:** Type stripping only supports *erasable* syntax —
+  interfaces, type aliases, and `as` casts. **No `enum`, no `namespace`, no
+  parameter properties.** All v2 code obeys this.
+- **Imports must carry the `.ts` extension** (ESM resolution), e.g.
+  `import { createRuntime } from "./daemon/runtime.ts"`.
+
+## 2. Layout: `src/v2/` (not a separate package)
+
+- **Decision:** All spike code lives under `src/v2/` with subfolders
+  `core/`, `fizzy/`, `codex/`, `daemon/`, `cockpit/`, `cli/`, plus a barrel
+  `src/v2/index.ts`. Fixtures live in `test/fixtures/v2/`, tests in `test/v2/`.
+- **Why:** A `packages/` monorepo split was considered but rejected as too
+  disruptive for a spike. `src/v2/` is additive, leaves all of v1 untouched, and
+  is trivial to delete or promote later.
+- **No v1 deletion.** Not one v1 file was removed. The only v1 edit is additive
+  wiring in `bin/fizzy-symphony.js` (two new command branches) and the
+  `package.json` test script (so `test/v2/*.test.js` also runs).
+
+## 3. Tests are `.js`, source is `.ts`
+
+- **Decision:** Test files keep the `*.test.js` extension and import the `.ts`
+  modules under test.
+- **Why:** The existing runner globs `test/*.test.js`. Keeping the extension means
+  the v2 tests slot into the same harness with no new toolchain. Verified that a
+  `.js` test can import and exercise a `.ts` module under Node 26.
+
+## 4. Commands are dry-run by default
+
+- **Decision:** `createRuntime` accepts `applyCommands` (default **`false`**).
+  In the spike, every operator command is **validated**, **availability-checked**,
+  and then **recorded as a dry-run event** (`command.dry-run.<type>`) with outcome
+  `"dry-run"`. No real side effect is performed.
+- **Why:** The brief forbids fake controls. A button that *pretends* to cancel a
+  run is a fake control. A button that honestly reports "validated, would dispatch
+  `run.cancel run_426` — not wired in spike" is not. Dry-run is the honest middle:
+  the full validation/availability path is real, only the final effect is stubbed.
+- **Single choke point:** `runtime.submitCommand` is the *only* place a command is
+  evaluated or applied. Render and model code never mutate state.
+
+## 5. Fizzy and Codex adapters are boundaries, not fakes
+
+- **Decision:** `createFizzyAdapter` and `createCodexAdapter` implement the real
+  port interfaces but **throw on live operations** with explicit codes
+  (`FIZZY_ADAPTER_NOT_WIRED`, `CODEX_ADAPTER_NOT_WIRED`). Their `describe()` /
+  `health()` honestly advertise "not wired."
+- **Why:** The spike must prove the *shape* of the ports without pretending to
+  talk to a real Fizzy or Codex. The fakes (`createFakeFizzyPort`,
+  `createFakeCodexRunner`) are the deterministic, fixture-backed implementations
+  used by tests and the cockpit.
+- **FizzyPort is independent of the SDK.** The port types are hand-written in
+  `core/types.ts` and do not import or re-export `@37signals/fizzy` types. The SDK
+  is one possible adapter `mode`, not the contract.
+- **CodexRunnerPort is SDK-compatible.** Its method set
+  (`detect/health/startSession/startTurn/streamTurn/cancelTurn/stopSession/terminateOwnedProcess`)
+  mirrors the Codex app-server/SDK lifecycle so a real adapter can be dropped in.
+
+## 6. Default cockpit fixture
+
+- **Decision:** `fizzy-symphony cockpit` with no source flags loads
+  `test/fixtures/v2/ready.json`.
+- **Why:** A spike needs a zero-arg happy path for demos. Documented here so it is
+  not mistaken for production behavior.
+
+## 7. Non-TTY behavior preserved
+
+- **Decision:** In a non-TTY stream (or with `--once`), the cockpit prints a single
+  static text frame to stdout and a short note to stderr; it never tries to grab
+  the terminal. `--json` emits machine-readable model/capability output.
+- **Why:** v1 already supports non-interactive status. The spike must not regress
+  pipelines or CI.
+
+## 8. Terminal Kit imported lazily
+
+- **Decision:** `terminal-kit` is imported dynamically, only inside the interactive
+  renderer, behind a `terminalFactory` seam.
+- **Why:** It is a CJS dependency; lazy import keeps v1 startup and all non-TTY /
+  test paths free of it, and lets tests inject a fake terminal.
+
+## Reversal notes
+
+The entire spike is contained in `src/v2/`, `test/v2/`, `test/fixtures/v2/`,
+`docs/v2/`, and two additive edits (`bin/fizzy-symphony.js`, `package.json`).
+Deleting those directories and reverting the two edits removes v2 with zero impact
+on v1.

--- a/docs/v2/migration-inventory.md
+++ b/docs/v2/migration-inventory.md
@@ -1,0 +1,63 @@
+# v1 → v2 Migration Inventory
+
+A feature-by-feature inventory of the v1 runtime, mapped to its v2 cockpit
+contract and a keep / defer / drop disposition for the spike. This is the
+"what exists and where it goes" map — **no v1 code was deleted**; this document
+is the plan, not the surgery.
+
+Legend for **Disposition**:
+- **Keep** — modelled in the v2 contract now (status field, capability, and/or
+  command).
+- **Defer** — recognized in the contract surface but not wired in the spike
+  (adapter boundary or dry-run only).
+- **Drop** — intentionally out of the v2 cockpit scope.
+
+| # | Feature | v1 source (representative) | v1 tests | User-facing command | v2 contract surface | Disposition | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Setup / onboarding wizard | `src/setup.js`, `src/setup-wizard.js` | `test/setup*.test.js` | `fizzy-symphony setup` | — (stays v1) | Drop (from cockpit) | Cockpit assumes setup already ran; not an operator-cockpit concern. |
+| 2 | Config load/validate | `src/config.js`, `src/validation.js` | `test/config.test.js`, `test/validation.test.js` | implicit | `InstanceStatus`, readiness blockers | Keep | v2 reads endpoint/instance from status. |
+| 3 | Board & route discovery | `src/domain.js`, `src/fizzy-client.js` | `test/domain.test.js`, `test/fizzy-client.test.js` | `fizzy-symphony status` | `boards[]`, `routes[]`, `FizzyPort.listBoards/listCards` | Keep | FizzyPort is SDK-independent; fake serves fixtures. |
+| 4 | Golden-ticket routing | `src/router.js`, `src/workflow.js` | `test/router.test.js`, `test/workflow.test.js` | start/daemon | `route.golden` capability, `CardRuntimeStatus.golden` | Keep | Golden cards flagged in lanes. |
+| 5 | Start / daemon loop | `src/daemon.js`, `src/scheduler.js`, `src/operator.js` | `test/daemon.test.js`, `test/scheduler.test.js` | `fizzy-symphony start` | `createRuntime`, `/v2/health`, `/v2/ready` | Keep (skeleton) | v2 daemon is a status/command runtime skeleton, not the full scheduler. |
+| 6 | Status reporting | `src/status.js`, `src/status-cli.js`, `src/status-discovery.js` | `test/status*.test.js` | `fizzy-symphony status` | `SymphonyStatus`, `/v2/status` | Keep | v2 schema is `fizzy-symphony-status-v2` (camelCase). |
+| 7 | Dashboard / terminal UI | `src/dashboard.js`, `src/terminal-ui.js`, `src/terminal-renderer.js` | `test/dashboard.test.js`, `test/terminal-*.test.js` | `fizzy-symphony dashboard` | `CockpitModel`, `renderCockpitText`, interactive cockpit | Keep | v2 cockpit is the successor surface; v1 dashboard remains. |
+| 8 | Run lifecycle / registry | `src/run-registry.js`, `src/reconciler.js` | `test/run-registry.test.js`, `test/reconciler.test.js` | observed in status | `RunStatus`, `RunBuckets`, `/v2/runs` | Keep | Bucketed by state. |
+| 9 | Claim markers | `src/claims.js`, `src/marker-comment.js` | `test/claims.test.js` | implicit | `ClaimStatus`, `claim.*` capability | Keep (model) | Claim state surfaced; mutation deferred. |
+| 10 | Workspace / worktree metadata | `src/workspace.js` | `test/workspace.test.js` | implicit | `WorktreeStatus`, `/v2/worktrees` | Keep | Dirty/preserved flags + dirty paths. |
+| 11 | Dirty-worktree protection | `src/workspace.js`, `src/recovery.js` | `test/recovery.test.js`, `test/workspace.test.js` | implicit | `WorktreeStatus.dirty`, hazard label "Spill / hazard" | Keep | Hazard is visually obvious in render. |
+| 12 | Worktree preserve / cleanup | `src/recovery.js`, `src/workspace.js` | `test/recovery.test.js` | implicit | `worktree.preserve` / `worktree.cleanup` commands | Defer | Validated + dry-run only in spike. |
+| 13 | Goal-closing doctor | `src/recovery.js` (doctor) | covered in recovery tests | `--goal` doctor | `DoctorStatus`, `doctor.goal` capability | Keep | `goalClosable` + blockers, themed "Factory cannot close". |
+| 14 | Workflow loading / cache fallback | `src/workflow.js`, `src/git-source-cache.js` | `test/workflow.test.js`, `test/git-source-cache.test.js` | implicit | `route.model/backend` fields | Defer | Routing metadata only; loader not re-implemented. |
+| 15 | Retry queue | `src/scheduler.js`, `src/run-registry.js` | `test/scheduler.test.js` | observed in status | `RetryQueueItem[]` | Keep (model) | Surfaced in status; scheduling deferred. |
+| 16 | Capacity refusals (`--max-agents`) | `src/scheduler.js` | `test/scheduler.test.js` | start flag | `CapacityRefusal[]` | Keep (model) | Refusals surfaced as diagnostics. |
+| 17 | Webhook filtering | `src/listener.js` | `test/listener.test.js` | listener | `webhook.filter` capability, `FizzyPort.verifyWebhook` | Defer | Capability advertised; adapter not wired. |
+| 18 | Managed webhooks | `src/listener.js`, `src/fizzy-http-client.js` | `test/listener.test.js` | listener | `FizzyPort.listWebhooks` (optional) | Defer | Optional port method; not wired. |
+| 19 | Runner health monitoring | `src/runner-health.js`, `src/runner-contract.js` | `test/runner-contract.test.js` | observed | `CodexRunnerPort.health`, `runner.health` capability | Keep | Health drives `codex.run` enablement. |
+| 20 | Codex CLI runner | `src/codex-cli-app-server-runner.js` | `test/codex-cli-app-server-runner.test.js` | start | `createCodexAdapter({mode:"cli-app-server"})` | Defer | Boundary; contract `codex-runner-cli-app-server-v1`. |
+| 21 | Codex app-server transport | `src/codex-app-server-transport.js` | `test/codex-app-server-transport.test.js` | start | `CodexRunnerPort` streaming shape | Defer | Mirrored by fake's streaming. |
+| 22 | Codex SDK compatibility | `src/client-factories.js`, `src/fizzy-sdk-adapter.js` | `test/fizzy-sdk-adapter.test.js` | start | `createCodexAdapter({mode:"sdk"})` | Defer | Contract `codex-runner-sdk-v1`. |
+| 23 | Run cancellation | `src/run-registry.js`, `src/operator.js` | `test/run-registry.test.js` | operator | `run.cancel` command, `CodexRunnerPort.cancelTurn` | Defer | Validated + dry-run; fake supports cancel. |
+| 24 | Session stop | `src/operator.js` | covered | operator | `session.stop` command, `stopSession` | Defer | Validated + dry-run. |
+| 25 | Process termination | `src/codex-cli-app-server-runner.js` | covered | operator | `CodexRunnerPort.terminateOwnedProcess` (optional) | Defer | Optional port method. |
+| 26 | Dispatch pause / resume | `src/operator.js`, `src/scheduler.js` | covered | operator | `dispatch.pause` / `dispatch.resume`, `control.dispatch` | Keep | "Lock / unlock factory" actions; dry-run in spike. |
+| 27 | Card rerun / move | `src/operator.js`, `src/router.js` | covered | operator | `card.rerun` / `card.move` commands | Defer | Validated + dry-run; `card.move` needs target column. |
+| 28 | Completion proof | `src/completion.js` | `test/completion.test.js` | observed | `CardRuntimeState: completed`, run state | Keep (model) | Completion reflected in card/run state. |
+| 29 | Event / activity log | `src/logger.js`, polling events | `test/logger.test.js` | dashboard | `RuntimeEvent[]`, `/v2/events`, `diagnostics.events` | Keep | v2 event log with JSONL export. |
+| 30 | Non-TTY behavior | `src/cli-opener.js`, `src/dashboard.js` | `test/cli-opener.test.js` | all | `renderCockpitText`, `--once`, `--json` | Keep | Static frame + machine output; no terminal grab. |
+| 31 | Polling / etag cache | `src/polling.js`, `src/etag-cache.js` | `test/polling.test.js`, `test/etag-cache.test.js` | internal | endpoint refresh in CLI | Defer | v2 reads on demand; no long-poll loop in spike. |
+| 32 | Instance registry | `src/instance-registry.js`, `src/instance.js` | `test/instance*.test.js` | discovery | `InstanceStatus` | Keep (model) | Single-instance assumption in spike. |
+
+## Summary
+
+- **Keep (modelled now):** status schema, boards/routes/cards, runs, worktrees,
+  doctor, capabilities, dispatch pause/resume, events, non-TTY rendering — the
+  observable cockpit surface.
+- **Defer (boundary / dry-run):** all *mutating* operations (run cancel, session
+  stop, card rerun/move, worktree preserve/cleanup) and all *live* integrations
+  (Fizzy SDK/HTTP, Codex SDK/CLI, webhooks, polling). These have honest contract
+  surfaces but are not wired — no fake controls.
+- **Drop (out of cockpit scope):** setup/onboarding.
+
+The v2 cockpit therefore gives an operator a truthful, read-mostly view of the
+factory plus a validated command palette whose effects are explicitly dry-run
+until the adapters are wired.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "setup": "node bin/fizzy-symphony.js setup",
     "start": "node bin/fizzy-symphony.js start",
     "dashboard": "node bin/fizzy-symphony.js dashboard",
-    "test": "for file in test/*.test.js; do node --test \"$file\" || exit $?; done",
+    "cockpit": "node bin/fizzy-symphony.js cockpit",
+    "capabilities": "node bin/fizzy-symphony.js capabilities",
+    "test": "for file in test/*.test.js test/v2/*.test.js; do node --test \"$file\" || exit $?; done",
+    "test:v2": "for file in test/v2/*.test.js; do node --test \"$file\" || exit $?; done",
     "test:live:e2e": "node --test test/live-e2e-smoke.test.js"
   },
   "engines": {

--- a/src/v2/cli/capabilities.ts
+++ b/src/v2/cli/capabilities.ts
@@ -1,0 +1,65 @@
+// `fizzy-symphony capabilities` command.
+//
+// Prints the capability registry (optionally derived against a fixture/endpoint
+// status snapshot so disabled reasons are live). Supports --json.
+
+import { readFile } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
+
+import { deriveCapabilities, listCapabilities } from "../core/capabilities.ts";
+import { normalizeStatus } from "../core/status.ts";
+import type { Capability, FixtureBundle, SymphonyStatus } from "../core/types.ts";
+
+export interface CapabilitiesIo {
+  stdout: { write(text: string): void };
+  stderr: { write(text: string): void };
+  fetch?: typeof fetch;
+}
+
+function optionValue(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  return args[index + 1];
+}
+
+async function statusFromArgs(args: string[], io: CapabilitiesIo): Promise<SymphonyStatus | undefined> {
+  const fixture = optionValue(args, "--fixture");
+  const endpoint = optionValue(args, "--endpoint");
+  if (fixture) {
+    const path = isAbsolute(fixture) ? fixture : resolve(process.cwd(), fixture);
+    const raw = JSON.parse(await readFile(path, "utf8")) as FixtureBundle | SymphonyStatus;
+    const status = "status" in (raw as Record<string, unknown>) ? (raw as FixtureBundle).status : (raw as SymphonyStatus);
+    return normalizeStatus(status);
+  }
+  if (endpoint) {
+    const doFetch = io.fetch ?? fetch;
+    const res = await doFetch(`${endpoint.replace(/\/$/, "")}/v2/status`);
+    if (!res.ok) throw new Error(`GET /v2/status failed: ${res.status}`);
+    return normalizeStatus((await res.json()) as SymphonyStatus);
+  }
+  return undefined;
+}
+
+export async function runCapabilitiesCommand(args: string[], io: CapabilitiesIo): Promise<number> {
+  let capabilities: Capability[];
+  try {
+    const status = await statusFromArgs(args, io);
+    capabilities = status ? deriveCapabilities(status) : listCapabilities();
+  } catch (error) {
+    io.stderr.write(`capabilities: ${(error as Error).message}\n`);
+    return 1;
+  }
+
+  if (args.includes("--json")) {
+    io.stdout.write(`${JSON.stringify({ capabilities }, null, 2)}\n`);
+    return 0;
+  }
+
+  io.stdout.write("fizzy-symphony capabilities (v2)\n");
+  for (const capability of capabilities) {
+    const state = capability.enabled ? "enabled " : "DISABLED";
+    const reason = capability.enabled ? "" : `  (${capability.disabledReason ?? "n/a"})`;
+    io.stdout.write(`  [${state}] ${capability.category.padEnd(11)} ${capability.id} — ${capability.title}${reason}\n`);
+  }
+  return 0;
+}

--- a/src/v2/cli/cockpit.ts
+++ b/src/v2/cli/cockpit.ts
@@ -1,0 +1,133 @@
+// `fizzy-symphony cockpit` command.
+//
+// Modes:
+//   cockpit                         interactive (TTY) or static (non-TTY)
+//   cockpit --endpoint URL          read snapshot from a running v2 daemon
+//   cockpit --fixture PATH          read a fixture bundle
+//   cockpit --once                  print one static frame and exit
+//   cockpit --json                  print the cockpit model as JSON and exit
+//
+// Layering rule: this command builds a runtime (fixture or snapshot), derives
+// the pure cockpit model, then renders. It never reaches into Fizzy/Codex.
+
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createCockpitModel } from "../cockpit/model.ts";
+import { renderCockpitText } from "../cockpit/renderer.ts";
+import { startInteractiveCockpit } from "../cockpit/interactive.ts";
+import { createRuntime } from "../daemon/runtime.ts";
+import type { SymphonyRuntime } from "../daemon/runtime.ts";
+import type { FixtureBundle, SymphonyStatus } from "../core/types.ts";
+
+export interface CockpitIo {
+  stdout: { write(text: string): void };
+  stderr: { write(text: string): void };
+  env?: Record<string, string | undefined>;
+  fetch?: typeof fetch;
+  stdoutIsTTY?: boolean;
+}
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const DEFAULT_FIXTURE = join(PACKAGE_ROOT, "test", "fixtures", "v2", "ready.json");
+
+function optionValue(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  return args[index + 1];
+}
+
+function hasFlag(args: string[], name: string): boolean {
+  return args.includes(name);
+}
+
+function asBundle(raw: unknown): FixtureBundle {
+  if (raw && typeof raw === "object" && "status" in (raw as Record<string, unknown>)) {
+    return raw as FixtureBundle;
+  }
+  return { status: raw as Partial<SymphonyStatus> as SymphonyStatus };
+}
+
+async function loadFixtureBundle(path: string): Promise<FixtureBundle> {
+  const resolved = isAbsolute(path) ? path : resolve(process.cwd(), path);
+  const text = await readFile(resolved, "utf8");
+  return asBundle(JSON.parse(text));
+}
+
+async function loadEndpointBundle(endpoint: string, io: CockpitIo): Promise<FixtureBundle> {
+  const doFetch = io.fetch ?? fetch;
+  const base = endpoint.replace(/\/$/, "");
+  const statusRes = await doFetch(`${base}/v2/status`);
+  if (!statusRes.ok) throw new Error(`GET /v2/status failed: ${statusRes.status}`);
+  const status = (await statusRes.json()) as SymphonyStatus;
+  let events;
+  try {
+    const eventsRes = await doFetch(`${base}/v2/events`);
+    if (eventsRes.ok) events = ((await eventsRes.json()) as { events?: unknown }).events as FixtureBundle["events"];
+  } catch {
+    // events are optional
+  }
+  return { status, events };
+}
+
+async function buildRuntime(args: string[], io: CockpitIo): Promise<{ runtime: SymphonyRuntime; source: string }> {
+  const endpoint = optionValue(args, "--endpoint");
+  const fixture = optionValue(args, "--fixture");
+  if (endpoint) {
+    const bundle = await loadEndpointBundle(endpoint, io);
+    return { runtime: createRuntime({ status: bundle.status, events: bundle.events }), source: `endpoint ${endpoint}` };
+  }
+  const fixturePath = fixture ?? DEFAULT_FIXTURE;
+  const bundle = await loadFixtureBundle(fixturePath);
+  return {
+    runtime: createRuntime({ status: bundle.status, events: bundle.events, capabilities: bundle.capabilities }),
+    source: `fixture ${fixturePath}`
+  };
+}
+
+export async function runCockpitCommand(args: string[], io: CockpitIo): Promise<number> {
+  let runtime: SymphonyRuntime;
+  let source: string;
+  try {
+    ({ runtime, source } = await buildRuntime(args, io));
+  } catch (error) {
+    io.stderr.write(`cockpit: failed to load source: ${(error as Error).message}\n`);
+    return 1;
+  }
+
+  const wantJson = hasFlag(args, "--json");
+  const wantOnce = hasFlag(args, "--once");
+  const isTty = io.stdoutIsTTY ?? Boolean((io.stdout as { isTTY?: boolean }).isTTY);
+
+  const model = createCockpitModel({
+    status: runtime.getStatus(),
+    events: runtime.getEvents(20),
+    capabilities: runtime.getCapabilities(),
+    selectedId: optionValue(args, "--select")
+  });
+
+  if (wantJson) {
+    io.stdout.write(`${JSON.stringify(model, null, 2)}\n`);
+    return 0;
+  }
+
+  if (wantOnce || !isTty) {
+    if (!isTty && !wantOnce) {
+      io.stderr.write(`cockpit: non-TTY detected, printing static frame (${source}).\n`);
+    }
+    io.stdout.write(`${renderCockpitText(model)}\n`);
+    return 0;
+  }
+
+  // Interactive TTY mode.
+  try {
+    const session = await startInteractiveCockpit({ runtime });
+    await session.done;
+    return 0;
+  } catch (error) {
+    io.stderr.write(`cockpit: interactive renderer unavailable (${(error as Error).message}); static frame:\n`);
+    io.stdout.write(`${renderCockpitText(model)}\n`);
+    return 0;
+  }
+}

--- a/src/v2/cockpit/interactive.ts
+++ b/src/v2/cockpit/interactive.ts
@@ -1,0 +1,191 @@
+// Interactive Terminal Kit cockpit renderer.
+//
+// This is the only place Terminal Kit is touched. It draws the pure
+// CockpitModel and routes keypresses to:
+//   - navigation/selection/filter/help (read-only, re-derives the model)
+//   - command requests (delegated to runtime.submitCommand)
+//
+// It NEVER calls Fizzy/Codex, never mutates status, never spawns processes.
+// Mutations only ever happen through runtime.submitCommand (typed commands).
+
+import { createCockpitModel } from "./model.ts";
+import { renderCockpitText } from "./renderer.ts";
+import type { SymphonyRuntime } from "../daemon/runtime.ts";
+import type { CockpitModel, SymphonyStatus } from "../core/types.ts";
+
+export interface InteractiveCockpitOptions {
+  runtime: SymphonyRuntime;
+  // Injected for tests; defaults to dynamically importing terminal-kit.
+  terminalFactory?: () => Promise<TerminalLike>;
+}
+
+// Minimal slice of the terminal-kit Terminal surface we rely on.
+export interface TerminalLike {
+  fullscreen(on: boolean): void;
+  clear(): void;
+  moveTo(x: number, y: number): void;
+  hideCursor(on?: boolean): void;
+  grabInput(options: boolean | Record<string, unknown>): void;
+  on(event: "key", handler: (name: string) => void): void;
+  off?(event: "key", handler: (name: string) => void): void;
+  (text: string): void;
+}
+
+function selectableIds(status: SymphonyStatus): string[] {
+  const ids: string[] = [];
+  for (const card of status.cards) ids.push(card.id);
+  for (const run of status.runs.running) ids.push(run.id);
+  for (const worktree of status.worktrees) ids.push(worktree.workspaceKey);
+  return ids;
+}
+
+const ACTION_KEY_TO_ID: Record<string, string> = {
+  p: "dispatch.pause",
+  u: "dispatch.resume",
+  c: "run.cancel",
+  s: "session.stop",
+  R: "card.rerun"
+};
+
+async function defaultTerminalFactory(): Promise<TerminalLike> {
+  const mod = await import("terminal-kit");
+  return (mod.terminal ?? (mod as { default?: { terminal: TerminalLike } }).default?.terminal) as TerminalLike;
+}
+
+export interface InteractiveSession {
+  // Resolves when the user quits.
+  done: Promise<void>;
+  // For tests: simulate a key without a real TTY.
+  handleKey(name: string): void;
+  currentModel(): CockpitModel;
+}
+
+// Starts the interactive loop. Returns a session handle whose `done` promise
+// resolves on quit. Pure model derivation happens on every keypress.
+export async function startInteractiveCockpit(
+  options: InteractiveCockpitOptions
+): Promise<InteractiveSession> {
+  const runtime = options.runtime;
+  const term = await (options.terminalFactory ?? defaultTerminalFactory)();
+
+  let selectedIndex = 0;
+  let filter: string | undefined;
+  let statusLine = "Ready. Press ? for the Factory Manual, q to quit.";
+  let resolveDone!: () => void;
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+
+  function model(): CockpitModel {
+    const status = runtime.getStatus();
+    const ids = selectableIds(status);
+    const selectedId = ids.length > 0 ? ids[Math.max(0, Math.min(selectedIndex, ids.length - 1))] : undefined;
+    return createCockpitModel({
+      status,
+      events: runtime.getEvents(20),
+      capabilities: runtime.getCapabilities(),
+      selectedId,
+      filter
+    });
+  }
+
+  function draw(): void {
+    term.clear();
+    term.moveTo(1, 1);
+    term(renderCockpitText(model()));
+    term(`\n\n> ${statusLine}\n`);
+  }
+
+  function submit(actionId: string): void {
+    const current = model();
+    const action = current.actions.find((entry) => entry.id === actionId);
+    if (!action) {
+      statusLine = `Action ${actionId} not available in this build.`;
+      return;
+    }
+    if (!action.enabled || !action.commandType) {
+      statusLine = `${action.label} disabled: ${action.disabledReason ?? "unavailable"}`;
+      return;
+    }
+    const selection = current.selected;
+    const command = buildCommand(action.commandType, selection);
+    if (!command) {
+      statusLine = `${action.label} disabled: no valid target selected.`;
+      return;
+    }
+    const result = runtime.submitCommand(command);
+    statusLine = `${result.outcome.toUpperCase()}: ${result.message}`;
+  }
+
+  function handleKey(name: string): void {
+    const ids = selectableIds(runtime.getStatus());
+    if (name === "q" || name === "ESCAPE" || name === "CTRL_C") {
+      cleanup();
+      return;
+    }
+    if (name === "r") {
+      statusLine = "Refreshed.";
+    } else if (name === "?") {
+      statusLine = model().help.manualTitle;
+    } else if (name === "UP" || name === "k") {
+      selectedIndex = Math.max(0, selectedIndex - 1);
+    } else if (name === "DOWN" || name === "j") {
+      selectedIndex = Math.min(Math.max(0, ids.length - 1), selectedIndex + 1);
+    } else if (name === "a") {
+      const actions = model().actions.map((entry) => `${entry.key}:${entry.enabled ? "on" : "off"}`).join(" ");
+      statusLine = `Actions ${actions}`;
+    } else if (ACTION_KEY_TO_ID[name]) {
+      submit(ACTION_KEY_TO_ID[name]);
+    }
+    draw();
+  }
+
+  function cleanup(): void {
+    try {
+      term.grabInput(false);
+      term.hideCursor(false);
+      term.fullscreen(false);
+    } catch {
+      // best-effort terminal restore
+    }
+    resolveDone();
+  }
+
+  if (typeof term.fullscreen === "function") term.fullscreen(true);
+  if (typeof term.hideCursor === "function") term.hideCursor(true);
+  if (typeof term.grabInput === "function") term.grabInput({ mouse: false });
+  if (typeof term.on === "function") term.on("key", handleKey);
+  draw();
+
+  return {
+    done,
+    handleKey,
+    currentModel: model
+  };
+}
+
+function buildCommand(
+  commandType: string,
+  selection: CockpitModel["selected"]
+): unknown {
+  switch (commandType) {
+    case "dispatch.pause":
+      return { type: "dispatch.pause" };
+    case "dispatch.resume":
+      return { type: "dispatch.resume" };
+    case "run.cancel":
+      return selection?.raw?.runId
+        ? { type: "run.cancel", runId: String(selection.raw.runId), reason: "operator cockpit" }
+        : undefined;
+    case "session.stop":
+      return selection?.raw?.sessionId
+        ? { type: "session.stop", sessionId: String(selection.raw.sessionId), reason: "operator cockpit" }
+        : undefined;
+    case "card.rerun":
+      return selection?.kind === "card" && selection.id
+        ? { type: "card.rerun", cardId: selection.id, reason: "operator cockpit" }
+        : undefined;
+    default:
+      return undefined;
+  }
+}

--- a/src/v2/cockpit/model.ts
+++ b/src/v2/cockpit/model.ts
@@ -1,0 +1,417 @@
+// Pure cockpit model.
+//
+// createCockpitModel takes a status snapshot (+ events + capabilities + a
+// selection + a filter) and produces a fully-derived view model for the
+// renderer. It MUST be pure:
+//   - no fetch, no file IO, no process spawning
+//   - no calls to Fizzy or Codex
+//   - no mutation of status, no command enqueueing
+//
+// The renderer consumes this model and draws it. The renderer never reaches
+// past this model to perform work.
+
+import {
+  deriveCapabilities,
+  listCapabilities
+} from "../core/capabilities.ts";
+import { checkCommandAvailability } from "../core/commands.ts";
+import { deriveFactoryState } from "../core/status.ts";
+import {
+  FACTORY_STATE_LABELS,
+  ROUTE_THEME_LABEL,
+  cardThemeLabel,
+  doctorThemeLabel,
+  eventThemeLabel,
+  runThemeLabel,
+  worktreeThemeLabel
+} from "./theme.ts";
+import type {
+  Capability,
+  CapabilitySummary,
+  CockpitAction,
+  CockpitEventSummary,
+  CockpitLane,
+  CockpitLaneCard,
+  CockpitModel,
+  CockpitModelInput,
+  CockpitRunSummary,
+  CockpitSelection,
+  CockpitWorktreeSummary,
+  OperatorCommand,
+  RuntimeEvent,
+  SymphonyStatus
+} from "../core/types.ts";
+
+const CARD_HAZARD_STATES = new Set(["failed", "blocked"]);
+
+function matchesFilter(text: string, filter?: string): boolean {
+  if (!filter) return true;
+  return text.toLowerCase().includes(filter.toLowerCase());
+}
+
+function buildLanes(status: SymphonyStatus, filter?: string): CockpitLane[] {
+  return status.routes.map((route) => {
+    const cards: CockpitLaneCard[] = status.cards
+      .filter((card) => card.routeId === route.id)
+      .filter((card) =>
+        matchesFilter(`${card.title} ${card.number ?? ""} ${card.id} ${card.state}`, filter)
+      )
+      .map((card) => ({
+        id: card.id,
+        themeLabel: cardThemeLabel(card.state, card.golden),
+        title: card.title,
+        number: card.number,
+        state: card.state,
+        golden: card.golden,
+        runId: card.runId,
+        hazard: CARD_HAZARD_STATES.has(card.state),
+        attention: card.attention
+      }));
+
+    return {
+      routeId: route.id,
+      boardId: route.boardId,
+      title: route.name,
+      themeLabel: ROUTE_THEME_LABEL,
+      factoryLine: route.sourceColumnName ?? route.name,
+      cards,
+      enabled: route.enabled,
+      disabledReason: route.disabledReason
+    };
+  });
+}
+
+function buildSelection(status: SymphonyStatus, selectedId?: string): CockpitSelection | undefined {
+  if (!selectedId) return undefined;
+
+  const card = status.cards.find((entry) => entry.id === selectedId);
+  if (card) {
+    const run = card.runId
+      ? [...status.runs.running, ...status.runs.failed, ...status.runs.completed].find(
+          (entry) => entry.id === card.runId
+        )
+      : undefined;
+    return {
+      kind: "card",
+      id: card.id,
+      themeLabel: cardThemeLabel(card.state, card.golden),
+      recommendedAction: card.attention ?? run?.recommendedAction,
+      raw: {
+        boardId: card.boardId,
+        cardId: card.id,
+        cardNumber: card.number,
+        routeId: card.routeId,
+        columnId: card.columnId,
+        columnName: card.columnName,
+        state: card.state,
+        runId: card.runId,
+        claimId: card.claimId,
+        sessionId: run?.sessionId,
+        workspacePath: card.workspacePath ?? run?.workspacePath,
+        status: run?.state ?? card.state,
+        error: run?.error
+      }
+    };
+  }
+
+  const allRuns = [
+    ...status.runs.running,
+    ...status.runs.queued,
+    ...status.runs.failed,
+    ...status.runs.completed,
+    ...status.runs.cancelled,
+    ...status.runs.preempted
+  ];
+  const run = allRuns.find((entry) => entry.id === selectedId);
+  if (run) {
+    return {
+      kind: "run",
+      id: run.id,
+      themeLabel: runThemeLabel(run.state, run.stalled),
+      recommendedAction: run.recommendedAction,
+      raw: {
+        runId: run.id,
+        attemptId: run.attemptId,
+        boardId: run.boardId,
+        cardId: run.cardId,
+        cardNumber: run.cardNumber,
+        routeId: run.routeId,
+        claimId: run.claimId,
+        sessionId: run.sessionId,
+        turnId: run.turnId,
+        workspacePath: run.workspacePath,
+        status: run.state,
+        error: run.error
+      }
+    };
+  }
+
+  const worktree = status.worktrees.find((entry) => entry.workspaceKey === selectedId);
+  if (worktree) {
+    return {
+      kind: "worktree",
+      id: worktree.workspaceKey,
+      themeLabel: worktreeThemeLabel(worktree.dirty, worktree.preserved),
+      recommendedAction: worktree.recommendedAction,
+      raw: {
+        workspaceKey: worktree.workspaceKey,
+        workspacePath: worktree.path,
+        cardId: worktree.cardId,
+        cardNumber: worktree.cardNumber,
+        runId: worktree.runId,
+        branch: worktree.branch,
+        dirty: worktree.dirty,
+        preserved: worktree.preserved,
+        dirtyPaths: worktree.dirtyPaths,
+        error: worktree.lastError
+      }
+    };
+  }
+
+  const route = status.routes.find((entry) => entry.id === selectedId);
+  if (route) {
+    return {
+      kind: "route",
+      id: route.id,
+      themeLabel: ROUTE_THEME_LABEL,
+      raw: {
+        routeId: route.id,
+        boardId: route.boardId,
+        sourceColumnId: route.sourceColumnId,
+        goldenCardId: route.goldenCardId,
+        backend: route.backend,
+        model: route.model,
+        enabled: route.enabled
+      }
+    };
+  }
+
+  return { kind: "none", raw: { selectedId } };
+}
+
+function activeRunSummaries(status: SymphonyStatus): CockpitRunSummary[] {
+  const summaries: CockpitRunSummary[] = [];
+  for (const run of [...status.runs.running, ...status.runs.queued]) {
+    summaries.push({
+      id: run.id,
+      state: run.state,
+      themeLabel: runThemeLabel(run.state, run.stalled),
+      cardNumber: run.cardNumber,
+      cardTitle: run.cardTitle,
+      stalled: run.stalled === true,
+      error: run.error
+    });
+  }
+  for (const run of status.runs.failed) {
+    summaries.push({
+      id: run.id,
+      state: run.state,
+      themeLabel: runThemeLabel(run.state),
+      cardNumber: run.cardNumber,
+      cardTitle: run.cardTitle,
+      stalled: false,
+      error: run.error
+    });
+  }
+  return summaries;
+}
+
+function worktreeSummaries(status: SymphonyStatus): CockpitWorktreeSummary[] {
+  return status.worktrees.map((worktree) => ({
+    workspaceKey: worktree.workspaceKey,
+    path: worktree.path,
+    dirty: worktree.dirty,
+    preserved: worktree.preserved,
+    themeLabel: worktreeThemeLabel(worktree.dirty, worktree.preserved),
+    recommendedAction: worktree.recommendedAction
+  }));
+}
+
+function eventSummaries(events: RuntimeEvent[]): CockpitEventSummary[] {
+  return events.map((event) => ({
+    id: event.id,
+    severity: event.severity,
+    message: event.message,
+    at: event.at,
+    themeLabel: eventThemeLabel(event.severity)
+  }));
+}
+
+function capabilitySummaries(capabilities: Capability[]): CapabilitySummary[] {
+  return capabilities.map((capability) => ({
+    id: capability.id,
+    title: capability.title,
+    category: capability.category,
+    enabled: capability.enabled,
+    disabledReason: capability.disabledReason
+  }));
+}
+
+interface ActionSpec {
+  id: string;
+  key: string;
+  label: string;
+  command: (selection?: CockpitSelection) => OperatorCommand | undefined;
+}
+
+const ACTION_SPECS: ActionSpec[] = [
+  {
+    id: "dispatch.pause",
+    key: "p",
+    label: "Lock factory (pause dispatch)",
+    command: () => ({ type: "dispatch.pause" })
+  },
+  {
+    id: "dispatch.resume",
+    key: "u",
+    label: "Unlock factory (resume dispatch)",
+    command: () => ({ type: "dispatch.resume" })
+  },
+  {
+    id: "run.cancel",
+    key: "c",
+    label: "Cancel selected run",
+    command: (selection) =>
+      selection?.raw?.runId
+        ? { type: "run.cancel", runId: String(selection.raw.runId), reason: "operator cockpit" }
+        : undefined
+  },
+  {
+    id: "session.stop",
+    key: "s",
+    label: "Stop selected session",
+    command: (selection) =>
+      selection?.raw?.sessionId
+        ? { type: "session.stop", sessionId: String(selection.raw.sessionId), reason: "operator cockpit" }
+        : undefined
+  },
+  {
+    id: "card.rerun",
+    key: "R",
+    label: "Request rerun of selected card",
+    command: (selection) =>
+      selection?.kind === "card" && selection.id
+        ? { type: "card.rerun", cardId: selection.id, reason: "operator cockpit" }
+        : undefined
+  }
+];
+
+function buildActions(status: SymphonyStatus, selection?: CockpitSelection): CockpitAction[] {
+  return ACTION_SPECS.map((spec) => {
+    const command = spec.command(selection);
+    if (!command) {
+      return {
+        id: spec.id,
+        key: spec.key,
+        label: spec.label,
+        enabled: false,
+        disabledReason: disabledSelectionReason(spec.id)
+      };
+    }
+    const availability = checkCommandAvailability(command, status);
+    return {
+      id: spec.id,
+      commandType: command.type,
+      key: spec.key,
+      label: spec.label,
+      enabled: availability.available,
+      disabledReason: availability.available ? undefined : availability.reason
+    };
+  });
+}
+
+function disabledSelectionReason(actionId: string): string {
+  switch (actionId) {
+    case "run.cancel":
+      return "No run selected";
+    case "session.stop":
+      return "Selected item has no active session";
+    case "card.rerun":
+      return "No card selected";
+    default:
+      return "Unavailable in current selection";
+  }
+}
+
+const HELP_KEYS: Array<{ key: string; description: string }> = [
+  { key: "q / Esc", description: "quit" },
+  { key: "?", description: "help / Factory Manual" },
+  { key: "Ctrl-P", description: "command palette" },
+  { key: "r", description: "refresh" },
+  { key: "arrows / h j k l", description: "navigate" },
+  { key: "/", description: "filter" },
+  { key: "Enter", description: "inspect selected item" },
+  { key: "a", description: "available actions" },
+  { key: "d", description: "doctor panel" },
+  { key: "w", description: "worktrees panel" },
+  { key: "l", description: "event / activity panel" },
+  { key: "p", description: "pause dispatch (if available)" },
+  { key: "u", description: "resume dispatch (if available)" },
+  { key: "c", description: "cancel selected run (if available)" },
+  { key: "s", description: "stop selected session (if available)" },
+  { key: "R", description: "request rerun (if available)" },
+  { key: "m", description: "move selected card (if available)" }
+];
+
+export function createCockpitModel(input: CockpitModelInput): CockpitModel {
+  const status = input.status;
+  const events = input.events ?? status.recentEvents ?? [];
+  const capabilities =
+    input.capabilities && input.capabilities.length > 0
+      ? input.capabilities
+      : status.capabilities && status.capabilities.length > 0
+        ? status.capabilities
+        : deriveCapabilities(status);
+
+  const factoryState = deriveFactoryState(status);
+  const lanes = buildLanes(status, input.filter);
+  const selection = buildSelection(status, input.selectedId);
+  const actions = buildActions(status, selection);
+
+  const dirtyWorktrees = status.worktrees.filter((worktree) => worktree.dirty).length;
+
+  const header = {
+    instanceId: status.instance.id,
+    instanceLabel: status.instance.label,
+    endpoint: status.instance.endpoint,
+    readiness: status.readiness.state,
+    factoryState,
+    runnerStatus: status.readiness.runnerStatus,
+    lastUpdatedAt: status.lastUpdatedAt,
+    counts: {
+      boards: status.boards.length,
+      routes: status.routes.length,
+      running: status.runs.running.length,
+      queued: status.runs.queued.length,
+      failed: status.runs.failed.length,
+      dirtyWorktrees,
+      warnings: status.warnings.length
+    }
+  };
+
+  return {
+    header,
+    factoryState,
+    lanes,
+    selected: selection,
+    panels: {
+      activeRuns: activeRunSummaries(status),
+      worktrees: worktreeSummaries(status),
+      doctor: {
+        goalClosable: status.doctor.goalClosable,
+        themeLabel: doctorThemeLabel(status.doctor.goalClosable),
+        blockers: status.doctor.blockers
+      },
+      events: eventSummaries(events),
+      capabilities: capabilitySummaries(capabilities)
+    },
+    actions,
+    help: {
+      manualTitle: `Factory Manual — ${FACTORY_STATE_LABELS[factoryState]}`,
+      keys: HELP_KEYS,
+      capabilities: capabilitySummaries(
+        capabilities.length > 0 ? capabilities : listCapabilities()
+      )
+    }
+  };
+}

--- a/src/v2/cockpit/renderer.ts
+++ b/src/v2/cockpit/renderer.ts
@@ -1,0 +1,139 @@
+// Cockpit text renderer.
+//
+// renderCockpitText turns a CockpitModel into a static, plain-text cockpit.
+// It is pure (string in, string out) and is used for:
+//   - non-TTY fallback
+//   - `cockpit --once`
+//   - the body of the interactive renderer's static frames
+//
+// The interactive Terminal Kit renderer lives in ./interactive.ts and reuses
+// this text where helpful. Truth-first: raw IDs always accompany theme labels.
+
+import { FACTORY_STATE_LABELS } from "./theme.ts";
+import type { CockpitModel } from "../core/types.ts";
+
+function hr(label: string): string {
+  const line = "─".repeat(Math.max(0, 62 - label.length));
+  return `── ${label} ${line}`;
+}
+
+function fmtCounts(counts: CockpitModel["header"]["counts"]): string {
+  return [
+    `boards=${counts.boards}`,
+    `routes=${counts.routes}`,
+    `running=${counts.running}`,
+    `queued=${counts.queued}`,
+    `failed=${counts.failed}`,
+    `dirty=${counts.dirtyWorktrees}`,
+    `warn=${counts.warnings}`
+  ].join("  ");
+}
+
+export function renderCockpitText(model: CockpitModel): string {
+  const lines: string[] = [];
+  const header = model.header;
+
+  lines.push(hr("FIZZY-SYMPHONY COCKPIT (v2 spike)"));
+  lines.push(
+    `instance: ${header.instanceId}${header.instanceLabel ? ` (${header.instanceLabel})` : ""}` +
+      `   endpoint: ${header.endpoint ?? "—"}`
+  );
+  lines.push(
+    `readiness: ${header.readiness}   factory: ${FACTORY_STATE_LABELS[model.factoryState]}` +
+      `   runner: ${header.runnerStatus ?? "unknown"}`
+  );
+  lines.push(`updated: ${header.lastUpdatedAt}`);
+  lines.push(fmtCounts(header.counts));
+
+  lines.push("");
+  lines.push(hr("BOARD / FACTORY LANES"));
+  if (model.lanes.length === 0) {
+    lines.push("  (no routes)");
+  }
+  for (const lane of model.lanes) {
+    const laneState = lane.enabled ? "" : `  [disabled: ${lane.disabledReason ?? "unknown"}]`;
+    lines.push(`▣ ${lane.title}  «${lane.factoryLine}»  [route ${lane.routeId}]${laneState}`);
+    if (lane.cards.length === 0) {
+      lines.push("    (no cards)");
+    }
+    for (const card of lane.cards) {
+      const hazard = card.hazard ? " ⚠" : "";
+      const num = card.number !== undefined ? `#${card.number} ` : "";
+      lines.push(
+        `    • ${card.themeLabel}: ${num}${card.title} [${card.state}]${hazard}` +
+          `  (card ${card.id}${card.runId ? `, run ${card.runId}` : ""})`
+      );
+      if (card.attention) lines.push(`        attention: ${card.attention}`);
+    }
+  }
+
+  if (model.selected) {
+    lines.push("");
+    lines.push(hr("SELECTED DETAIL (raw truth)"));
+    lines.push(`kind: ${model.selected.kind}   theme: ${model.selected.themeLabel ?? "—"}`);
+    for (const [key, value] of Object.entries(model.selected.raw)) {
+      if (value === undefined || value === null) continue;
+      lines.push(`  ${key}: ${typeof value === "object" ? JSON.stringify(value) : String(value)}`);
+    }
+    if (model.selected.recommendedAction) {
+      lines.push(`  recommendedAction: ${model.selected.recommendedAction}`);
+    }
+  }
+
+  lines.push("");
+  lines.push(hr("ACTIVE RUNS"));
+  if (model.panels.activeRuns.length === 0) lines.push("  (none)");
+  for (const run of model.panels.activeRuns) {
+    const stall = run.stalled ? " [STALLED]" : "";
+    const err = run.error ? `  err=${run.error.code}: ${run.error.message}` : "";
+    lines.push(
+      `  ${run.themeLabel}: run ${run.id} [${run.state}]${stall}` +
+        `${run.cardNumber !== undefined ? ` card #${run.cardNumber}` : ""}${err}`
+    );
+  }
+
+  lines.push("");
+  lines.push(hr("WORKTREES / DOCTOR"));
+  lines.push(`doctor: ${model.panels.doctor.themeLabel} (goalClosable=${model.panels.doctor.goalClosable})`);
+  for (const blocker of model.panels.doctor.blockers) {
+    lines.push(`  ✗ ${blocker.code}: ${blocker.message}${blocker.workspaceKey ? ` [${blocker.workspaceKey}]` : ""}`);
+  }
+  if (model.panels.worktrees.length === 0) lines.push("  (no worktrees)");
+  for (const wt of model.panels.worktrees) {
+    const flags = [wt.dirty ? "dirty" : null, wt.preserved ? "preserved" : null].filter(Boolean).join(",") || "clean";
+    lines.push(`  ${wt.themeLabel}: ${wt.workspaceKey} [${flags}] ${wt.path}`);
+    if (wt.recommendedAction) lines.push(`      action: ${wt.recommendedAction}`);
+  }
+
+  lines.push("");
+  lines.push(hr("ACTIVITY"));
+  if (model.panels.events.length === 0) lines.push("  (no events)");
+  for (const event of model.panels.events.slice(0, 10)) {
+    lines.push(`  [${event.severity}] ${event.themeLabel}: ${event.message}  (${event.at})`);
+  }
+
+  lines.push("");
+  lines.push(hr("ACTIONS"));
+  for (const action of model.actions) {
+    const state = action.enabled
+      ? "enabled"
+      : `disabled: ${action.disabledReason ?? "unavailable"}`;
+    lines.push(`  [${action.key ?? "?"}] ${action.label} — ${state}`);
+  }
+
+  lines.push("");
+  lines.push(hr("FOOTER / KEYS"));
+  lines.push(model.help.keys.map((entry) => `${entry.key}:${entry.description}`).join("   "));
+
+  return lines.join("\n");
+}
+
+export function renderCapabilitiesText(model: CockpitModel): string {
+  const lines: string[] = [];
+  lines.push(hr(model.help.manualTitle));
+  for (const capability of model.help.capabilities) {
+    const state = capability.enabled ? "enabled" : `disabled: ${capability.disabledReason ?? "n/a"}`;
+    lines.push(`  [${capability.category}] ${capability.id} — ${capability.title} (${state})`);
+  }
+  return lines.join("\n");
+}

--- a/src/v2/cockpit/theme.ts
+++ b/src/v2/cockpit/theme.ts
@@ -1,0 +1,85 @@
+// Wonka factory theme. Theme is allowed; lies are not.
+//
+// Every themed label here is paired with raw truth elsewhere in the model
+// (the detail panel always carries board id, card id, run id, status, etc.).
+// This module is a pure lookup table with no state.
+
+import type {
+  CardRuntimeState,
+  FactoryState,
+  RunState,
+  WarningSeverity
+} from "./types.ts";
+
+export const FACTORY_STATE_LABELS: Record<FactoryState, string> = {
+  open: "Factory open",
+  running: "Machines in motion",
+  blocked: "Factory cannot close",
+  locked: "Factory locked",
+  unknown: "Status unknown"
+};
+
+export function cardThemeLabel(state: CardRuntimeState, golden: boolean): string {
+  if (golden) return "Golden ticket";
+  switch (state) {
+    case "running":
+      return "Machine in motion";
+    case "queued":
+      return "Queued on the line";
+    case "completed":
+      return "Wrapped candy";
+    case "failed":
+      return "Jammed machine";
+    case "cancelled":
+      return "Stopped machine";
+    case "blocked":
+      return "Hazard on the line";
+    case "idle":
+    default:
+      return "Wonka bar";
+  }
+}
+
+export function runThemeLabel(state: RunState, stalled = false): string {
+  if (stalled) return "Stalled machine";
+  switch (state) {
+    case "running":
+      return "Machine in motion";
+    case "queued":
+      return "Queued on the line";
+    case "completed":
+      return "Wrapped candy";
+    case "failed":
+      return "Jammed machine";
+    case "cancelled":
+      return "Stopped machine";
+    case "preempted":
+      return "Bumped from the line";
+    default:
+      return "Machine";
+  }
+}
+
+export function worktreeThemeLabel(dirty: boolean, preserved: boolean): string {
+  if (dirty) return "Spill / hazard";
+  if (preserved) return "Sealed vault";
+  return "Clean bench";
+}
+
+export function doctorThemeLabel(goalClosable: boolean): string {
+  return goalClosable ? "Factory can close" : "Factory cannot close";
+}
+
+export function eventThemeLabel(severity: WarningSeverity): string {
+  switch (severity) {
+    case "error":
+      return "Alarm";
+    case "warning":
+      return "Caution light";
+    case "info":
+    default:
+      return "Intercom";
+  }
+}
+
+export const ROUTE_THEME_LABEL = "Factory line";

--- a/src/v2/codex/adapter.ts
+++ b/src/v2/codex/adapter.ts
@@ -1,0 +1,67 @@
+// Codex runner adapter boundary.
+//
+// Codex SDK compatibility matters, so the runner sits behind CodexRunnerPort
+// (core/types.ts). Adapter priority for production v2:
+//
+//   1. Codex SDK adapter           — preferred where practical.
+//   2. Codex CLI app-server runner — v1 already ships this in
+//      src/codex-cli-app-server-runner.js for streaming/cancel/session control.
+//   3. Fake runner                 — ./fake.ts, used by tests.
+//
+// For the spike we expose a typed factory that advertises its mode via
+// describe() and throws a clear "not wired" error if a live op is invoked.
+// The cockpit never talks to Codex directly; only the daemon runtime does.
+
+import type { CodexRunnerPort } from "../core/types.ts";
+
+export type CodexAdapterMode = "sdk" | "cli-app-server";
+
+export interface CodexAdapterOptions {
+  mode?: CodexAdapterMode;
+  command?: string;
+  protocolVersion?: string;
+}
+
+const SDK_CONTRACT = "codex-runner-sdk-v1";
+const CLI_CONTRACT = "codex-runner-cli-app-server-v1";
+
+function notWired(operation: string, mode: CodexAdapterMode): never {
+  const error = new Error(
+    `CodexRunnerPort.${operation} is not wired in the v2 spike (${mode} mode). ` +
+      `Delegate to v1 src/codex-cli-app-server-runner.js or the Codex SDK here.`
+  );
+  (error as { code?: string }).code = "CODEX_ADAPTER_NOT_WIRED";
+  throw error;
+}
+
+export function createCodexAdapter(options: CodexAdapterOptions = {}): CodexRunnerPort {
+  const mode: CodexAdapterMode = options.mode ?? "sdk";
+  const contract = mode === "sdk" ? SDK_CONTRACT : CLI_CONTRACT;
+  const note =
+    mode === "sdk"
+      ? "v2 spike: Codex SDK adapter (preferred), not wired"
+      : "v2 spike: delegate to v1 codex-cli-app-server-runner";
+
+  return {
+    describe() {
+      return { kind: `codex-${mode}`, sdk: mode === "sdk", contract, note };
+    },
+    async detect() {
+      return { kind: `codex-${mode}`, available: false, contract, sdk: mode === "sdk", note };
+    },
+    async health() {
+      return {
+        status: "unknown",
+        kind: `codex-${mode}`,
+        contract,
+        failureCode: "ADAPTER_NOT_WIRED",
+        remediation: note
+      };
+    },
+    startSession: async () => notWired("startSession", mode),
+    startTurn: async () => notWired("startTurn", mode),
+    streamTurn: async () => notWired("streamTurn", mode),
+    cancelTurn: async () => notWired("cancelTurn", mode),
+    stopSession: async () => notWired("stopSession", mode)
+  };
+}

--- a/src/v2/codex/fake.ts
+++ b/src/v2/codex/fake.ts
@@ -1,0 +1,101 @@
+// Fake CodexRunnerPort for tests.
+//
+// Deterministic, in-memory, no subprocess. Keeps unit tests independent of a
+// live Codex CLI or SDK. Mirrors the streaming/cancel/session-stop surface so
+// the daemon runtime can be exercised end to end against fixtures.
+
+import type {
+  CancelTurnInput,
+  CodexRunnerPort,
+  RunnerDetectInput,
+  RunnerDetectResult,
+  RunnerEventSink,
+  RunnerHealthInput,
+  RunnerHealthResult,
+  SessionHandle,
+  StartSessionInput,
+  StartTurnInput,
+  StopSessionInput,
+  StreamTurnInput,
+  TerminateProcessInput,
+  TurnHandle,
+  TurnResult
+} from "../core/types.ts";
+
+export interface CodexFakeOptions {
+  available?: boolean;
+  healthStatus?: "ready" | "unavailable" | "unknown";
+  mode?: "completed" | "failed" | "input_required";
+  events?: Array<{ type: string; text?: string }>;
+  contract?: string;
+}
+
+const CONTRACT = "codex-runner-fake-v2";
+
+export function createFakeCodexRunner(options: CodexFakeOptions = {}): CodexRunnerPort {
+  let sessionCounter = 0;
+  let turnCounter = 0;
+  const available = options.available ?? true;
+  const contract = options.contract ?? CONTRACT;
+
+  return {
+    describe() {
+      return { kind: "fake", sdk: false, contract, note: "fixture-backed CodexRunnerPort" };
+    },
+    async detect(_input?: RunnerDetectInput): Promise<RunnerDetectResult> {
+      return { kind: "fake", available, contract, sdk: false, note: "fake runner" };
+    },
+    async health(_input?: RunnerHealthInput): Promise<RunnerHealthResult> {
+      return {
+        status: options.healthStatus ?? (available ? "ready" : "unavailable"),
+        kind: "fake",
+        contract,
+        checkedAt: new Date(0).toISOString()
+      };
+    },
+    async startSession(input: StartSessionInput): Promise<SessionHandle> {
+      sessionCounter += 1;
+      return { sessionId: `session_${sessionCounter}`, workspacePath: input.workspacePath };
+    },
+    async startTurn(input: StartTurnInput): Promise<TurnHandle> {
+      turnCounter += 1;
+      return { turnId: `turn_${turnCounter}`, sessionId: input.session.sessionId };
+    },
+    async streamTurn(input: StreamTurnInput, onEvent: RunnerEventSink): Promise<TurnResult> {
+      const events = options.events ?? [
+        { type: "turn.started" },
+        { type: "assistant.delta", text: "ok" },
+        { type: "turn.completed" }
+      ];
+      for (const event of events) {
+        onEvent({ type: event.type, text: event.text });
+      }
+      if (options.mode === "failed") {
+        return {
+          status: "failed",
+          turnId: input.turn.turnId,
+          sessionId: input.turn.sessionId,
+          error: { code: "RUNNER_ERROR", message: "fake runner error" }
+        };
+      }
+      if (options.mode === "input_required") {
+        return {
+          status: "input_required",
+          turnId: input.turn.turnId,
+          sessionId: input.turn.sessionId,
+          error: { code: "RUNNER_INPUT_REQUIRED", message: "runner requested input in unattended mode" }
+        };
+      }
+      return { status: "completed", turnId: input.turn.turnId, sessionId: input.turn.sessionId };
+    },
+    async cancelTurn(input: CancelTurnInput): Promise<TurnResult> {
+      return { status: "cancelled", turnId: input.turn.turnId, sessionId: input.turn.sessionId };
+    },
+    async stopSession(_input: StopSessionInput): Promise<void> {
+      // no-op for the fake
+    },
+    async terminateOwnedProcess(_input: TerminateProcessInput): Promise<void> {
+      // no-op for the fake
+    }
+  };
+}

--- a/src/v2/core/capabilities.ts
+++ b/src/v2/core/capabilities.ts
@@ -1,0 +1,185 @@
+// Capability registry: the project's memory of what it can do.
+//
+// The cockpit help/manual screen and the `capabilities` command are generated
+// from this registry rather than from hardcoded stale text. Capabilities are
+// derived against a status snapshot so disabled reasons reflect live state.
+
+import type {
+  Capability,
+  SymphonyStatus
+} from "./types.ts";
+
+// Static catalogue of v2 capabilities. `enabled` here is the baseline; the
+// derive step below can flip a capability to disabled with a reason based on
+// the current status snapshot.
+const CATALOGUE: Capability[] = [
+  {
+    id: "fizzy.boards",
+    title: "List Fizzy boards & routes",
+    category: "fizzy",
+    description: "Discover boards, columns, and golden cards through the FizzyPort adapter (SDK or HTTP).",
+    enabled: true,
+    commands: [],
+    endpoints: ["GET /v2/status"],
+    stateFields: ["boards", "routes"]
+  },
+  {
+    id: "route.golden",
+    title: "Golden-card routing",
+    category: "route",
+    description: "Golden cards define automation routes per board column.",
+    enabled: true,
+    stateFields: ["routes", "cards"]
+  },
+  {
+    id: "codex.run",
+    title: "Run Codex turns",
+    category: "codex",
+    description: "Dispatch Codex agent turns for active cards behind the CodexRunnerPort.",
+    enabled: true,
+    stateFields: ["runs"],
+    risks: ["Spawns agent processes that modify worktrees"]
+  },
+  {
+    id: "codex.cancel",
+    title: "Cancel a running turn",
+    category: "runner",
+    description: "Interrupt an in-flight Codex turn for the selected run.",
+    enabled: true,
+    commands: ["run.cancel"],
+    endpoints: ["POST /v2/commands"],
+    stateFields: ["runs.running"],
+    risks: ["Aborts in-progress agent work"]
+  },
+  {
+    id: "session.stop",
+    title: "Stop a Codex session",
+    category: "runner",
+    description: "Unsubscribe and stop a Codex session for the selected run.",
+    enabled: true,
+    commands: ["session.stop"],
+    endpoints: ["POST /v2/commands"]
+  },
+  {
+    id: "control.dispatch",
+    title: "Pause / resume dispatch",
+    category: "control",
+    description: "Operator control over whether the daemon dispatches new turns.",
+    enabled: true,
+    commands: ["dispatch.pause", "dispatch.resume"],
+    endpoints: ["POST /v2/commands"]
+  },
+  {
+    id: "card.rerun",
+    title: "Request a card rerun",
+    category: "route",
+    description: "Re-dispatch automation for a card that already ran.",
+    enabled: true,
+    commands: ["card.rerun"],
+    endpoints: ["POST /v2/commands"]
+  },
+  {
+    id: "card.move",
+    title: "Move a card",
+    category: "fizzy",
+    description: "Move a card to another column through the Fizzy moveCard adapter.",
+    enabled: true,
+    commands: ["card.move"],
+    endpoints: ["POST /v2/commands"],
+    risks: ["Mutates the Fizzy board"]
+  },
+  {
+    id: "worktree.inspect",
+    title: "Inspect worktrees",
+    category: "worktree",
+    description: "Surface dirty worktrees, preserved workspaces, branch, and last error.",
+    enabled: true,
+    endpoints: ["GET /v2/worktrees"],
+    stateFields: ["worktrees"]
+  },
+  {
+    id: "worktree.preserve",
+    title: "Preserve / cleanup worktree",
+    category: "worktree",
+    description: "Keep or clean a Symphony worktree after triage.",
+    enabled: true,
+    commands: ["worktree.preserve", "worktree.cleanup"],
+    endpoints: ["POST /v2/commands"],
+    risks: ["cleanup discards local worktree state"]
+  },
+  {
+    id: "doctor.goal",
+    title: "Goal-closing doctor",
+    category: "doctor",
+    description: "Block goal closure while dirty worktrees or untriaged failures remain.",
+    enabled: true,
+    stateFields: ["doctor", "worktrees"]
+  },
+  {
+    id: "runner.health",
+    title: "Runner health monitoring",
+    category: "runner",
+    description: "Track Codex runner availability and gate dispatch readiness.",
+    enabled: true,
+    stateFields: ["readiness", "runs"]
+  },
+  {
+    id: "webhook.filter",
+    title: "Webhook filtering",
+    category: "webhook",
+    description: "Filter Fizzy webhook events by freshness and self-event suppression.",
+    enabled: true,
+    stateFields: ["warnings"]
+  },
+  {
+    id: "diagnostics.events",
+    title: "Runtime event log",
+    category: "diagnostics",
+    description: "Recent completions, failures, warnings, and capacity refusals.",
+    enabled: true,
+    endpoints: ["GET /v2/events"],
+    stateFields: ["recentEvents", "warnings", "capacityRefusals"]
+  }
+];
+
+export function listCapabilities(): Capability[] {
+  return CATALOGUE.map((capability) => ({ ...capability }));
+}
+
+export function getCapability(id: string): Capability | undefined {
+  const found = CATALOGUE.find((capability) => capability.id === id);
+  return found ? { ...found } : undefined;
+}
+
+// Derive capabilities against a live status snapshot. This is pure: it never
+// mutates the input and returns fresh objects.
+export function deriveCapabilities(status: SymphonyStatus): Capability[] {
+  const runningCount = status.runs?.running?.length ?? 0;
+  const dispatchPaused = status.readiness?.dispatchPaused === true;
+  const runnerReady = status.readiness?.runnerStatus === "ready";
+
+  return CATALOGUE.map((capability) => {
+    const next: Capability = { ...capability };
+    switch (capability.id) {
+      case "codex.cancel":
+      case "session.stop":
+        if (runningCount === 0) {
+          next.enabled = false;
+          next.disabledReason = "No active run";
+        }
+        break;
+      case "codex.run":
+        if (!runnerReady) {
+          next.enabled = false;
+          next.disabledReason = "Runner not ready";
+        }
+        break;
+      case "control.dispatch":
+        next.disabledReason = dispatchPaused ? "Dispatch already paused" : undefined;
+        break;
+      default:
+        break;
+    }
+    return next;
+  });
+}

--- a/src/v2/core/commands.ts
+++ b/src/v2/core/commands.ts
@@ -1,0 +1,167 @@
+// Command model: every mutation is a typed operator command.
+//
+// This module is pure. It validates the *shape* of a command and decides
+// whether the command is currently available given a status snapshot. It does
+// NOT perform any mutation; execution lives in the daemon runtime, which emits
+// an audit event when a command is accepted.
+
+import type {
+  CommandResult,
+  CommandValidation,
+  OperatorCommand,
+  OperatorCommandType,
+  SymphonyStatus
+} from "./types.ts";
+
+const KNOWN_TYPES = new Set<OperatorCommandType>([
+  "dispatch.pause",
+  "dispatch.resume",
+  "run.cancel",
+  "session.stop",
+  "card.rerun",
+  "card.move",
+  "worktree.preserve",
+  "worktree.cleanup"
+]);
+
+function requireString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+// Validate that an unknown payload is a well-formed OperatorCommand.
+export function validateCommand(payload: unknown): CommandValidation {
+  if (typeof payload !== "object" || payload === null) {
+    return { ok: false, code: "INVALID_COMMAND", message: "Command must be an object." };
+  }
+  const command = payload as Record<string, unknown>;
+  const type = command.type;
+  if (typeof type !== "string" || !KNOWN_TYPES.has(type as OperatorCommandType)) {
+    return { ok: false, code: "UNKNOWN_COMMAND", message: `Unknown command type: ${String(type)}` };
+  }
+
+  switch (type as OperatorCommandType) {
+    case "dispatch.pause":
+    case "dispatch.resume":
+      return { ok: true, command: { type } as OperatorCommand };
+    case "run.cancel":
+      if (!requireString(command.runId)) {
+        return { ok: false, code: "MISSING_FIELD", message: "run.cancel requires runId." };
+      }
+      if (!requireString(command.reason)) {
+        return { ok: false, code: "MISSING_REASON", message: "run.cancel requires a reason." };
+      }
+      return { ok: true, command: command as OperatorCommand };
+    case "session.stop":
+      if (!requireString(command.sessionId)) {
+        return { ok: false, code: "MISSING_FIELD", message: "session.stop requires sessionId." };
+      }
+      if (!requireString(command.reason)) {
+        return { ok: false, code: "MISSING_REASON", message: "session.stop requires a reason." };
+      }
+      return { ok: true, command: command as OperatorCommand };
+    case "card.rerun":
+      if (!requireString(command.cardId)) {
+        return { ok: false, code: "MISSING_FIELD", message: "card.rerun requires cardId." };
+      }
+      if (!requireString(command.reason)) {
+        return { ok: false, code: "MISSING_REASON", message: "card.rerun requires a reason." };
+      }
+      return { ok: true, command: command as OperatorCommand };
+    case "card.move":
+      if (!requireString(command.cardId) || !requireString(command.targetColumnId)) {
+        return { ok: false, code: "MISSING_FIELD", message: "card.move requires cardId and targetColumnId." };
+      }
+      if (!requireString(command.reason)) {
+        return { ok: false, code: "MISSING_REASON", message: "card.move requires a reason." };
+      }
+      return { ok: true, command: command as OperatorCommand };
+    case "worktree.preserve":
+    case "worktree.cleanup":
+      if (!requireString(command.workspaceKey)) {
+        return { ok: false, code: "MISSING_FIELD", message: `${type} requires workspaceKey.` };
+      }
+      if (!requireString(command.reason)) {
+        return { ok: false, code: "MISSING_REASON", message: `${type} requires a reason.` };
+      }
+      return { ok: true, command: command as OperatorCommand };
+    default:
+      return { ok: false, code: "UNKNOWN_COMMAND", message: "Unknown command." };
+  }
+}
+
+export interface AvailabilityCheck {
+  available: boolean;
+  code?: string;
+  reason?: string;
+}
+
+// Decide whether a (valid) command can be applied against the current status.
+// This does not mutate; it only reports availability + reason. The spike runs
+// commands as dry-run by default, but availability still reflects real state.
+export function checkCommandAvailability(
+  command: OperatorCommand,
+  status: SymphonyStatus
+): AvailabilityCheck {
+  const running = status.runs?.running ?? [];
+  switch (command.type) {
+    case "dispatch.pause":
+      if (status.readiness?.dispatchPaused) {
+        return { available: false, code: "ALREADY_PAUSED", reason: "Dispatch already paused." };
+      }
+      return { available: true };
+    case "dispatch.resume":
+      if (!status.readiness?.dispatchPaused) {
+        return { available: false, code: "NOT_PAUSED", reason: "Dispatch is not paused." };
+      }
+      return { available: true };
+    case "run.cancel": {
+      const run = running.find((entry) => entry.id === command.runId);
+      if (!run) {
+        return { available: false, code: "NO_ACTIVE_RUN", reason: "Selected run is not running." };
+      }
+      return { available: true };
+    }
+    case "session.stop": {
+      const run = running.find((entry) => entry.sessionId === command.sessionId);
+      if (!run) {
+        return { available: false, code: "NO_ACTIVE_SESSION", reason: "No active session with that id." };
+      }
+      return { available: true };
+    }
+    case "card.rerun": {
+      const card = status.cards?.find((entry) => entry.id === command.cardId);
+      if (!card) {
+        return { available: false, code: "UNKNOWN_CARD", reason: "Card not found in status." };
+      }
+      if (card.state === "running") {
+        return { available: false, code: "CARD_RUNNING", reason: "Card already has an active run." };
+      }
+      return { available: true };
+    }
+    case "card.move": {
+      const card = status.cards?.find((entry) => entry.id === command.cardId);
+      if (!card) {
+        return { available: false, code: "UNKNOWN_CARD", reason: "Card not found in status." };
+      }
+      return { available: true };
+    }
+    case "worktree.preserve":
+    case "worktree.cleanup": {
+      const worktree = status.worktrees?.find((entry) => entry.workspaceKey === command.workspaceKey);
+      if (!worktree) {
+        return { available: false, code: "UNKNOWN_WORKTREE", reason: "Worktree not found in status." };
+      }
+      return { available: true };
+    }
+    default:
+      return { available: false, code: "UNKNOWN_COMMAND", reason: "Unknown command." };
+  }
+}
+
+export function unavailableResult(type: OperatorCommandType, code: string, message: string): CommandResult {
+  return { outcome: "unavailable", commandType: type, code, message };
+}
+
+export function rejectedResult(code: string, message: string): CommandResult {
+  return { outcome: "rejected", code, message };
+}

--- a/src/v2/core/events.ts
+++ b/src/v2/core/events.ts
@@ -1,0 +1,84 @@
+// Local runtime event log.
+//
+// For the spike this is an in-memory append-only log that can optionally
+// serialize to JSONL. No database. Events are plain data; the cockpit renders
+// recent events but never writes them during render.
+
+import { randomUUID } from "node:crypto";
+
+import type { RuntimeEvent, WarningSeverity } from "./types.ts";
+
+export interface EventLogOptions {
+  limit?: number;
+  now?: () => Date;
+}
+
+export interface AppendEventInput {
+  type: string;
+  severity?: WarningSeverity;
+  message: string;
+  boardId?: string;
+  cardId?: string;
+  cardNumber?: number | string;
+  runId?: string;
+  sessionId?: string;
+  workspacePath?: string;
+  data?: unknown;
+}
+
+export interface EventLog {
+  append(input: AppendEventInput): RuntimeEvent;
+  recent(count?: number): RuntimeEvent[];
+  all(): RuntimeEvent[];
+  toJsonl(): string;
+}
+
+export function createEventLog(options: EventLogOptions = {}): EventLog {
+  const limit = options.limit ?? 200;
+  const now = options.now ?? (() => new Date());
+  const events: RuntimeEvent[] = [];
+
+  function append(input: AppendEventInput): RuntimeEvent {
+    const event: RuntimeEvent = {
+      id: randomUUID(),
+      type: input.type,
+      severity: input.severity ?? "info",
+      message: input.message,
+      at: now().toISOString(),
+      boardId: input.boardId,
+      cardId: input.cardId,
+      cardNumber: input.cardNumber,
+      runId: input.runId,
+      sessionId: input.sessionId,
+      workspacePath: input.workspacePath,
+      data: input.data
+    };
+    events.push(event);
+    if (events.length > limit) {
+      events.splice(0, events.length - limit);
+    }
+    return event;
+  }
+
+  function recent(count = 20): RuntimeEvent[] {
+    return events.slice(-count).reverse();
+  }
+
+  function all(): RuntimeEvent[] {
+    return [...events];
+  }
+
+  function toJsonl(): string {
+    return events.map((event) => JSON.stringify(event)).join("\n");
+  }
+
+  return { append, recent, all, toJsonl };
+}
+
+export function parseJsonlEvents(text: string): RuntimeEvent[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as RuntimeEvent);
+}

--- a/src/v2/core/status.ts
+++ b/src/v2/core/status.ts
@@ -1,0 +1,113 @@
+// Status model normalization.
+//
+// Accepts a partial / loosely-shaped status object (e.g. from a fixture, the
+// v2 daemon runtime, or a v1->v2 bridge) and returns a fully-populated,
+// schema-stamped SymphonyStatus. Pure: never mutates input, never does IO.
+
+import {
+  STATUS_SCHEMA_VERSION
+} from "./types.ts";
+import type {
+  FactoryState,
+  ReadinessState,
+  ReadinessStatus,
+  RunBuckets,
+  SymphonyStatus
+} from "./types.ts";
+
+function asArray<T>(value: T[] | undefined | null): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function emptyRunBuckets(): RunBuckets {
+  return {
+    queued: [],
+    running: [],
+    completed: [],
+    failed: [],
+    cancelled: [],
+    preempted: []
+  };
+}
+
+function normalizeReadiness(input: Partial<ReadinessStatus> | undefined): ReadinessStatus {
+  const blockers = asArray(input?.blockers);
+  const dispatchPaused = input?.dispatchPaused === true;
+  let state: ReadinessState = input?.state ?? "unknown";
+  if (!input?.state) {
+    if (blockers.length > 0) state = "blocked";
+    else if (input?.ready) state = "ready";
+  }
+  return {
+    state,
+    ready: input?.ready ?? state === "ready",
+    blockers,
+    dispatchPaused,
+    runnerStatus: input?.runnerStatus
+  };
+}
+
+// Map readiness + runtime activity to the themed factory state.
+export function deriveFactoryState(status: SymphonyStatus): FactoryState {
+  const readiness = status.readiness;
+  if (!readiness || readiness.state === "unknown") return "unknown";
+  if (readiness.dispatchPaused) return "locked";
+  if (readiness.state === "blocked" || readiness.state === "locked") {
+    return readiness.state === "locked" ? "locked" : "blocked";
+  }
+  if (!readiness.ready) return "blocked";
+  if ((status.runs?.running?.length ?? 0) > 0) return "running";
+  return "open";
+}
+
+export function normalizeStatus(raw: Partial<SymphonyStatus> | undefined): SymphonyStatus {
+  const input = raw ?? {};
+  const runs = input.runs ?? {};
+  const status: SymphonyStatus = {
+    schemaVersion: STATUS_SCHEMA_VERSION,
+    instance: {
+      id: input.instance?.id ?? "unknown",
+      label: input.instance?.label,
+      pid: input.instance?.pid ?? null,
+      startedAt: input.instance?.startedAt ?? null,
+      endpoint: input.instance?.endpoint ?? null,
+      daemonVersion: input.instance?.daemonVersion
+    },
+    readiness: normalizeReadiness(input.readiness),
+    capabilities: asArray(input.capabilities),
+    boards: asArray(input.boards),
+    routes: asArray(input.routes),
+    cards: asArray(input.cards),
+    runs: {
+      ...emptyRunBuckets(),
+      queued: asArray(runs.queued),
+      running: asArray(runs.running),
+      completed: asArray(runs.completed),
+      failed: asArray(runs.failed),
+      cancelled: asArray(runs.cancelled),
+      preempted: asArray(runs.preempted)
+    },
+    claims: asArray(input.claims),
+    worktrees: asArray(input.worktrees),
+    retryQueue: asArray(input.retryQueue),
+    capacityRefusals: asArray(input.capacityRefusals),
+    doctor: {
+      goalClosable: input.doctor?.goalClosable ?? true,
+      blockers: asArray(input.doctor?.blockers),
+      checkedAt: input.doctor?.checkedAt
+    },
+    warnings: asArray(input.warnings),
+    recentEvents: asArray(input.recentEvents),
+    lastUpdatedAt: input.lastUpdatedAt ?? new Date(0).toISOString()
+  };
+  return status;
+}
+
+// Convenience selectors used by the cockpit model and CLI text output.
+export function countDirtyWorktrees(status: SymphonyStatus): number {
+  return status.worktrees.filter((worktree) => worktree.dirty).length;
+}
+
+export function countPreservedWorktrees(status: SymphonyStatus): number {
+  return status.worktrees.filter((worktree) => worktree.preserved).length;
+}

--- a/src/v2/core/types.ts
+++ b/src/v2/core/types.ts
@@ -1,0 +1,616 @@
+// fizzy-symphony v2 core contracts.
+//
+// These types are the boring runtime contract for the v2 cockpit spike. They
+// are intentionally independent of the Fizzy SDK and the Codex SDK: the daemon
+// and cockpit speak this vocabulary, and adapters translate at the edges.
+//
+// Runtime is plain ESM JavaScript with native TypeScript type stripping
+// (Node >= 23.6 / project engine >= 25). Nothing here emits runtime code.
+
+export const STATUS_SCHEMA_VERSION = "fizzy-symphony-status-v2";
+export type StatusSchemaVersion = "fizzy-symphony-status-v2";
+
+// ---------------------------------------------------------------------------
+// Status model
+// ---------------------------------------------------------------------------
+
+export type ReadinessState = "ready" | "blocked" | "locked" | "unknown";
+
+export interface InstanceStatus {
+  id: string;
+  label?: string;
+  pid?: number | null;
+  startedAt?: string | null;
+  endpoint?: string | null;
+  daemonVersion?: string;
+}
+
+export interface ReadinessBlocker {
+  code: string;
+  message: string;
+  detail?: unknown;
+}
+
+export interface ReadinessStatus {
+  state: ReadinessState;
+  ready: boolean;
+  blockers: ReadinessBlocker[];
+  dispatchPaused?: boolean;
+  runnerStatus?: string;
+}
+
+export type CapabilityCategory =
+  | "fizzy"
+  | "codex"
+  | "board"
+  | "route"
+  | "runner"
+  | "worktree"
+  | "doctor"
+  | "control"
+  | "webhook"
+  | "diagnostics";
+
+export interface Capability {
+  id: string;
+  title: string;
+  category: CapabilityCategory;
+  description: string;
+  enabled: boolean;
+  disabledReason?: string;
+  commands?: string[];
+  endpoints?: string[];
+  stateFields?: string[];
+  risks?: string[];
+}
+
+export interface BoardRuntimeStatus {
+  id: string;
+  name: string;
+  routeIds: string[];
+  activeCardCount: number;
+  goldenCardCount: number;
+}
+
+export interface RouteRuntimeStatus {
+  id: string;
+  boardId: string;
+  name: string;
+  sourceColumnId?: string;
+  sourceColumnName?: string;
+  goldenCardId?: string;
+  goldenCardNumber?: number | string;
+  backend?: string;
+  model?: string;
+  enabled: boolean;
+  disabledReason?: string;
+}
+
+export type CardRuntimeState =
+  | "idle"
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "blocked";
+
+export interface CardRuntimeStatus {
+  id: string;
+  number?: number | string;
+  title: string;
+  boardId: string;
+  routeId?: string;
+  columnId?: string;
+  columnName?: string;
+  state: CardRuntimeState;
+  golden: boolean;
+  runId?: string;
+  claimId?: string;
+  workspacePath?: string;
+  attention?: string;
+}
+
+export type RunState =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "preempted";
+
+export interface RunStatus {
+  id: string;
+  attemptId?: string;
+  state: RunState;
+  boardId?: string;
+  cardId?: string;
+  cardNumber?: number | string;
+  cardTitle?: string;
+  routeId?: string;
+  claimId?: string;
+  sessionId?: string;
+  turnId?: string;
+  workspacePath?: string;
+  startedAt?: string;
+  updatedAt?: string;
+  stalled?: boolean;
+  error?: RuntimeErrorInfo;
+  recommendedAction?: string;
+}
+
+export interface RuntimeErrorInfo {
+  code: string;
+  message: string;
+  remediation?: string;
+}
+
+export type ClaimState =
+  | "claimed"
+  | "renewed"
+  | "released"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "lost";
+
+export interface ClaimStatus {
+  id: string;
+  cardId?: string;
+  boardId?: string;
+  routeId?: string;
+  runId?: string;
+  state: ClaimState;
+  expiresAt?: string;
+  workspaceKey?: string;
+}
+
+export interface WorktreeStatus {
+  workspaceKey: string;
+  path: string;
+  cardId?: string;
+  cardNumber?: number | string;
+  runId?: string;
+  branch?: string;
+  dirty: boolean;
+  preserved: boolean;
+  dirtyPaths?: string[];
+  lastError?: RuntimeErrorInfo;
+  recommendedAction?: string;
+}
+
+export interface RetryQueueItem {
+  runId: string;
+  cardId?: string;
+  attempt: number;
+  maxAttempts?: number;
+  nextRetryAt?: string;
+  reason?: string;
+}
+
+export interface DoctorStatus {
+  goalClosable: boolean;
+  blockers: DoctorBlocker[];
+  checkedAt?: string;
+}
+
+export interface DoctorBlocker {
+  code: string;
+  message: string;
+  workspaceKey?: string;
+  recommendedAction?: string;
+}
+
+export type WarningSeverity = "info" | "warning" | "error";
+
+export interface RuntimeWarning {
+  code: string;
+  message: string;
+  severity: WarningSeverity;
+  at?: string;
+  cardId?: string;
+  runId?: string;
+}
+
+export interface CapacityRefusal {
+  cardId?: string;
+  routeId?: string;
+  reason: string;
+  refusedAt?: string;
+}
+
+export interface RuntimeEvent {
+  id: string;
+  type: string;
+  severity: WarningSeverity;
+  message: string;
+  at: string;
+  boardId?: string;
+  cardId?: string;
+  cardNumber?: number | string;
+  runId?: string;
+  sessionId?: string;
+  workspacePath?: string;
+  data?: unknown;
+}
+
+export interface RunBuckets {
+  queued: RunStatus[];
+  running: RunStatus[];
+  completed: RunStatus[];
+  failed: RunStatus[];
+  cancelled: RunStatus[];
+  preempted: RunStatus[];
+}
+
+export interface SymphonyStatus {
+  schemaVersion: StatusSchemaVersion;
+  instance: InstanceStatus;
+  readiness: ReadinessStatus;
+  capabilities: Capability[];
+  boards: BoardRuntimeStatus[];
+  routes: RouteRuntimeStatus[];
+  cards: CardRuntimeStatus[];
+  runs: RunBuckets;
+  claims: ClaimStatus[];
+  worktrees: WorktreeStatus[];
+  retryQueue: RetryQueueItem[];
+  capacityRefusals: CapacityRefusal[];
+  doctor: DoctorStatus;
+  warnings: RuntimeWarning[];
+  recentEvents: RuntimeEvent[];
+  lastUpdatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Command model
+// ---------------------------------------------------------------------------
+
+export type OperatorCommand =
+  | { type: "dispatch.pause"; reason?: string }
+  | { type: "dispatch.resume"; reason?: string }
+  | { type: "run.cancel"; runId: string; reason: string }
+  | { type: "session.stop"; sessionId: string; reason: string }
+  | { type: "card.rerun"; cardId: string; reason: string }
+  | { type: "card.move"; cardId: string; targetColumnId: string; reason: string }
+  | { type: "worktree.preserve"; workspaceKey: string; reason: string }
+  | { type: "worktree.cleanup"; workspaceKey: string; reason: string };
+
+export type OperatorCommandType = OperatorCommand["type"];
+
+export interface CommandValidation {
+  ok: boolean;
+  command?: OperatorCommand;
+  code?: string;
+  message?: string;
+}
+
+export type CommandOutcome = "accepted" | "rejected" | "unavailable" | "dry-run";
+
+export interface CommandResult {
+  outcome: CommandOutcome;
+  commandType?: OperatorCommandType;
+  message: string;
+  code?: string;
+  event?: RuntimeEvent;
+}
+
+// ---------------------------------------------------------------------------
+// Cockpit model
+// ---------------------------------------------------------------------------
+
+export type FactoryState = "open" | "running" | "blocked" | "locked" | "unknown";
+
+export interface CockpitHeader {
+  instanceId: string;
+  instanceLabel?: string;
+  endpoint?: string | null;
+  readiness: ReadinessState;
+  factoryState: FactoryState;
+  runnerStatus?: string;
+  lastUpdatedAt: string;
+  counts: {
+    boards: number;
+    routes: number;
+    running: number;
+    queued: number;
+    failed: number;
+    dirtyWorktrees: number;
+    warnings: number;
+  };
+}
+
+export interface CockpitLaneCard {
+  id: string;
+  themeLabel: string;
+  title: string;
+  number?: number | string;
+  state: CardRuntimeState;
+  golden: boolean;
+  runId?: string;
+  hazard: boolean;
+  attention?: string;
+}
+
+export interface CockpitLane {
+  routeId: string;
+  boardId: string;
+  title: string;
+  themeLabel: string;
+  factoryLine: string;
+  cards: CockpitLaneCard[];
+  enabled: boolean;
+  disabledReason?: string;
+}
+
+export interface CockpitSelection {
+  kind: "card" | "run" | "worktree" | "route" | "none";
+  id?: string;
+  themeLabel?: string;
+  raw: Record<string, unknown>;
+  recommendedAction?: string;
+}
+
+export interface CockpitRunSummary {
+  id: string;
+  state: RunState;
+  themeLabel: string;
+  cardNumber?: number | string;
+  cardTitle?: string;
+  stalled: boolean;
+  error?: RuntimeErrorInfo;
+}
+
+export interface CockpitWorktreeSummary {
+  workspaceKey: string;
+  path: string;
+  dirty: boolean;
+  preserved: boolean;
+  themeLabel: string;
+  recommendedAction?: string;
+}
+
+export interface CockpitDoctorSummary {
+  goalClosable: boolean;
+  themeLabel: string;
+  blockers: DoctorBlocker[];
+}
+
+export interface CockpitEventSummary {
+  id: string;
+  severity: WarningSeverity;
+  message: string;
+  at: string;
+  themeLabel: string;
+}
+
+export interface CapabilitySummary {
+  id: string;
+  title: string;
+  category: CapabilityCategory;
+  enabled: boolean;
+  disabledReason?: string;
+}
+
+export interface CockpitAction {
+  id: string;
+  commandType?: OperatorCommandType;
+  key?: string;
+  label: string;
+  enabled: boolean;
+  disabledReason?: string;
+}
+
+export interface CockpitHelp {
+  manualTitle: string;
+  keys: Array<{ key: string; description: string }>;
+  capabilities: CapabilitySummary[];
+}
+
+export interface CockpitModel {
+  header: CockpitHeader;
+  factoryState: FactoryState;
+  lanes: CockpitLane[];
+  selected?: CockpitSelection;
+  panels: {
+    activeRuns: CockpitRunSummary[];
+    worktrees: CockpitWorktreeSummary[];
+    doctor: CockpitDoctorSummary;
+    events: CockpitEventSummary[];
+    capabilities: CapabilitySummary[];
+  };
+  actions: CockpitAction[];
+  help: CockpitHelp;
+}
+
+export interface CockpitModelInput {
+  status: SymphonyStatus;
+  events?: RuntimeEvent[];
+  capabilities?: Capability[];
+  selectedId?: string;
+  filter?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture bundle (status + events shipped together for fixture-first tests)
+// ---------------------------------------------------------------------------
+
+export interface FixtureBundle {
+  status: SymphonyStatus;
+  events?: RuntimeEvent[];
+  capabilities?: Capability[];
+}
+
+// ---------------------------------------------------------------------------
+// Fizzy port (independent of any SDK)
+// ---------------------------------------------------------------------------
+
+export interface FizzyBoard {
+  id: string;
+  name: string;
+  columns?: FizzyColumn[];
+}
+
+export interface FizzyColumn {
+  id: string;
+  name: string;
+}
+
+export interface FizzyCard {
+  id: string;
+  number?: number | string;
+  title: string;
+  boardId: string;
+  columnId?: string;
+  tags?: string[];
+  golden?: boolean;
+}
+
+export interface FizzyComment {
+  id: string;
+  cardId: string;
+  body: string;
+  createdAt?: string;
+}
+
+export interface FizzyWebhook {
+  id: string;
+  boardId: string;
+  url: string;
+}
+
+export interface ListBoardsInput {
+  accountSlug?: string;
+}
+export interface GetBoardInput {
+  boardId: string;
+}
+export interface ListCardsInput {
+  boardId: string;
+  columnId?: string;
+}
+export interface GetCardInput {
+  cardId: string;
+}
+export interface ListCommentsInput {
+  cardId: string;
+}
+export interface CreateCommentInput {
+  cardId: string;
+  body: string;
+}
+export interface UpdateCommentInput {
+  commentId: string;
+  body: string;
+}
+export interface MoveCardInput {
+  cardId: string;
+  targetColumnId: string;
+}
+export interface ListWebhooksInput {
+  boardId: string;
+}
+export interface VerifyWebhookInput {
+  signature: string;
+  payload: string;
+}
+
+export interface FizzyPort {
+  describe(): { kind: string; sdk: boolean; note?: string };
+  listBoards(input?: ListBoardsInput): Promise<FizzyBoard[]>;
+  getBoard(input: GetBoardInput): Promise<FizzyBoard>;
+  listCards(input: ListCardsInput): Promise<FizzyCard[]>;
+  getCard(input: GetCardInput): Promise<FizzyCard>;
+  listComments(input: ListCommentsInput): Promise<FizzyComment[]>;
+  createComment(input: CreateCommentInput): Promise<FizzyComment>;
+  updateComment(input: UpdateCommentInput): Promise<FizzyComment>;
+  moveCard(input: MoveCardInput): Promise<FizzyCard>;
+  listWebhooks?(input: ListWebhooksInput): Promise<FizzyWebhook[]>;
+  verifyWebhook?(input: VerifyWebhookInput): Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// Codex runner port (SDK-compatible shape)
+// ---------------------------------------------------------------------------
+
+export interface RunnerDetectInput {
+  cwd?: string;
+}
+export interface RunnerDetectResult {
+  kind: string;
+  available: boolean;
+  contract: string;
+  version?: string;
+  sdk: boolean;
+  note?: string;
+}
+export interface RunnerHealthInput {
+  cwd?: string;
+}
+export interface RunnerHealthResult {
+  status: "ready" | "unavailable" | "unknown";
+  kind: string;
+  contract: string;
+  checkedAt?: string;
+  failureCode?: string;
+  remediation?: string;
+}
+export interface StartSessionInput {
+  workspacePath: string;
+  model?: string;
+  reasoningEffort?: string;
+  sandboxPolicy?: string;
+  metadata?: Record<string, unknown>;
+}
+export interface SessionHandle {
+  sessionId: string;
+  workspacePath: string;
+}
+export interface StartTurnInput {
+  session: SessionHandle;
+  prompt: string;
+  metadata?: Record<string, unknown>;
+}
+export interface TurnHandle {
+  turnId: string;
+  sessionId: string;
+}
+export interface StreamTurnInput {
+  turn: TurnHandle;
+}
+export interface RunnerEvent {
+  type: string;
+  text?: string;
+  data?: unknown;
+}
+export type RunnerEventSink = (event: RunnerEvent) => void;
+export interface TurnResult {
+  status: "completed" | "failed" | "cancelled" | "input_required";
+  turnId: string;
+  sessionId: string;
+  error?: RuntimeErrorInfo;
+}
+export interface CancelTurnInput {
+  turn: TurnHandle;
+  reason: string;
+}
+export interface StopSessionInput {
+  session: SessionHandle;
+  reason: string;
+}
+export interface TerminateProcessInput {
+  sessionId: string;
+  reason: string;
+}
+
+export interface CodexRunnerPort {
+  describe(): { kind: string; sdk: boolean; contract: string; note?: string };
+  detect(input?: RunnerDetectInput): Promise<RunnerDetectResult>;
+  health(input?: RunnerHealthInput): Promise<RunnerHealthResult>;
+  startSession(input: StartSessionInput): Promise<SessionHandle>;
+  startTurn(input: StartTurnInput): Promise<TurnHandle>;
+  streamTurn(input: StreamTurnInput, onEvent: RunnerEventSink): Promise<TurnResult>;
+  cancelTurn(input: CancelTurnInput): Promise<TurnResult>;
+  stopSession(input: StopSessionInput): Promise<void>;
+  terminateOwnedProcess?(input: TerminateProcessInput): Promise<void>;
+}

--- a/src/v2/daemon/api.ts
+++ b/src/v2/daemon/api.ts
@@ -1,0 +1,142 @@
+// v2 local API skeleton.
+//
+// Read-only endpoints serve the fixture-backed runtime. The single command
+// endpoint validates, reports disabled/unavailable when not implemented, and
+// writes an audit event when accepted. No database, no auth layer in the spike.
+
+import { createServer } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+
+import type { SymphonyRuntime } from "./runtime.ts";
+
+export interface ApiHandlerResult {
+  statusCode: number;
+  body: unknown;
+}
+
+// Pure request router: maps (method, path, parsed body) -> result. Exported so
+// tests can exercise routing without binding a socket.
+export function handleApiRequest(
+  runtime: SymphonyRuntime,
+  method: string,
+  pathname: string,
+  body?: unknown
+): ApiHandlerResult {
+  const status = runtime.getStatus();
+
+  if (method === "GET") {
+    switch (pathname) {
+      case "/v2/health":
+        return {
+          statusCode: 200,
+          body: {
+            live: true,
+            instanceId: status.instance.id,
+            readiness: status.readiness.state
+          }
+        };
+      case "/v2/ready":
+        return {
+          statusCode: status.readiness.ready ? 200 : 503,
+          body: {
+            ready: status.readiness.ready,
+            state: status.readiness.state,
+            blockers: status.readiness.blockers
+          }
+        };
+      case "/v2/status":
+        return { statusCode: 200, body: status };
+      case "/v2/capabilities":
+        return { statusCode: 200, body: { capabilities: runtime.getCapabilities() } };
+      case "/v2/events":
+        return { statusCode: 200, body: { events: runtime.getEvents(50) } };
+      case "/v2/runs":
+        return { statusCode: 200, body: { runs: status.runs } };
+      case "/v2/worktrees":
+        return { statusCode: 200, body: { worktrees: runtime.getWorktrees() } };
+      default:
+        break;
+    }
+
+    const runMatch = pathname.match(/^\/v2\/runs\/([^/]+)$/);
+    if (runMatch) {
+      const run = runtime.getRun(decodeURIComponent(runMatch[1]));
+      if (!run) return { statusCode: 404, body: { error: "RUN_NOT_FOUND", runId: runMatch[1] } };
+      return { statusCode: 200, body: { run } };
+    }
+
+    return { statusCode: 404, body: { error: "NOT_FOUND", path: pathname } };
+  }
+
+  if (method === "POST" && pathname === "/v2/commands") {
+    const result = runtime.submitCommand(body);
+    const code =
+      result.outcome === "accepted" || result.outcome === "dry-run"
+        ? 202
+        : result.outcome === "unavailable"
+          ? 409
+          : 400;
+    return { statusCode: code, body: result };
+  }
+
+  return { statusCode: 404, body: { error: "NOT_FOUND", path: pathname, method } };
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  if (chunks.length === 0) return undefined;
+  const text = Buffer.concat(chunks).toString("utf8").trim();
+  if (!text) return undefined;
+  return JSON.parse(text);
+}
+
+export interface ApiServerOptions {
+  host?: string;
+  port?: number;
+}
+
+export interface ApiServer {
+  server: Server;
+  listen(): Promise<{ host: string; port: number; url: string }>;
+  close(): Promise<void>;
+}
+
+export function createApiServer(runtime: SymphonyRuntime, options: ApiServerOptions = {}): ApiServer {
+  const host = options.host ?? "127.0.0.1";
+  const port = options.port ?? 0;
+
+  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const method = req.method ?? "GET";
+    const url = new URL(req.url ?? "/", "http://localhost");
+    let result: ApiHandlerResult;
+    try {
+      const body = method === "POST" ? await readJsonBody(req) : undefined;
+      result = handleApiRequest(runtime, method, url.pathname, body);
+    } catch (error) {
+      result = { statusCode: 400, body: { error: "BAD_REQUEST", message: (error as Error).message } };
+    }
+    const payload = `${JSON.stringify(result.body)}\n`;
+    res.writeHead(result.statusCode, { "content-type": "application/json" });
+    res.end(payload);
+  });
+
+  return {
+    server,
+    listen() {
+      return new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(port, host, () => {
+          const address = server.address();
+          const boundPort = typeof address === "object" && address ? address.port : port;
+          resolve({ host, port: boundPort, url: `http://${host}:${boundPort}` });
+        });
+      });
+    },
+    close() {
+      return new Promise((resolve) => server.close(() => resolve()));
+    }
+  };
+}

--- a/src/v2/daemon/runtime.ts
+++ b/src/v2/daemon/runtime.ts
@@ -1,0 +1,152 @@
+// v2 daemon runtime (fixture-backed for the spike).
+//
+// Holds the current SymphonyStatus, an event log, and the capability set.
+// It is the ONLY place commands are applied. Commands are validated, checked
+// for availability, then (in the spike) executed as dry-run while still
+// writing an audit event. Real mutation would call FizzyPort / CodexRunnerPort
+// here — never from the cockpit or renderer.
+
+import { deriveCapabilities } from "../core/capabilities.ts";
+import {
+  checkCommandAvailability,
+  rejectedResult,
+  unavailableResult,
+  validateCommand
+} from "../core/commands.ts";
+import { createEventLog } from "../core/events.ts";
+import { normalizeStatus } from "../core/status.ts";
+import type { EventLog } from "../core/events.ts";
+import type {
+  Capability,
+  CodexRunnerPort,
+  CommandResult,
+  FizzyPort,
+  RuntimeEvent,
+  SymphonyStatus
+} from "../core/types.ts";
+
+export interface RuntimeOptions {
+  status: Partial<SymphonyStatus>;
+  events?: RuntimeEvent[];
+  capabilities?: Capability[];
+  fizzy?: FizzyPort;
+  codex?: CodexRunnerPort;
+  // When false (default for the spike) commands are dry-run only and never
+  // mutate Fizzy/Codex; the audit event records the intent.
+  applyCommands?: boolean;
+  now?: () => Date;
+}
+
+export interface SymphonyRuntime {
+  getStatus(): SymphonyStatus;
+  getCapabilities(): Capability[];
+  getEvents(count?: number): RuntimeEvent[];
+  getRun(runId: string): SymphonyStatus["runs"]["running"][number] | undefined;
+  getWorktrees(): SymphonyStatus["worktrees"];
+  submitCommand(payload: unknown): CommandResult;
+  describePorts(): { fizzy: ReturnType<FizzyPort["describe"]> | null; codex: ReturnType<CodexRunnerPort["describe"]> | null };
+}
+
+export function createRuntime(options: RuntimeOptions): SymphonyRuntime {
+  const applyCommands = options.applyCommands ?? false;
+  const status = normalizeStatus(options.status);
+  const eventLog: EventLog = createEventLog({ now: options.now });
+  for (const event of options.events ?? status.recentEvents ?? []) {
+    eventLog.append({
+      type: event.type,
+      severity: event.severity,
+      message: event.message,
+      boardId: event.boardId,
+      cardId: event.cardId,
+      cardNumber: event.cardNumber,
+      runId: event.runId,
+      sessionId: event.sessionId,
+      workspacePath: event.workspacePath,
+      data: event.data
+    });
+  }
+
+  const capabilities =
+    options.capabilities && options.capabilities.length > 0
+      ? options.capabilities
+      : deriveCapabilities(status);
+
+  function allRuns() {
+    return [
+      ...status.runs.running,
+      ...status.runs.queued,
+      ...status.runs.completed,
+      ...status.runs.failed,
+      ...status.runs.cancelled,
+      ...status.runs.preempted
+    ];
+  }
+
+  function submitCommand(payload: unknown): CommandResult {
+    const validation = validateCommand(payload);
+    if (!validation.ok || !validation.command) {
+      return rejectedResult(validation.code ?? "INVALID_COMMAND", validation.message ?? "Invalid command.");
+    }
+    const command = validation.command;
+    const availability = checkCommandAvailability(command, status);
+    if (!availability.available) {
+      return unavailableResult(
+        command.type,
+        availability.code ?? "UNAVAILABLE",
+        availability.reason ?? "Command unavailable."
+      );
+    }
+
+    if (!applyCommands) {
+      const event = eventLog.append({
+        type: `command.dry-run.${command.type}`,
+        severity: "info",
+        message: `Dry-run accepted command ${command.type}`,
+        runId: "runId" in command ? command.runId : undefined,
+        sessionId: "sessionId" in command ? command.sessionId : undefined,
+        cardId: "cardId" in command ? command.cardId : undefined,
+        data: command
+      });
+      return {
+        outcome: "dry-run",
+        commandType: command.type,
+        message: `Command ${command.type} accepted as dry-run (spike build).`,
+        event
+      };
+    }
+
+    // Production wiring would dispatch to FizzyPort / CodexRunnerPort here.
+    const event = eventLog.append({
+      type: `command.accepted.${command.type}`,
+      severity: "info",
+      message: `Accepted command ${command.type}`,
+      data: command
+    });
+    return { outcome: "accepted", commandType: command.type, message: `Command ${command.type} accepted.`, event };
+  }
+
+  return {
+    getStatus() {
+      return { ...status, recentEvents: eventLog.recent(20), capabilities };
+    },
+    getCapabilities() {
+      return capabilities.map((capability) => ({ ...capability }));
+    },
+    getEvents(count = 20) {
+      return eventLog.recent(count);
+    },
+    getRun(runId: string) {
+      return allRuns().find((run) => run.id === runId);
+    },
+    getWorktrees() {
+      return status.worktrees.map((worktree) => ({ ...worktree }));
+    },
+    submitCommand,
+    describePorts() {
+      return {
+        fizzy: options.fizzy ? options.fizzy.describe() : null,
+        codex: options.codex ? options.codex.describe() : null
+      };
+    }
+  };
+}

--- a/src/v2/fizzy/adapter.ts
+++ b/src/v2/fizzy/adapter.ts
@@ -1,0 +1,59 @@
+// SDK / HTTP boundary for the FizzyPort.
+//
+// The point of this file is the boundary, not the implementation. The daemon
+// and cockpit depend on FizzyPort (in core/types.ts), never on the Fizzy SDK
+// types. Three implementations are anticipated:
+//
+//   1. SDK adapter   — wraps @37signals/fizzy when it cleanly supports an op.
+//   2. HTTP adapter  — direct HTTP/OpenAPI where the SDK lacks an op.
+//   3. Fake          — fixture-backed, see ./fake.ts (used by tests).
+//
+// For the spike the SDK/HTTP adapters are deliberately left as a typed factory
+// that reports its mode and throws a clear "not wired in spike" error if an op
+// is called. v1 already ships a working SDK-backed client (src/fizzy-client.js
+// + src/fizzy-sdk-adapter.js); production v2 would delegate to it here.
+
+import type { FizzyPort } from "../core/types.ts";
+
+export type FizzyAdapterMode = "sdk" | "http";
+
+export interface FizzyAdapterOptions {
+  mode?: FizzyAdapterMode;
+  apiUrl?: string;
+  token?: string;
+  account?: string;
+}
+
+function notWired(operation: string, mode: FizzyAdapterMode): never {
+  const error = new Error(
+    `FizzyPort.${operation} is not wired in the v2 spike (${mode} mode). ` +
+      `Delegate to v1 src/fizzy-client.js or implement the ${mode} call here.`
+  );
+  (error as { code?: string }).code = "FIZZY_ADAPTER_NOT_WIRED";
+  throw error;
+}
+
+// Returns a FizzyPort whose read/write ops are intentionally unimplemented for
+// the spike. describe() advertises the chosen boundary so the cockpit can show
+// "moveCard adapter unavailable" rather than silently failing.
+export function createFizzyAdapter(options: FizzyAdapterOptions = {}): FizzyPort {
+  const mode: FizzyAdapterMode = options.mode ?? "sdk";
+  const note =
+    mode === "sdk"
+      ? "v2 spike: delegate to @37signals/fizzy via v1 adapter"
+      : "v2 spike: direct HTTP/OpenAPI adapter";
+
+  return {
+    describe() {
+      return { kind: `fizzy-${mode}`, sdk: mode === "sdk", note };
+    },
+    listBoards: async () => notWired("listBoards", mode),
+    getBoard: async () => notWired("getBoard", mode),
+    listCards: async () => notWired("listCards", mode),
+    getCard: async () => notWired("getCard", mode),
+    listComments: async () => notWired("listComments", mode),
+    createComment: async () => notWired("createComment", mode),
+    updateComment: async () => notWired("updateComment", mode),
+    moveCard: async () => notWired("moveCard", mode)
+  };
+}

--- a/src/v2/fizzy/fake.ts
+++ b/src/v2/fizzy/fake.ts
@@ -1,0 +1,95 @@
+// Fixture-backed FizzyPort fake.
+//
+// Keeps unit tests independent of live Fizzy and the @37signals/fizzy SDK.
+// The daemon and cockpit only ever see the FizzyPort interface, so swapping
+// this for the SDK adapter or the HTTP adapter requires no downstream change.
+
+import type {
+  CreateCommentInput,
+  FizzyBoard,
+  FizzyCard,
+  FizzyComment,
+  FizzyPort,
+  FizzyWebhook,
+  GetBoardInput,
+  GetCardInput,
+  ListBoardsInput,
+  ListCardsInput,
+  ListCommentsInput,
+  ListWebhooksInput,
+  MoveCardInput,
+  UpdateCommentInput,
+  VerifyWebhookInput
+} from "../core/types.ts";
+
+export interface FizzyFakeSeed {
+  boards?: FizzyBoard[];
+  cards?: FizzyCard[];
+  comments?: FizzyComment[];
+  webhooks?: FizzyWebhook[];
+}
+
+export function createFakeFizzyPort(seed: FizzyFakeSeed = {}): FizzyPort {
+  const boards = (seed.boards ?? []).map((board) => ({ ...board }));
+  const cards = (seed.cards ?? []).map((card) => ({ ...card }));
+  const comments = (seed.comments ?? []).map((comment) => ({ ...comment }));
+  const webhooks = (seed.webhooks ?? []).map((webhook) => ({ ...webhook }));
+  let commentCounter = comments.length;
+
+  return {
+    describe() {
+      return { kind: "fake", sdk: false, note: "fixture-backed FizzyPort for tests" };
+    },
+    async listBoards(_input?: ListBoardsInput): Promise<FizzyBoard[]> {
+      return boards.map((board) => ({ ...board }));
+    },
+    async getBoard(input: GetBoardInput): Promise<FizzyBoard> {
+      const board = boards.find((entry) => entry.id === input.boardId);
+      if (!board) throw new Error(`Unknown board: ${input.boardId}`);
+      return { ...board };
+    },
+    async listCards(input: ListCardsInput): Promise<FizzyCard[]> {
+      return cards
+        .filter((card) => card.boardId === input.boardId)
+        .filter((card) => (input.columnId ? card.columnId === input.columnId : true))
+        .map((card) => ({ ...card }));
+    },
+    async getCard(input: GetCardInput): Promise<FizzyCard> {
+      const card = cards.find((entry) => entry.id === input.cardId);
+      if (!card) throw new Error(`Unknown card: ${input.cardId}`);
+      return { ...card };
+    },
+    async listComments(input: ListCommentsInput): Promise<FizzyComment[]> {
+      return comments.filter((comment) => comment.cardId === input.cardId).map((c) => ({ ...c }));
+    },
+    async createComment(input: CreateCommentInput): Promise<FizzyComment> {
+      commentCounter += 1;
+      const comment: FizzyComment = {
+        id: `comment_${commentCounter}`,
+        cardId: input.cardId,
+        body: input.body,
+        createdAt: new Date(0).toISOString()
+      };
+      comments.push(comment);
+      return { ...comment };
+    },
+    async updateComment(input: UpdateCommentInput): Promise<FizzyComment> {
+      const comment = comments.find((entry) => entry.id === input.commentId);
+      if (!comment) throw new Error(`Unknown comment: ${input.commentId}`);
+      comment.body = input.body;
+      return { ...comment };
+    },
+    async moveCard(input: MoveCardInput): Promise<FizzyCard> {
+      const card = cards.find((entry) => entry.id === input.cardId);
+      if (!card) throw new Error(`Unknown card: ${input.cardId}`);
+      card.columnId = input.targetColumnId;
+      return { ...card };
+    },
+    async listWebhooks(input: ListWebhooksInput): Promise<FizzyWebhook[]> {
+      return webhooks.filter((webhook) => webhook.boardId === input.boardId).map((w) => ({ ...w }));
+    },
+    async verifyWebhook(_input: VerifyWebhookInput): Promise<boolean> {
+      return true;
+    }
+  };
+}

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -1,0 +1,48 @@
+// fizzy-symphony v2 spike — public surface.
+//
+// A local, spec-driven operator cockpit for running Codex agents from Fizzy
+// boards. This barrel re-exports the v2 contracts and entry points so the bin
+// CLI and tests can import from a single place.
+
+export * from "./core/types.ts";
+export {
+  STATUS_SCHEMA_VERSION
+} from "./core/types.ts";
+export {
+  normalizeStatus,
+  deriveFactoryState,
+  countDirtyWorktrees,
+  countPreservedWorktrees
+} from "./core/status.ts";
+export {
+  listCapabilities,
+  getCapability,
+  deriveCapabilities
+} from "./core/capabilities.ts";
+export {
+  validateCommand,
+  checkCommandAvailability
+} from "./core/commands.ts";
+export {
+  createEventLog,
+  parseJsonlEvents
+} from "./core/events.ts";
+
+export { createFakeFizzyPort } from "./fizzy/fake.ts";
+export { createFizzyAdapter } from "./fizzy/adapter.ts";
+export { createFakeCodexRunner } from "./codex/fake.ts";
+export { createCodexAdapter } from "./codex/adapter.ts";
+
+export { createRuntime } from "./daemon/runtime.ts";
+export type { SymphonyRuntime } from "./daemon/runtime.ts";
+export {
+  handleApiRequest,
+  createApiServer
+} from "./daemon/api.ts";
+
+export { createCockpitModel } from "./cockpit/model.ts";
+export { renderCockpitText, renderCapabilitiesText } from "./cockpit/renderer.ts";
+export { startInteractiveCockpit } from "./cockpit/interactive.ts";
+
+export { runCockpitCommand } from "./cli/cockpit.ts";
+export { runCapabilitiesCommand } from "./cli/capabilities.ts";

--- a/test/fixtures/v2/blocked-runner.json
+++ b/test/fixtures/v2/blocked-runner.json
@@ -1,0 +1,37 @@
+{
+  "status": {
+    "schemaVersion": "fizzy-symphony-status-v2",
+    "instance": { "id": "instance-local", "label": "operator-laptop", "endpoint": "http://127.0.0.1:4567" },
+    "readiness": {
+      "state": "blocked",
+      "ready": false,
+      "dispatchPaused": false,
+      "runnerStatus": "unavailable",
+      "blockers": [
+        { "code": "RUNNER_NOT_READY", "message": "Codex runner health is unavailable.", "detail": { "kind": "cli_app_server", "failureCode": "CODEX_NOT_FOUND", "remediation": "Install the Codex CLI or set runner.cli_app_server.command." } }
+      ]
+    },
+    "boards": [ { "id": "board_42", "name": "Agents", "routeIds": ["route_ready"], "activeCardCount": 0, "goldenCardCount": 1 } ],
+    "routes": [
+      { "id": "route_ready", "boardId": "board_42", "name": "Ready for Agents", "sourceColumnId": "col_ready", "sourceColumnName": "Ready for Agents", "goldenCardId": "card_golden", "backend": "codex", "enabled": false, "disabledReason": "Runner unavailable" }
+    ],
+    "cards": [
+      { "id": "card_golden", "number": 1, "title": "Agent instructions (golden ticket)", "boardId": "board_42", "routeId": "route_ready", "state": "idle", "golden": true },
+      { "id": "card_426", "number": 426, "title": "Fix terminal output", "boardId": "board_42", "routeId": "route_ready", "state": "blocked", "golden": false, "attention": "Runner unavailable; card cannot be dispatched." }
+    ],
+    "runs": { "queued": [], "running": [], "completed": [], "failed": [], "cancelled": [], "preempted": [] },
+    "claims": [],
+    "worktrees": [],
+    "retryQueue": [],
+    "capacityRefusals": [],
+    "doctor": { "goalClosable": false, "blockers": [{ "code": "RUNNER_UNAVAILABLE", "message": "Cannot close goal: runner is not ready." }] },
+    "warnings": [
+      { "code": "RUNNER_NOT_READY", "message": "Codex runner is unavailable; dispatch is blocked.", "severity": "error" }
+    ],
+    "recentEvents": [],
+    "lastUpdatedAt": "2026-05-29T08:00:10.000Z"
+  },
+  "events": [
+    { "id": "evt_block_1", "type": "runner.health", "severity": "error", "message": "Factory cannot close: Codex runner unavailable (CODEX_NOT_FOUND).", "at": "2026-05-29T08:00:09.000Z" }
+  ]
+}

--- a/test/fixtures/v2/capacity-refused.json
+++ b/test/fixtures/v2/capacity-refused.json
@@ -1,0 +1,38 @@
+{
+  "status": {
+    "schemaVersion": "fizzy-symphony-status-v2",
+    "instance": { "id": "instance-local", "label": "operator-laptop", "endpoint": "http://127.0.0.1:4567" },
+    "readiness": { "state": "ready", "ready": true, "blockers": [], "dispatchPaused": false, "runnerStatus": "ready" },
+    "boards": [ { "id": "board_42", "name": "Agents", "routeIds": ["route_ready"], "activeCardCount": 2, "goldenCardCount": 1 } ],
+    "routes": [
+      { "id": "route_ready", "boardId": "board_42", "name": "Ready for Agents", "sourceColumnId": "col_ready", "sourceColumnName": "Ready for Agents", "goldenCardId": "card_golden", "backend": "codex", "enabled": true }
+    ],
+    "cards": [
+      { "id": "card_golden", "number": 1, "title": "Agent instructions (golden ticket)", "boardId": "board_42", "routeId": "route_ready", "state": "idle", "golden": true },
+      { "id": "card_426", "number": 426, "title": "Fix terminal output", "boardId": "board_42", "routeId": "route_ready", "state": "running", "golden": false, "runId": "run_426", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426" },
+      { "id": "card_427", "number": 427, "title": "Add cockpit help screen", "boardId": "board_42", "routeId": "route_ready", "state": "blocked", "golden": false, "attention": "Capacity refused: agent.max_concurrent reached (1)." }
+    ],
+    "runs": {
+      "queued": [],
+      "running": [
+        { "id": "run_426", "attemptId": "attempt_1", "state": "running", "boardId": "board_42", "cardId": "card_426", "cardNumber": 426, "cardTitle": "Fix terminal output", "routeId": "route_ready", "sessionId": "session_9", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426", "startedAt": "2026-05-29T08:01:00.000Z", "stalled": false }
+      ],
+      "completed": [], "failed": [], "cancelled": [], "preempted": []
+    },
+    "claims": [ { "id": "claim_426", "cardId": "card_426", "runId": "run_426", "state": "claimed", "workspaceKey": "ws_426" } ],
+    "worktrees": [ { "workspaceKey": "ws_426", "path": "/work/repo/.fizzy-symphony/worktrees/card-426", "cardId": "card_426", "runId": "run_426", "branch": "fizzy/board42-card-426", "dirty": false, "preserved": false } ],
+    "retryQueue": [],
+    "capacityRefusals": [
+      { "cardId": "card_427", "routeId": "route_ready", "reason": "agent.max_concurrent reached (1)", "refusedAt": "2026-05-29T08:02:00.000Z" }
+    ],
+    "doctor": { "goalClosable": false, "blockers": [{ "code": "RUN_IN_FLIGHT", "message": "A run is still in motion for card 426." }] },
+    "warnings": [
+      { "code": "CAPACITY_REFUSED", "message": "Queued on the line: card 427 refused, max_concurrent reached.", "severity": "info", "cardId": "card_427" }
+    ],
+    "recentEvents": [],
+    "lastUpdatedAt": "2026-05-29T08:02:01.000Z"
+  },
+  "events": [
+    { "id": "evt_cap_1", "type": "capacity.refused", "severity": "info", "message": "Capacity refusal: card 427 not dispatched (max_concurrent=1).", "at": "2026-05-29T08:02:00.000Z", "cardId": "card_427", "cardNumber": 427 }
+  ]
+}

--- a/test/fixtures/v2/commands-disabled.json
+++ b/test/fixtures/v2/commands-disabled.json
@@ -1,0 +1,35 @@
+{
+  "status": {
+    "schemaVersion": "fizzy-symphony-status-v2",
+    "instance": { "id": "instance-local", "label": "operator-laptop", "endpoint": "http://127.0.0.1:4567" },
+    "readiness": {
+      "state": "locked",
+      "ready": true,
+      "dispatchPaused": true,
+      "runnerStatus": "ready",
+      "blockers": [{ "code": "DISPATCH_PAUSED", "message": "Operator paused dispatch." }]
+    },
+    "boards": [ { "id": "board_42", "name": "Agents", "routeIds": ["route_ready"], "activeCardCount": 1, "goldenCardCount": 1 } ],
+    "routes": [
+      { "id": "route_ready", "boardId": "board_42", "name": "Ready for Agents", "sourceColumnId": "col_ready", "sourceColumnName": "Ready for Agents", "goldenCardId": "card_golden", "backend": "codex", "enabled": false, "disabledReason": "Dispatch paused" }
+    ],
+    "cards": [
+      { "id": "card_golden", "number": 1, "title": "Agent instructions (golden ticket)", "boardId": "board_42", "routeId": "route_ready", "state": "idle", "golden": true },
+      { "id": "card_426", "number": 426, "title": "Fix terminal output", "boardId": "board_42", "routeId": "route_ready", "state": "queued", "golden": false, "attention": "Dispatch paused by operator; will not start." }
+    ],
+    "runs": { "queued": [], "running": [], "completed": [], "failed": [], "cancelled": [], "preempted": [] },
+    "claims": [],
+    "worktrees": [],
+    "retryQueue": [],
+    "capacityRefusals": [],
+    "doctor": { "goalClosable": true, "blockers": [] },
+    "warnings": [
+      { "code": "DISPATCH_PAUSED", "message": "Factory locked: dispatch is paused; cancel/stop need an active run.", "severity": "info" }
+    ],
+    "recentEvents": [],
+    "lastUpdatedAt": "2026-05-29T08:09:00.000Z"
+  },
+  "events": [
+    { "id": "evt_pause_1", "type": "command.accepted.dispatch.pause", "severity": "info", "message": "Factory locked: operator paused dispatch.", "at": "2026-05-29T08:08:55.000Z" }
+  ]
+}

--- a/test/fixtures/v2/dirty-worktree.json
+++ b/test/fixtures/v2/dirty-worktree.json
@@ -1,0 +1,48 @@
+{
+  "status": {
+    "schemaVersion": "fizzy-symphony-status-v2",
+    "instance": { "id": "instance-local", "label": "operator-laptop", "endpoint": "http://127.0.0.1:4567" },
+    "readiness": { "state": "ready", "ready": true, "blockers": [], "dispatchPaused": false, "runnerStatus": "ready" },
+    "boards": [ { "id": "board_42", "name": "Agents", "routeIds": ["route_ready"], "activeCardCount": 1, "goldenCardCount": 1 } ],
+    "routes": [
+      { "id": "route_ready", "boardId": "board_42", "name": "Ready for Agents", "sourceColumnId": "col_ready", "sourceColumnName": "Ready for Agents", "goldenCardId": "card_golden", "backend": "codex", "enabled": true }
+    ],
+    "cards": [
+      { "id": "card_golden", "number": 1, "title": "Agent instructions (golden ticket)", "boardId": "board_42", "routeId": "route_ready", "state": "idle", "golden": true },
+      { "id": "card_426", "number": 426, "title": "Fix terminal output", "boardId": "board_42", "routeId": "route_ready", "state": "failed", "golden": false, "runId": "run_426", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426", "attention": "Worktree preserved with uncommitted changes; triage before rerun." }
+    ],
+    "runs": { "queued": [], "running": [], "completed": [], "failed": [], "cancelled": [], "preempted": [] },
+    "claims": [],
+    "worktrees": [
+      {
+        "workspaceKey": "ws_426",
+        "path": "/work/repo/.fizzy-symphony/worktrees/card-426",
+        "cardId": "card_426",
+        "cardNumber": 426,
+        "runId": "run_426",
+        "branch": "fizzy/board42-card-426",
+        "dirty": true,
+        "preserved": true,
+        "dirtyPaths": ["src/terminal-renderer.js", ".fizzy-symphony/notes.md"],
+        "lastError": { "code": "RUNNER_ERROR", "message": "Codex turn failed mid-edit." },
+        "recommendedAction": "Inspect dirty paths, commit or discard, then rerun card 426."
+      }
+    ],
+    "retryQueue": [],
+    "capacityRefusals": [],
+    "doctor": {
+      "goalClosable": false,
+      "blockers": [
+        { "code": "DIRTY_WORKTREE", "message": "Worktree ws_426 has uncommitted changes.", "workspaceKey": "ws_426", "recommendedAction": "fizzy-symphony worktrees --card 426" }
+      ]
+    },
+    "warnings": [
+      { "code": "WORKTREE_DIRTY", "message": "Spill on the line: card 426 worktree is dirty.", "severity": "warning", "cardId": "card_426" }
+    ],
+    "recentEvents": [],
+    "lastUpdatedAt": "2026-05-29T08:05:00.000Z"
+  },
+  "events": [
+    { "id": "evt_dirty_1", "type": "worktree.preserved", "severity": "warning", "message": "Spill / hazard: preserved dirty worktree for card 426.", "at": "2026-05-29T08:04:59.000Z", "cardId": "card_426", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426" }
+  ]
+}

--- a/test/fixtures/v2/doctor-blocked.json
+++ b/test/fixtures/v2/doctor-blocked.json
@@ -1,0 +1,45 @@
+{
+  "status": {
+    "schemaVersion": "fizzy-symphony-status-v2",
+    "instance": { "id": "instance-local", "label": "operator-laptop", "endpoint": "http://127.0.0.1:4567" },
+    "readiness": { "state": "ready", "ready": true, "blockers": [], "dispatchPaused": false, "runnerStatus": "ready" },
+    "boards": [ { "id": "board_42", "name": "Agents", "routeIds": ["route_ready"], "activeCardCount": 1, "goldenCardCount": 1 } ],
+    "routes": [
+      { "id": "route_ready", "boardId": "board_42", "name": "Ready for Agents", "sourceColumnId": "col_ready", "sourceColumnName": "Ready for Agents", "goldenCardId": "card_golden", "backend": "codex", "enabled": true }
+    ],
+    "cards": [
+      { "id": "card_golden", "number": 1, "title": "Agent instructions (golden ticket)", "boardId": "board_42", "routeId": "route_ready", "state": "idle", "golden": true },
+      { "id": "card_426", "number": 426, "title": "Fix terminal output", "boardId": "board_42", "routeId": "route_ready", "state": "completed", "golden": false, "runId": "run_426", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426" }
+    ],
+    "runs": {
+      "queued": [],
+      "running": [],
+      "completed": [
+        { "id": "run_426", "attemptId": "attempt_1", "state": "completed", "boardId": "board_42", "cardId": "card_426", "cardNumber": 426, "cardTitle": "Fix terminal output", "routeId": "route_ready", "sessionId": "session_9", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426", "startedAt": "2026-05-29T08:01:00.000Z", "updatedAt": "2026-05-29T08:08:00.000Z" }
+      ],
+      "failed": [], "cancelled": [], "preempted": []
+    },
+    "claims": [ { "id": "claim_426", "cardId": "card_426", "runId": "run_426", "state": "completed", "workspaceKey": "ws_426" } ],
+    "worktrees": [
+      { "workspaceKey": "ws_426", "path": "/work/repo/.fizzy-symphony/worktrees/card-426", "cardId": "card_426", "runId": "run_426", "branch": "fizzy/board42-card-426", "dirty": true, "preserved": true, "dirtyPaths": [".fizzy-symphony/notes.md"], "recommendedAction": "Proof written; goal still blocked until dirty worktree is triaged." }
+    ],
+    "retryQueue": [],
+    "capacityRefusals": [],
+    "doctor": {
+      "goalClosable": false,
+      "blockers": [
+        { "code": "DIRTY_WORKTREE", "message": "Completed run left a dirty worktree.", "workspaceKey": "ws_426", "recommendedAction": "fizzy-symphony worktrees --card 426 --dirty-only" }
+      ],
+      "checkedAt": "2026-05-29T08:08:30.000Z"
+    },
+    "warnings": [
+      { "code": "GOAL_NOT_CLOSABLE", "message": "Factory cannot close: dirty worktree remains after completion.", "severity": "warning", "cardId": "card_426" }
+    ],
+    "recentEvents": [],
+    "lastUpdatedAt": "2026-05-29T08:08:31.000Z"
+  },
+  "events": [
+    { "id": "evt_done_1", "type": "run.completed", "severity": "info", "message": "Wrapped candy: run_426 completed with proof.", "at": "2026-05-29T08:08:00.000Z", "runId": "run_426", "cardId": "card_426" },
+    { "id": "evt_doctor_1", "type": "doctor.blocked", "severity": "warning", "message": "Factory cannot close: dirty worktree ws_426.", "at": "2026-05-29T08:08:30.000Z", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426" }
+  ]
+}

--- a/test/fixtures/v2/failed-run.json
+++ b/test/fixtures/v2/failed-run.json
@@ -1,0 +1,56 @@
+{
+  "status": {
+    "schemaVersion": "fizzy-symphony-status-v2",
+    "instance": { "id": "instance-local", "label": "operator-laptop", "endpoint": "http://127.0.0.1:4567" },
+    "readiness": { "state": "ready", "ready": true, "blockers": [], "dispatchPaused": false, "runnerStatus": "ready" },
+    "boards": [ { "id": "board_42", "name": "Agents", "routeIds": ["route_ready"], "activeCardCount": 1, "goldenCardCount": 1 } ],
+    "routes": [
+      { "id": "route_ready", "boardId": "board_42", "name": "Ready for Agents", "sourceColumnId": "col_ready", "sourceColumnName": "Ready for Agents", "goldenCardId": "card_golden", "backend": "codex", "enabled": true }
+    ],
+    "cards": [
+      { "id": "card_golden", "number": 1, "title": "Agent instructions (golden ticket)", "boardId": "board_42", "routeId": "route_ready", "state": "idle", "golden": true },
+      { "id": "card_426", "number": 426, "title": "Fix terminal output", "boardId": "board_42", "routeId": "route_ready", "state": "failed", "golden": false, "runId": "run_426_attempt2", "attention": "Run failed with RUNNER_ERROR; see retry queue." }
+    ],
+    "runs": {
+      "queued": [],
+      "running": [],
+      "completed": [],
+      "failed": [
+        {
+          "id": "run_426_attempt2",
+          "attemptId": "attempt_2",
+          "state": "failed",
+          "boardId": "board_42",
+          "cardId": "card_426",
+          "cardNumber": 426,
+          "cardTitle": "Fix terminal output",
+          "routeId": "route_ready",
+          "sessionId": "session_12",
+          "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426",
+          "startedAt": "2026-05-29T08:04:00.000Z",
+          "updatedAt": "2026-05-29T08:04:45.000Z",
+          "error": { "code": "RUNNER_ERROR", "message": "Codex turn exited non-zero.", "remediation": "Inspect worktree and retry; attempt 2 of 3." },
+          "recommendedAction": "Review failure, then allow retry or cancel."
+        }
+      ],
+      "cancelled": [], "preempted": []
+    },
+    "claims": [
+      { "id": "claim_426", "cardId": "card_426", "runId": "run_426_attempt2", "state": "failed", "workspaceKey": "ws_426" }
+    ],
+    "worktrees": [
+      { "workspaceKey": "ws_426", "path": "/work/repo/.fizzy-symphony/worktrees/card-426", "cardId": "card_426", "runId": "run_426_attempt2", "branch": "fizzy/board42-card-426", "dirty": false, "preserved": true, "lastError": { "code": "RUNNER_ERROR", "message": "Codex turn exited non-zero." }, "recommendedAction": "Awaiting retry attempt 3." }
+    ],
+    "retryQueue": [],
+    "capacityRefusals": [],
+    "doctor": { "goalClosable": false, "blockers": [{ "code": "FAILED_RUN", "message": "Untriaged failed run for card 426." }] },
+    "warnings": [
+      { "code": "RUN_FAILED", "message": "Jammed machine: run_426_attempt2 failed (RUNNER_ERROR).", "severity": "error", "runId": "run_426_attempt2", "cardId": "card_426" }
+    ],
+    "recentEvents": [],
+    "lastUpdatedAt": "2026-05-29T08:04:46.000Z"
+  },
+  "events": [
+    { "id": "evt_fail_1", "type": "run.failed", "severity": "error", "message": "Jammed machine: run_426_attempt2 failed (RUNNER_ERROR).", "at": "2026-05-29T08:04:45.000Z", "runId": "run_426_attempt2", "cardId": "card_426", "cardNumber": 426 }
+  ]
+}

--- a/test/fixtures/v2/ready.json
+++ b/test/fixtures/v2/ready.json
@@ -1,0 +1,69 @@
+{
+  "status": {
+    "schemaVersion": "fizzy-symphony-status-v2",
+    "instance": {
+      "id": "instance-local",
+      "label": "operator-laptop",
+      "pid": 4242,
+      "startedAt": "2026-05-29T08:00:00.000Z",
+      "endpoint": "http://127.0.0.1:4567",
+      "daemonVersion": "0.2.0-spike"
+    },
+    "readiness": {
+      "state": "ready",
+      "ready": true,
+      "blockers": [],
+      "dispatchPaused": false,
+      "runnerStatus": "ready"
+    },
+    "boards": [
+      { "id": "board_42", "name": "Agents", "routeIds": ["route_ready"], "activeCardCount": 0, "goldenCardCount": 1 }
+    ],
+    "routes": [
+      {
+        "id": "route_ready",
+        "boardId": "board_42",
+        "name": "Ready for Agents",
+        "sourceColumnId": "col_ready",
+        "sourceColumnName": "Ready for Agents",
+        "goldenCardId": "card_golden",
+        "goldenCardNumber": 1,
+        "backend": "codex",
+        "model": "gpt-5.5",
+        "enabled": true
+      }
+    ],
+    "cards": [
+      {
+        "id": "card_golden",
+        "number": 1,
+        "title": "Agent instructions (golden ticket)",
+        "boardId": "board_42",
+        "routeId": "route_ready",
+        "columnId": "col_ready",
+        "columnName": "Ready for Agents",
+        "state": "idle",
+        "golden": true
+      }
+    ],
+    "runs": { "queued": [], "running": [], "completed": [], "failed": [], "cancelled": [], "preempted": [] },
+    "claims": [],
+    "worktrees": [],
+    "retryQueue": [],
+    "capacityRefusals": [],
+    "doctor": { "goalClosable": true, "blockers": [], "checkedAt": "2026-05-29T08:00:00.000Z" },
+    "warnings": [],
+    "recentEvents": [],
+    "lastUpdatedAt": "2026-05-29T08:00:05.000Z"
+  },
+  "events": [
+    {
+      "id": "evt_ready_1",
+      "type": "daemon.ready",
+      "severity": "info",
+      "message": "Factory open: runner ready, dispatch enabled.",
+      "at": "2026-05-29T08:00:05.000Z",
+      "boardId": "board_42"
+    }
+  ]
+}

--- a/test/fixtures/v2/retry-queue.json
+++ b/test/fixtures/v2/retry-queue.json
@@ -1,0 +1,36 @@
+{
+  "status": {
+    "schemaVersion": "fizzy-symphony-status-v2",
+    "instance": { "id": "instance-local", "label": "operator-laptop", "endpoint": "http://127.0.0.1:4567" },
+    "readiness": { "state": "ready", "ready": true, "blockers": [], "dispatchPaused": false, "runnerStatus": "ready" },
+    "boards": [ { "id": "board_42", "name": "Agents", "routeIds": ["route_ready"], "activeCardCount": 2, "goldenCardCount": 1 } ],
+    "routes": [
+      { "id": "route_ready", "boardId": "board_42", "name": "Ready for Agents", "sourceColumnId": "col_ready", "sourceColumnName": "Ready for Agents", "goldenCardId": "card_golden", "backend": "codex", "enabled": true }
+    ],
+    "cards": [
+      { "id": "card_golden", "number": 1, "title": "Agent instructions (golden ticket)", "boardId": "board_42", "routeId": "route_ready", "state": "idle", "golden": true },
+      { "id": "card_426", "number": 426, "title": "Fix terminal output", "boardId": "board_42", "routeId": "route_ready", "state": "queued", "golden": false, "runId": "run_426", "attention": "Awaiting retry attempt 2 of 3." },
+      { "id": "card_430", "number": 430, "title": "Update docs", "boardId": "board_42", "routeId": "route_ready", "state": "queued", "golden": false, "runId": "run_430", "attention": "Awaiting retry attempt 3 of 3." }
+    ],
+    "runs": { "queued": [], "running": [], "completed": [], "failed": [], "cancelled": [], "preempted": [] },
+    "claims": [],
+    "worktrees": [
+      { "workspaceKey": "ws_426", "path": "/work/repo/.fizzy-symphony/worktrees/card-426", "cardId": "card_426", "runId": "run_426", "branch": "fizzy/board42-card-426", "dirty": false, "preserved": true }
+    ],
+    "retryQueue": [
+      { "runId": "run_426", "cardId": "card_426", "attempt": 2, "maxAttempts": 3, "nextRetryAt": "2026-05-29T08:10:00.000Z", "reason": "RUNNER_ERROR" },
+      { "runId": "run_430", "cardId": "card_430", "attempt": 3, "maxAttempts": 3, "nextRetryAt": "2026-05-29T08:15:00.000Z", "reason": "TURN_TIMEOUT" }
+    ],
+    "capacityRefusals": [],
+    "doctor": { "goalClosable": false, "blockers": [{ "code": "RETRIES_PENDING", "message": "2 runs queued for retry." }] },
+    "warnings": [
+      { "code": "RETRY_SCHEDULED", "message": "Repair queue: 2 runs scheduled for retry.", "severity": "warning" }
+    ],
+    "recentEvents": [],
+    "lastUpdatedAt": "2026-05-29T08:06:00.000Z"
+  },
+  "events": [
+    { "id": "evt_retry_1", "type": "retry.scheduled", "severity": "warning", "message": "Repair queue: run_426 scheduled for retry (attempt 2/3).", "at": "2026-05-29T08:05:30.000Z", "runId": "run_426", "cardId": "card_426" },
+    { "id": "evt_retry_2", "type": "retry.scheduled", "severity": "warning", "message": "Repair queue: run_430 scheduled for retry (attempt 3/3).", "at": "2026-05-29T08:05:45.000Z", "runId": "run_430", "cardId": "card_430" }
+  ]
+}

--- a/test/fixtures/v2/running-multiple-cards.json
+++ b/test/fixtures/v2/running-multiple-cards.json
@@ -1,0 +1,52 @@
+{
+  "status": {
+    "schemaVersion": "fizzy-symphony-status-v2",
+    "instance": { "id": "instance-local", "label": "operator-laptop", "endpoint": "http://127.0.0.1:4567" },
+    "readiness": { "state": "ready", "ready": true, "blockers": [], "dispatchPaused": false, "runnerStatus": "ready" },
+    "boards": [
+      { "id": "board_42", "name": "Agents", "routeIds": ["route_ready", "route_review"], "activeCardCount": 3, "goldenCardCount": 2 }
+    ],
+    "routes": [
+      { "id": "route_ready", "boardId": "board_42", "name": "Ready for Agents", "sourceColumnId": "col_ready", "sourceColumnName": "Ready for Agents", "goldenCardId": "card_golden_a", "backend": "codex", "model": "gpt-5.5", "enabled": true },
+      { "id": "route_review", "boardId": "board_42", "name": "Auto Review", "sourceColumnId": "col_review", "sourceColumnName": "In Review", "goldenCardId": "card_golden_b", "backend": "codex", "model": "gpt-5.5", "enabled": true }
+    ],
+    "cards": [
+      { "id": "card_golden_a", "number": 1, "title": "Build agent (golden ticket)", "boardId": "board_42", "routeId": "route_ready", "state": "idle", "golden": true },
+      { "id": "card_golden_b", "number": 2, "title": "Review agent (golden ticket)", "boardId": "board_42", "routeId": "route_review", "state": "idle", "golden": true },
+      { "id": "card_426", "number": 426, "title": "Fix terminal output", "boardId": "board_42", "routeId": "route_ready", "state": "running", "golden": false, "runId": "run_426", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426" },
+      { "id": "card_427", "number": 427, "title": "Add cockpit help screen", "boardId": "board_42", "routeId": "route_ready", "state": "queued", "golden": false, "runId": "run_427" },
+      { "id": "card_500", "number": 500, "title": "Review PR for card 426", "boardId": "board_42", "routeId": "route_review", "state": "running", "golden": false, "runId": "run_500", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-500" }
+    ],
+    "runs": {
+      "queued": [
+        { "id": "run_427", "state": "queued", "boardId": "board_42", "cardId": "card_427", "cardNumber": 427, "cardTitle": "Add cockpit help screen", "routeId": "route_ready" }
+      ],
+      "running": [
+        { "id": "run_426", "attemptId": "attempt_1", "state": "running", "boardId": "board_42", "cardId": "card_426", "cardNumber": 426, "cardTitle": "Fix terminal output", "routeId": "route_ready", "sessionId": "session_9", "turnId": "turn_3", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426", "startedAt": "2026-05-29T08:01:00.000Z", "stalled": false },
+        { "id": "run_500", "attemptId": "attempt_1", "state": "running", "boardId": "board_42", "cardId": "card_500", "cardNumber": 500, "cardTitle": "Review PR for card 426", "routeId": "route_review", "sessionId": "session_10", "turnId": "turn_1", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-500", "startedAt": "2026-05-29T08:03:00.000Z", "stalled": true, "recommendedAction": "Check runner; turn has been idle past stall_timeout_ms." }
+      ],
+      "completed": [], "failed": [], "cancelled": [], "preempted": []
+    },
+    "claims": [
+      { "id": "claim_426", "cardId": "card_426", "runId": "run_426", "state": "claimed", "workspaceKey": "ws_426" },
+      { "id": "claim_500", "cardId": "card_500", "runId": "run_500", "state": "renewed", "workspaceKey": "ws_500" }
+    ],
+    "worktrees": [
+      { "workspaceKey": "ws_426", "path": "/work/repo/.fizzy-symphony/worktrees/card-426", "cardId": "card_426", "runId": "run_426", "branch": "fizzy/board42-card-426", "dirty": false, "preserved": false },
+      { "workspaceKey": "ws_500", "path": "/work/repo/.fizzy-symphony/worktrees/card-500", "cardId": "card_500", "runId": "run_500", "branch": "fizzy/board42-card-500", "dirty": false, "preserved": false }
+    ],
+    "retryQueue": [],
+    "capacityRefusals": [],
+    "doctor": { "goalClosable": false, "blockers": [{ "code": "RUNS_IN_FLIGHT", "message": "2 runs still in motion." }] },
+    "warnings": [
+      { "code": "RUN_STALLED", "message": "run_500 has been idle past the stall timeout.", "severity": "warning", "runId": "run_500" }
+    ],
+    "recentEvents": [],
+    "lastUpdatedAt": "2026-05-29T08:03:30.000Z"
+  },
+  "events": [
+    { "id": "evt_a", "type": "run.started", "severity": "info", "message": "Machine in motion for card 426.", "at": "2026-05-29T08:01:00.000Z", "runId": "run_426" },
+    { "id": "evt_b", "type": "run.started", "severity": "info", "message": "Machine in motion for card 500.", "at": "2026-05-29T08:03:00.000Z", "runId": "run_500" },
+    { "id": "evt_c", "type": "run.stalled", "severity": "warning", "message": "run_500 stalled past timeout.", "at": "2026-05-29T08:03:25.000Z", "runId": "run_500" }
+  ]
+}

--- a/test/fixtures/v2/running-one-card.json
+++ b/test/fixtures/v2/running-one-card.json
@@ -1,0 +1,72 @@
+{
+  "status": {
+    "schemaVersion": "fizzy-symphony-status-v2",
+    "instance": {
+      "id": "instance-local",
+      "label": "operator-laptop",
+      "pid": 4242,
+      "startedAt": "2026-05-29T08:00:00.000Z",
+      "endpoint": "http://127.0.0.1:4567"
+    },
+    "readiness": { "state": "ready", "ready": true, "blockers": [], "dispatchPaused": false, "runnerStatus": "ready" },
+    "boards": [
+      { "id": "board_42", "name": "Agents", "routeIds": ["route_ready"], "activeCardCount": 1, "goldenCardCount": 1 }
+    ],
+    "routes": [
+      {
+        "id": "route_ready",
+        "boardId": "board_42",
+        "name": "Ready for Agents",
+        "sourceColumnId": "col_ready",
+        "sourceColumnName": "Ready for Agents",
+        "goldenCardId": "card_golden",
+        "goldenCardNumber": 1,
+        "backend": "codex",
+        "model": "gpt-5.5",
+        "enabled": true
+      }
+    ],
+    "cards": [
+      { "id": "card_golden", "number": 1, "title": "Agent instructions (golden ticket)", "boardId": "board_42", "routeId": "route_ready", "columnId": "col_ready", "state": "idle", "golden": true },
+      { "id": "card_426", "number": 426, "title": "Fix terminal output", "boardId": "board_42", "routeId": "route_ready", "columnId": "col_ready", "state": "running", "golden": false, "runId": "run_426", "claimId": "claim_426", "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426" }
+    ],
+    "runs": {
+      "queued": [],
+      "running": [
+        {
+          "id": "run_426",
+          "attemptId": "attempt_1",
+          "state": "running",
+          "boardId": "board_42",
+          "cardId": "card_426",
+          "cardNumber": 426,
+          "cardTitle": "Fix terminal output",
+          "routeId": "route_ready",
+          "claimId": "claim_426",
+          "sessionId": "session_9",
+          "turnId": "turn_3",
+          "workspacePath": "/work/repo/.fizzy-symphony/worktrees/card-426",
+          "startedAt": "2026-05-29T08:01:00.000Z",
+          "updatedAt": "2026-05-29T08:02:30.000Z",
+          "stalled": false
+        }
+      ],
+      "completed": [], "failed": [], "cancelled": [], "preempted": []
+    },
+    "claims": [
+      { "id": "claim_426", "cardId": "card_426", "boardId": "board_42", "routeId": "route_ready", "runId": "run_426", "state": "claimed", "expiresAt": "2026-05-29T08:10:00.000Z", "workspaceKey": "ws_426" }
+    ],
+    "worktrees": [
+      { "workspaceKey": "ws_426", "path": "/work/repo/.fizzy-symphony/worktrees/card-426", "cardId": "card_426", "cardNumber": 426, "runId": "run_426", "branch": "fizzy/board42-card-426", "dirty": false, "preserved": false }
+    ],
+    "retryQueue": [],
+    "capacityRefusals": [],
+    "doctor": { "goalClosable": false, "blockers": [{ "code": "RUN_IN_FLIGHT", "message": "A Codex run is still in motion for card 426.", "workspaceKey": "ws_426" }], "checkedAt": "2026-05-29T08:02:30.000Z" },
+    "warnings": [],
+    "recentEvents": [],
+    "lastUpdatedAt": "2026-05-29T08:02:31.000Z"
+  },
+  "events": [
+    { "id": "evt_run_1", "type": "run.started", "severity": "info", "message": "Machine in motion: Codex turn started for card 426.", "at": "2026-05-29T08:01:00.000Z", "boardId": "board_42", "cardId": "card_426", "cardNumber": 426, "runId": "run_426", "sessionId": "session_9" }
+  ]
+}

--- a/test/fixtures/v2/webhook-error.json
+++ b/test/fixtures/v2/webhook-error.json
@@ -1,0 +1,29 @@
+{
+  "status": {
+    "schemaVersion": "fizzy-symphony-status-v2",
+    "instance": { "id": "instance-local", "label": "operator-laptop", "endpoint": "http://127.0.0.1:4567" },
+    "readiness": { "state": "ready", "ready": true, "blockers": [], "dispatchPaused": false, "runnerStatus": "ready" },
+    "boards": [ { "id": "board_42", "name": "Agents", "routeIds": ["route_ready"], "activeCardCount": 0, "goldenCardCount": 1 } ],
+    "routes": [
+      { "id": "route_ready", "boardId": "board_42", "name": "Ready for Agents", "sourceColumnId": "col_ready", "sourceColumnName": "Ready for Agents", "goldenCardId": "card_golden", "backend": "codex", "enabled": true }
+    ],
+    "cards": [
+      { "id": "card_golden", "number": 1, "title": "Agent instructions (golden ticket)", "boardId": "board_42", "routeId": "route_ready", "state": "idle", "golden": true }
+    ],
+    "runs": { "queued": [], "running": [], "completed": [], "failed": [], "cancelled": [], "preempted": [] },
+    "claims": [],
+    "worktrees": [],
+    "retryQueue": [],
+    "capacityRefusals": [],
+    "doctor": { "goalClosable": true, "blockers": [] },
+    "warnings": [
+      { "code": "WEBHOOK_DELIVERY_FAILED", "message": "Caution light: webhook callback returned 500 for board_42.", "severity": "error" }
+    ],
+    "recentEvents": [],
+    "lastUpdatedAt": "2026-05-29T08:00:30.000Z"
+  },
+  "events": [
+    { "id": "evt_wh_1", "type": "webhook.delivery_error", "severity": "error", "message": "Webhook delivery failed: callback http 500 for board_42.", "at": "2026-05-29T08:00:25.000Z", "boardId": "board_42", "data": { "code": "DELIVERY_FAILED", "httpStatus": 500 } },
+    { "id": "evt_wh_2", "type": "webhook.filtered", "severity": "info", "message": "Filtered stale webhook event (age > max_event_age_seconds).", "at": "2026-05-29T08:00:20.000Z", "boardId": "board_42" }
+  ]
+}

--- a/test/v2/api.test.js
+++ b/test/v2/api.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { handleApiRequest, createApiServer } from "../../src/v2/daemon/api.ts";
+import { createRuntime } from "../../src/v2/daemon/runtime.ts";
+
+function runtimeWithRun() {
+  return createRuntime({
+    status: {
+      instance: { id: "instance-test" },
+      readiness: { state: "ready", ready: true, runnerStatus: "ready" },
+      runs: { running: [{ id: "run_1", state: "running", sessionId: "s_1", cardId: "card_1" }] },
+      cards: [{ id: "card_1", title: "c", boardId: "b", state: "running", golden: false }],
+      worktrees: [{ workspaceKey: "ws_1", path: "/ws", dirty: true, preserved: true }]
+    }
+  });
+}
+
+test("handleApiRequest serves read endpoints", () => {
+  const runtime = runtimeWithRun();
+  assert.equal(handleApiRequest(runtime, "GET", "/v2/health").statusCode, 200);
+  assert.equal(handleApiRequest(runtime, "GET", "/v2/ready").statusCode, 200);
+  assert.equal(handleApiRequest(runtime, "GET", "/v2/status").body.schemaVersion, "fizzy-symphony-status-v2");
+  assert.ok(handleApiRequest(runtime, "GET", "/v2/capabilities").body.capabilities.length > 0);
+  assert.ok(Array.isArray(handleApiRequest(runtime, "GET", "/v2/events").body.events));
+  assert.ok(handleApiRequest(runtime, "GET", "/v2/runs").body.runs.running.length === 1);
+  assert.equal(handleApiRequest(runtime, "GET", "/v2/runs/run_1").body.run.id, "run_1");
+  assert.equal(handleApiRequest(runtime, "GET", "/v2/runs/missing").statusCode, 404);
+  assert.equal(handleApiRequest(runtime, "GET", "/v2/worktrees").body.worktrees.length, 1);
+});
+
+test("ready endpoint returns 503 when not ready", () => {
+  const runtime = createRuntime({ status: { readiness: { state: "blocked", ready: false, blockers: [{ code: "X", message: "m" }] } } });
+  assert.equal(handleApiRequest(runtime, "GET", "/v2/ready").statusCode, 503);
+});
+
+test("command endpoint validates and dry-runs", () => {
+  const runtime = runtimeWithRun();
+  const accepted = handleApiRequest(runtime, "POST", "/v2/commands", { type: "run.cancel", runId: "run_1", reason: "x" });
+  assert.equal(accepted.statusCode, 202);
+  assert.equal(accepted.body.outcome, "dry-run");
+
+  const unavailable = handleApiRequest(runtime, "POST", "/v2/commands", { type: "run.cancel", runId: "nope", reason: "x" });
+  assert.equal(unavailable.statusCode, 409);
+
+  const rejected = handleApiRequest(runtime, "POST", "/v2/commands", { type: "garbage" });
+  assert.equal(rejected.statusCode, 400);
+});
+
+test("unknown route returns 404", () => {
+  const runtime = runtimeWithRun();
+  assert.equal(handleApiRequest(runtime, "GET", "/v2/nope").statusCode, 404);
+});
+
+test("createApiServer serves over a real socket", async () => {
+  const runtime = runtimeWithRun();
+  const api = createApiServer(runtime);
+  const { url } = await api.listen();
+  try {
+    const statusRes = await fetch(`${url}/v2/status`);
+    assert.equal(statusRes.status, 200);
+    const status = await statusRes.json();
+    assert.equal(status.instance.id, "instance-test");
+
+    const cmdRes = await fetch(`${url}/v2/commands`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "run.cancel", runId: "run_1", reason: "operator" })
+    });
+    assert.equal(cmdRes.status, 202);
+    const cmd = await cmdRes.json();
+    assert.equal(cmd.outcome, "dry-run");
+  } finally {
+    await api.close();
+  }
+});

--- a/test/v2/capabilities.test.js
+++ b/test/v2/capabilities.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { listCapabilities, getCapability, deriveCapabilities } from "../../src/v2/core/capabilities.ts";
+import { normalizeStatus } from "../../src/v2/core/status.ts";
+
+test("registry lists capabilities with required shape", () => {
+  const capabilities = listCapabilities();
+  assert.ok(capabilities.length > 0);
+  for (const capability of capabilities) {
+    assert.equal(typeof capability.id, "string");
+    assert.equal(typeof capability.title, "string");
+    assert.equal(typeof capability.category, "string");
+    assert.equal(typeof capability.enabled, "boolean");
+  }
+});
+
+test("getCapability returns a copy, not the registry entry", () => {
+  const a = getCapability("codex.run");
+  const b = getCapability("codex.run");
+  assert.ok(a && b);
+  assert.notEqual(a, b);
+  a.enabled = false;
+  assert.equal(getCapability("codex.run").enabled, true);
+});
+
+test("deriveCapabilities disables cancel/stop when no run is active", () => {
+  const status = normalizeStatus({
+    readiness: { state: "ready", ready: true, runnerStatus: "ready" },
+    runs: { running: [] }
+  });
+  const derived = deriveCapabilities(status);
+  const cancel = derived.find((c) => c.id === "codex.cancel");
+  const stop = derived.find((c) => c.id === "session.stop");
+  assert.equal(cancel.enabled, false);
+  assert.equal(cancel.disabledReason, "No active run");
+  assert.equal(stop.enabled, false);
+});
+
+test("deriveCapabilities disables codex.run when runner not ready", () => {
+  const status = normalizeStatus({
+    readiness: { state: "blocked", ready: false, runnerStatus: "unavailable" }
+  });
+  const run = deriveCapabilities(status).find((c) => c.id === "codex.run");
+  assert.equal(run.enabled, false);
+  assert.equal(run.disabledReason, "Runner not ready");
+});
+
+test("deriveCapabilities enables cancel/stop when a run is active", () => {
+  const status = normalizeStatus({
+    readiness: { state: "ready", ready: true, runnerStatus: "ready" },
+    runs: { running: [{ id: "run_1", state: "running", sessionId: "s_1" }] }
+  });
+  const cancel = deriveCapabilities(status).find((c) => c.id === "codex.cancel");
+  assert.equal(cancel.enabled, true);
+});

--- a/test/v2/cockpit-cli.test.js
+++ b/test/v2/cockpit-cli.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { runCockpitCommand } from "../../src/v2/cli/cockpit.ts";
+import { runCapabilitiesCommand } from "../../src/v2/cli/capabilities.ts";
+
+const FIXTURE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "v2");
+
+function bufferIo(extra = {}) {
+  const out = [];
+  const err = [];
+  return {
+    io: {
+      stdout: { write: (t) => out.push(t) },
+      stderr: { write: (t) => err.push(t) },
+      ...extra
+    },
+    out: () => out.join(""),
+    err: () => err.join("")
+  };
+}
+
+test("cockpit --once prints a static frame (non-TTY safe)", async () => {
+  const { io, out } = bufferIo({ stdoutIsTTY: false });
+  const code = await runCockpitCommand(["--fixture", join(FIXTURE_DIR, "running-one-card.json"), "--once"], io);
+  assert.equal(code, 0);
+  assert.match(out(), /FIZZY-SYMPHONY COCKPIT/);
+  assert.match(out(), /Machine in motion/);
+  assert.match(out(), /run_426/);
+});
+
+test("cockpit falls back to static text in non-TTY without --once", async () => {
+  const { io, out, err } = bufferIo({ stdoutIsTTY: false });
+  const code = await runCockpitCommand(["--fixture", join(FIXTURE_DIR, "blocked-runner.json")], io);
+  assert.equal(code, 0);
+  assert.match(err(), /non-TTY detected/);
+  assert.match(out(), /Factory cannot close|blocked/);
+});
+
+test("cockpit --json emits the cockpit model", async () => {
+  const { io, out } = bufferIo({ stdoutIsTTY: false });
+  const code = await runCockpitCommand(["--fixture", join(FIXTURE_DIR, "dirty-worktree.json"), "--json"], io);
+  assert.equal(code, 0);
+  const model = JSON.parse(out());
+  assert.ok(model.header);
+  assert.ok(model.panels.worktrees.some((w) => w.dirty));
+});
+
+test("cockpit reports a clear error for a missing fixture", async () => {
+  const { io, err } = bufferIo({ stdoutIsTTY: false });
+  const code = await runCockpitCommand(["--fixture", join(FIXTURE_DIR, "does-not-exist.json"), "--once"], io);
+  assert.equal(code, 1);
+  assert.match(err(), /failed to load source/);
+});
+
+test("capabilities prints the registry", async () => {
+  const { io, out } = bufferIo();
+  const code = await runCapabilitiesCommand([], io);
+  assert.equal(code, 0);
+  assert.match(out(), /codex.run/);
+  assert.match(out(), /worktree.preserve/);
+});
+
+test("capabilities --json against a fixture reflects live disabled reasons", async () => {
+  const { io, out } = bufferIo();
+  const code = await runCapabilitiesCommand(["--fixture", join(FIXTURE_DIR, "ready.json"), "--json"], io);
+  assert.equal(code, 0);
+  const { capabilities } = JSON.parse(out());
+  const cancel = capabilities.find((c) => c.id === "codex.cancel");
+  assert.equal(cancel.enabled, false);
+  assert.equal(cancel.disabledReason, "No active run");
+});

--- a/test/v2/cockpit-model.test.js
+++ b/test/v2/cockpit-model.test.js
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { createCockpitModel } from "../../src/v2/cockpit/model.ts";
+import { normalizeStatus } from "../../src/v2/core/status.ts";
+
+const FIXTURE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "v2");
+
+function loadFixture(name) {
+  const raw = JSON.parse(readFileSync(join(FIXTURE_DIR, name), "utf8"));
+  return { status: normalizeStatus(raw.status), events: raw.events ?? [] };
+}
+
+function deepFreeze(value) {
+  if (value && typeof value === "object") {
+    Object.values(value).forEach(deepFreeze);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+test("cockpit model is pure: frozen input does not throw and is not mutated", () => {
+  const { status, events } = loadFixture("running-one-card.json");
+  const snapshot = JSON.parse(JSON.stringify(status));
+  deepFreeze(status);
+  deepFreeze(events);
+  const model = createCockpitModel({ status, events, selectedId: "card_426" });
+  assert.ok(model.header);
+  // input unchanged
+  assert.deepEqual(JSON.parse(JSON.stringify(status)), snapshot);
+});
+
+test("ready fixture renders factory open with no active runs", () => {
+  const { status, events } = loadFixture("ready.json");
+  const model = createCockpitModel({ status, events });
+  assert.equal(model.factoryState, "open");
+  assert.equal(model.header.counts.running, 0);
+  assert.equal(model.panels.activeRuns.length, 0);
+});
+
+test("running fixture surfaces a machine in motion", () => {
+  const { status, events } = loadFixture("running-one-card.json");
+  const model = createCockpitModel({ status, events });
+  assert.equal(model.factoryState, "running");
+  assert.equal(model.header.counts.running, 1);
+  const run = model.panels.activeRuns.find((r) => r.id === "run_426");
+  assert.equal(run.themeLabel, "Machine in motion");
+});
+
+test("blocked-runner fixture surfaces blocked factory and disabled route", () => {
+  const { status } = loadFixture("blocked-runner.json");
+  const model = createCockpitModel({ status });
+  assert.equal(model.factoryState, "blocked");
+  const lane = model.lanes.find((l) => l.routeId === "route_ready");
+  assert.equal(lane.enabled, false);
+  assert.equal(lane.disabledReason, "Runner unavailable");
+});
+
+test("locked factory when dispatch paused", () => {
+  const { status } = loadFixture("commands-disabled.json");
+  const model = createCockpitModel({ status });
+  assert.equal(model.factoryState, "locked");
+});
+
+test("dirty worktree is surfaced as a hazard with raw truth", () => {
+  const { status } = loadFixture("dirty-worktree.json");
+  const model = createCockpitModel({ status, selectedId: "ws_426" });
+  const wt = model.panels.worktrees.find((w) => w.workspaceKey === "ws_426");
+  assert.equal(wt.dirty, true);
+  assert.equal(wt.themeLabel, "Spill / hazard");
+  assert.equal(model.selected.kind, "worktree");
+  assert.equal(model.selected.raw.workspacePath, "/work/repo/.fizzy-symphony/worktrees/card-426");
+  assert.deepEqual(model.selected.raw.dirtyPaths, ["src/terminal-renderer.js", ".fizzy-symphony/notes.md"]);
+});
+
+test("failed run is surfaced with error in active runs panel", () => {
+  const { status } = loadFixture("failed-run.json");
+  const model = createCockpitModel({ status });
+  const failed = model.panels.activeRuns.find((r) => r.state === "failed");
+  assert.ok(failed);
+  assert.equal(failed.error.code, "RUNNER_ERROR");
+});
+
+test("selecting a card exposes raw ids in the detail panel", () => {
+  const { status } = loadFixture("running-one-card.json");
+  const model = createCockpitModel({ status, selectedId: "card_426" });
+  assert.equal(model.selected.kind, "card");
+  assert.equal(model.selected.raw.cardId, "card_426");
+  assert.equal(model.selected.raw.runId, "run_426");
+  assert.equal(model.selected.raw.sessionId, "session_9");
+  assert.equal(model.selected.raw.boardId, "board_42");
+});
+
+test("actions reflect enabled/disabled with reasons", () => {
+  const { status } = loadFixture("ready.json");
+  const model = createCockpitModel({ status });
+  const cancel = model.actions.find((a) => a.id === "run.cancel");
+  assert.equal(cancel.enabled, false);
+  assert.equal(cancel.disabledReason, "No run selected");
+
+  const running = loadFixture("running-one-card.json");
+  const runModel = createCockpitModel({ status: running.status, selectedId: "run_426" });
+  const cancelEnabled = runModel.actions.find((a) => a.id === "run.cancel");
+  assert.equal(cancelEnabled.enabled, true);
+  assert.equal(cancelEnabled.commandType, "run.cancel");
+});
+
+test("filter narrows lane cards without mutating status", () => {
+  const { status } = loadFixture("running-multiple-cards.json");
+  const before = status.cards.length;
+  const model = createCockpitModel({ status, filter: "cockpit help" });
+  const allCards = model.lanes.flatMap((l) => l.cards);
+  assert.ok(allCards.every((c) => c.title.toLowerCase().includes("cockpit help") || c.id.includes("cockpit")));
+  assert.equal(status.cards.length, before);
+});
+
+test("help is generated from capabilities, not hardcoded", () => {
+  const { status } = loadFixture("ready.json");
+  const model = createCockpitModel({ status });
+  assert.ok(model.help.capabilities.length > 0);
+  assert.ok(model.help.keys.some((k) => k.key === "?"));
+});

--- a/test/v2/commands.test.js
+++ b/test/v2/commands.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { validateCommand, checkCommandAvailability } from "../../src/v2/core/commands.ts";
+import { normalizeStatus } from "../../src/v2/core/status.ts";
+import { createRuntime } from "../../src/v2/daemon/runtime.ts";
+
+test("validateCommand rejects non-objects and unknown types", () => {
+  assert.equal(validateCommand(null).ok, false);
+  assert.equal(validateCommand("x").ok, false);
+  assert.equal(validateCommand({ type: "nope" }).code, "UNKNOWN_COMMAND");
+});
+
+test("validateCommand requires runId and reason for run.cancel", () => {
+  assert.equal(validateCommand({ type: "run.cancel" }).code, "MISSING_FIELD");
+  assert.equal(validateCommand({ type: "run.cancel", runId: "r" }).code, "MISSING_REASON");
+  assert.equal(validateCommand({ type: "run.cancel", runId: "r", reason: "x" }).ok, true);
+});
+
+test("validateCommand accepts dispatch pause/resume without extra fields", () => {
+  assert.equal(validateCommand({ type: "dispatch.pause" }).ok, true);
+  assert.equal(validateCommand({ type: "dispatch.resume" }).ok, true);
+});
+
+test("checkCommandAvailability gates cancel on an active run", () => {
+  const status = normalizeStatus({
+    runs: { running: [{ id: "run_1", state: "running", sessionId: "s_1" }] }
+  });
+  assert.equal(checkCommandAvailability({ type: "run.cancel", runId: "run_1", reason: "x" }, status).available, true);
+  const miss = checkCommandAvailability({ type: "run.cancel", runId: "nope", reason: "x" }, status);
+  assert.equal(miss.available, false);
+  assert.equal(miss.code, "NO_ACTIVE_RUN");
+});
+
+test("runtime submitCommand dry-runs and writes an audit event", () => {
+  const status = {
+    readiness: { state: "ready", ready: true, runnerStatus: "ready" },
+    runs: { running: [{ id: "run_1", state: "running", sessionId: "s_1", cardId: "card_1" }] },
+    cards: [{ id: "card_1", title: "c", boardId: "b", state: "running", golden: false }]
+  };
+  const runtime = createRuntime({ status });
+  const result = runtime.submitCommand({ type: "run.cancel", runId: "run_1", reason: "operator" });
+  assert.equal(result.outcome, "dry-run");
+  assert.equal(result.commandType, "run.cancel");
+  assert.ok(result.event);
+  const events = runtime.getEvents(10);
+  assert.ok(events.some((e) => e.type === "command.dry-run.run.cancel"));
+});
+
+test("runtime submitCommand reports unavailable without an audit accept", () => {
+  const runtime = createRuntime({ status: { readiness: { state: "ready", ready: true } } });
+  const result = runtime.submitCommand({ type: "run.cancel", runId: "missing", reason: "x" });
+  assert.equal(result.outcome, "unavailable");
+  assert.equal(result.code, "NO_ACTIVE_RUN");
+});
+
+test("runtime submitCommand rejects malformed commands", () => {
+  const runtime = createRuntime({ status: {} });
+  const result = runtime.submitCommand({ type: "run.cancel" });
+  assert.equal(result.outcome, "rejected");
+});
+
+test("runtime applyCommands mode emits accepted (not dry-run) audit event", () => {
+  const runtime = createRuntime({
+    status: { readiness: { state: "ready", ready: true, dispatchPaused: false } },
+    applyCommands: true
+  });
+  const result = runtime.submitCommand({ type: "dispatch.pause", reason: "maintenance" });
+  assert.equal(result.outcome, "accepted");
+});

--- a/test/v2/fixtures-render.test.js
+++ b/test/v2/fixtures-render.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { createCockpitModel } from "../../src/v2/cockpit/model.ts";
+import { renderCockpitText } from "../../src/v2/cockpit/renderer.ts";
+import { normalizeStatus } from "../../src/v2/core/status.ts";
+
+const FIXTURE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "v2");
+const fixtures = readdirSync(FIXTURE_DIR).filter((f) => f.endsWith(".json"));
+
+test("every fixture loads, normalizes, and renders without throwing", () => {
+  assert.ok(fixtures.length >= 11, `expected >= 11 fixtures, found ${fixtures.length}`);
+  for (const name of fixtures) {
+    const raw = JSON.parse(readFileSync(join(FIXTURE_DIR, name), "utf8"));
+    const status = normalizeStatus(raw.status);
+    const model = createCockpitModel({ status, events: raw.events ?? [] });
+    const text = renderCockpitText(model);
+    assert.match(text, /FIZZY-SYMPHONY COCKPIT/, `fixture ${name} should render header`);
+    assert.match(text, /ACTIONS/, `fixture ${name} should render actions`);
+  }
+});
+
+test("hazard states are visually obvious in rendered text", () => {
+  const dirty = JSON.parse(readFileSync(join(FIXTURE_DIR, "dirty-worktree.json"), "utf8"));
+  const dirtyModel = createCockpitModel({ status: normalizeStatus(dirty.status) });
+  assert.match(renderCockpitText(dirtyModel), /Spill \/ hazard/);
+
+  const failed = JSON.parse(readFileSync(join(FIXTURE_DIR, "failed-run.json"), "utf8"));
+  const failedModel = createCockpitModel({ status: normalizeStatus(failed.status) });
+  assert.match(renderCockpitText(failedModel), /Jammed machine|RUNNER_ERROR/);
+
+  const blocked = JSON.parse(readFileSync(join(FIXTURE_DIR, "blocked-runner.json"), "utf8"));
+  const blockedModel = createCockpitModel({ status: normalizeStatus(blocked.status) });
+  assert.match(renderCockpitText(blockedModel), /Factory cannot close/);
+});

--- a/test/v2/interactive.test.js
+++ b/test/v2/interactive.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { startInteractiveCockpit } from "../../src/v2/cockpit/interactive.ts";
+import { createRuntime } from "../../src/v2/daemon/runtime.ts";
+
+const FIXTURE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "v2");
+
+function loadRuntime(name) {
+  const raw = JSON.parse(readFileSync(join(FIXTURE_DIR, name), "utf8"));
+  return createRuntime({ status: raw.status, events: raw.events ?? [] });
+}
+
+function fakeTerminal() {
+  const frames = [];
+  const term = (text) => frames.push(text);
+  term.frames = frames;
+  term.fullscreen = () => {};
+  term.clear = () => {};
+  term.moveTo = () => {};
+  term.hideCursor = () => {};
+  term.grabInput = () => {};
+  term.on = () => {};
+  term.off = () => {};
+  return term;
+}
+
+test("interactive cockpit submits a typed command via keypress (dry-run)", async () => {
+  const runtime = loadRuntime("running-one-card.json");
+  const term = fakeTerminal();
+  const session = await startInteractiveCockpit({ runtime, terminalFactory: async () => term });
+
+  // selectable order: card_golden, card_426, run_426, ws_426. Move to card_426.
+  session.handleKey("DOWN");
+  const model = session.currentModel();
+  assert.equal(model.selected.raw.runId, "run_426");
+
+  session.handleKey("c"); // run.cancel
+  const lastFrame = term.frames.at(-1);
+  assert.match(lastFrame, /DRY-RUN/);
+
+  const events = runtime.getEvents(10);
+  assert.ok(events.some((e) => e.type === "command.dry-run.run.cancel"));
+
+  session.handleKey("q");
+  await session.done;
+});
+
+test("interactive cockpit shows a disabled reason when action unavailable", async () => {
+  const runtime = loadRuntime("ready.json");
+  const term = fakeTerminal();
+  const session = await startInteractiveCockpit({ runtime, terminalFactory: async () => term });
+  session.handleKey("c"); // no run selected
+  assert.match(term.frames.at(-1), /disabled/i);
+  session.handleKey("q");
+  await session.done;
+});
+
+test("interactive cockpit quits on ESCAPE", async () => {
+  const runtime = loadRuntime("ready.json");
+  const term = fakeTerminal();
+  const session = await startInteractiveCockpit({ runtime, terminalFactory: async () => term });
+  session.handleKey("ESCAPE");
+  await session.done; // resolves
+  assert.ok(true);
+});

--- a/test/v2/ports.test.js
+++ b/test/v2/ports.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createFakeFizzyPort } from "../../src/v2/fizzy/fake.ts";
+import { createFizzyAdapter } from "../../src/v2/fizzy/adapter.ts";
+import { createFakeCodexRunner } from "../../src/v2/codex/fake.ts";
+import { createCodexAdapter } from "../../src/v2/codex/adapter.ts";
+
+test("fake FizzyPort serves seeded boards and cards", async () => {
+  const port = createFakeFizzyPort({
+    boards: [{ id: "b1", name: "Agents" }],
+    cards: [{ id: "c1", number: 1, title: "Golden", boardId: "b1", columnId: "ready", golden: true }]
+  });
+  assert.equal(port.describe().sdk, false);
+  assert.equal((await port.listBoards()).length, 1);
+  assert.equal((await port.listCards({ boardId: "b1" })).length, 1);
+  const comment = await port.createComment({ cardId: "c1", body: "claim" });
+  assert.equal(comment.cardId, "c1");
+  const moved = await port.moveCard({ cardId: "c1", targetColumnId: "done" });
+  assert.equal(moved.columnId, "done");
+});
+
+test("Fizzy adapter advertises its boundary and refuses to silently fake ops", async () => {
+  const sdk = createFizzyAdapter({ mode: "sdk" });
+  assert.equal(sdk.describe().sdk, true);
+  await assert.rejects(() => sdk.listBoards(), /not wired/);
+
+  const http = createFizzyAdapter({ mode: "http" });
+  assert.equal(http.describe().sdk, false);
+});
+
+test("fake Codex runner streams a completed turn", async () => {
+  const runner = createFakeCodexRunner();
+  assert.equal((await runner.detect()).available, true);
+  assert.equal((await runner.health()).status, "ready");
+  const session = await runner.startSession({ workspacePath: "/ws" });
+  const turn = await runner.startTurn({ session, prompt: "do" });
+  const events = [];
+  const result = await runner.streamTurn({ turn }, (e) => events.push(e));
+  assert.equal(result.status, "completed");
+  assert.ok(events.some((e) => e.type === "turn.completed"));
+});
+
+test("fake Codex runner can simulate failure and cancellation", async () => {
+  const failing = createFakeCodexRunner({ mode: "failed" });
+  const session = await failing.startSession({ workspacePath: "/ws" });
+  const turn = await failing.startTurn({ session, prompt: "do" });
+  const result = await failing.streamTurn({ turn }, () => {});
+  assert.equal(result.status, "failed");
+  assert.equal(result.error.code, "RUNNER_ERROR");
+
+  const cancel = await failing.cancelTurn({ turn, reason: "operator" });
+  assert.equal(cancel.status, "cancelled");
+});
+
+test("Codex adapter is SDK-shaped and reports not-wired health", async () => {
+  const sdk = createCodexAdapter({ mode: "sdk" });
+  assert.equal(sdk.describe().sdk, true);
+  assert.equal(sdk.describe().contract, "codex-runner-sdk-v1");
+  const health = await sdk.health();
+  assert.equal(health.failureCode, "ADAPTER_NOT_WIRED");
+  await assert.rejects(() => sdk.startSession({ workspacePath: "/ws" }), /not wired/);
+});

--- a/test/v2/status-model.test.js
+++ b/test/v2/status-model.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  normalizeStatus,
+  deriveFactoryState,
+  countDirtyWorktrees,
+  countPreservedWorktrees
+} from "../../src/v2/core/status.ts";
+import { STATUS_SCHEMA_VERSION } from "../../src/v2/core/types.ts";
+
+test("normalizeStatus stamps the v2 schema and fills empty collections", () => {
+  const status = normalizeStatus({});
+  assert.equal(status.schemaVersion, STATUS_SCHEMA_VERSION);
+  assert.equal(status.instance.id, "unknown");
+  assert.deepEqual(status.runs.running, []);
+  assert.deepEqual(status.runs.queued, []);
+  assert.deepEqual(status.boards, []);
+  assert.deepEqual(status.warnings, []);
+  assert.equal(status.doctor.goalClosable, true);
+});
+
+test("normalizeStatus does not mutate its input", () => {
+  const input = { instance: { id: "x" }, runs: { running: [{ id: "r" }] } };
+  const frozen = JSON.parse(JSON.stringify(input));
+  normalizeStatus(input);
+  assert.deepEqual(input, frozen);
+});
+
+test("normalizeStatus infers readiness state from blockers", () => {
+  const status = normalizeStatus({ readiness: { blockers: [{ code: "X", message: "m" }] } });
+  assert.equal(status.readiness.state, "blocked");
+  assert.equal(status.readiness.ready, false);
+});
+
+test("deriveFactoryState maps readiness + activity to themed state", () => {
+  assert.equal(deriveFactoryState(normalizeStatus({})), "unknown");
+  assert.equal(
+    deriveFactoryState(normalizeStatus({ readiness: { state: "ready", ready: true } })),
+    "open"
+  );
+  assert.equal(
+    deriveFactoryState(
+      normalizeStatus({ readiness: { state: "ready", ready: true }, runs: { running: [{ id: "r", state: "running" }] } })
+    ),
+    "running"
+  );
+  assert.equal(
+    deriveFactoryState(normalizeStatus({ readiness: { state: "blocked", ready: false, blockers: [{ code: "B", message: "m" }] } })),
+    "blocked"
+  );
+  assert.equal(
+    deriveFactoryState(normalizeStatus({ readiness: { state: "ready", ready: true, dispatchPaused: true } })),
+    "locked"
+  );
+});
+
+test("worktree counters", () => {
+  const status = normalizeStatus({
+    worktrees: [
+      { workspaceKey: "a", path: "/a", dirty: true, preserved: true },
+      { workspaceKey: "b", path: "/b", dirty: false, preserved: true },
+      { workspaceKey: "c", path: "/c", dirty: false, preserved: false }
+    ]
+  });
+  assert.equal(countDirtyWorktrees(status), 1);
+  assert.equal(countPreservedWorktrees(status), 2);
+});


### PR DESCRIPTION
## Summary

A local, spec-driven operator cockpit for running Codex agents from Fizzy boards, added as an **additive spike under `src/v2/`** — no v1 code deleted.

- **TypeScript core** run via Node 26 native type stripping (no build pipeline; `.ts` imported directly, tests stay `.js`)
- **`SymphonyStatus` v2 schema** (`fizzy-symphony-status-v2`) + pure `normalizeStatus` / `deriveFactoryState` helpers (no mutation, no IO)
- **Ports** — `FizzyPort` (independent of `@37signals/fizzy`) and `CodexRunnerPort` (SDK-compatible lifecycle), each with a deterministic fake and a not-wired adapter boundary (`FIZZY_ADAPTER_NOT_WIRED` / `CODEX_ADAPTER_NOT_WIRED`)
- **Pure cockpit model** + Terminal Kit interactive renderer (lazily imported) + non-TTY text frame / `--once` / `--json`
- **Validated, dry-run-by-default command pipeline** through a single choke point (`runtime.submitCommand`) — no fake controls
- **14-capability catalogue** with honest enable/disable reasons
- **Local `/v2` API skeleton** (`status / ready / capabilities / events / runs / worktrees / commands`)
- **CLI** — `fizzy-symphony cockpit` and `fizzy-symphony capabilities`

## Tests

- Full suite green: **428 passing, 0 failing** (429 incl. 1 live-gated skip)
- 11 fixtures + 9 fixture-first test files under `test/v2/`
- `package.json` test script extended to run `test/v2/*.test.js`

## Docs

- `docs/v2/decision.md` — assumptions (TS via type-stripping, `src/v2/` layout, dry-run commands, adapter boundaries, default fixture)
- `docs/v2/migration-inventory.md` — v1→v2 feature map with keep/defer/drop disposition
- `docs/v2/cockpit-contract.md` — status, model, command, capability, API, and port contracts

## Scope notes

- All mutating operations (run cancel, session stop, card rerun/move, worktree preserve/cleanup) and live integrations (Fizzy SDK/HTTP, Codex SDK/CLI) are **deferred** — honest contract surfaces, validated + dry-run only, not wired.
- Reversible: deleting `src/v2/`, `test/v2/`, `test/fixtures/v2/`, `docs/v2/` and reverting the two additive edits (`bin/fizzy-symphony.js`, `package.json`) removes v2 with zero impact on v1.