### PR TITLE
feat(v2): apply operator commands to the runtime status model

### DIFF
--- a/docs/v2/cockpit-contract.md
+++ b/docs/v2/cockpit-contract.md
@@ -99,9 +99,13 @@ worktree.cleanup { workspaceKey, reason }
    current status. Codes: `NO_ACTIVE_RUN`, `NO_ACTIVE_SESSION`, `ALREADY_PAUSED`,
    `NOT_PAUSED`, `UNKNOWN_CARD`, `CARD_RUNNING`, `UNKNOWN_WORKTREE`.
    Failure → `outcome: "unavailable"`.
-3. **Apply.** If `applyCommands` is `false` (spike default), the command is
+3. **Apply.** If `applyCommands` is `false` (default), the command is
    recorded as a `command.dry-run.<type>` event and returns `outcome: "dry-run"`.
-   If `true`, it emits `command.accepted.<type>` and returns `outcome: "accepted"`.
+   If `true` (CLI `--apply`), the command is run through the pure reducer
+   `applyCommandToStatus` (`src/v2/daemon/apply-command.ts`), which mutates the
+   in-memory `SymphonyStatus` (pause/resume, run cancel, session stop, card
+   rerun/move, worktree preserve/cleanup); capabilities re-derive from the new
+   state. It emits `command.accepted.<type>` and returns `outcome: "accepted"`.
 
 `CommandResult.outcome` ∈ `accepted | rejected | unavailable | dry-run`.
 

--- a/docs/v2/decision.md
+++ b/docs/v2/decision.md
@@ -43,9 +43,17 @@
 ## 4. Commands are dry-run by default
 
 - **Decision:** `createRuntime` accepts `applyCommands` (default **`false`**).
-  In the spike, every operator command is **validated**, **availability-checked**,
+  With the default, every operator command is **validated**, **availability-checked**,
   and then **recorded as a dry-run event** (`command.dry-run.<type>`) with outcome
-  `"dry-run"`. No real side effect is performed.
+  `"dry-run"`. No state changes.
+- **With `applyCommands: true`** (CLI `--apply`), the same validated command is run
+  through the pure reducer `applyCommandToStatus`
+  ([src/v2/daemon/apply-command.ts](../../src/v2/daemon/apply-command.ts)), which
+  mutates the **in-memory `SymphonyStatus` model** (pause/resume, run cancel,
+  session stop, card rerun/move, worktree preserve/cleanup) and emits a
+  `command.accepted.<type>` event. Capabilities re-derive from the new state.
+  *Live* FizzyPort / CodexRunnerPort side-effects remain deferred — the reducer is
+  the deterministic model layer those adapters will sit beneath.
 - **Why:** The brief forbids fake controls. A button that *pretends* to cancel a
   run is a fake control. A button that honestly reports "validated, would dispatch
   `run.cancel run_426` — not wired in spike" is not. Dry-run is the honest middle:

--- a/src/v2/cli/cockpit.ts
+++ b/src/v2/cli/cockpit.ts
@@ -74,15 +74,26 @@ async function loadEndpointBundle(endpoint: string, io: CockpitIo): Promise<Fixt
 async function buildRuntime(args: string[], io: CockpitIo): Promise<{ runtime: SymphonyRuntime; source: string }> {
   const endpoint = optionValue(args, "--endpoint");
   const fixture = optionValue(args, "--fixture");
+  // --apply makes operator commands mutate the in-memory status model instead
+  // of being recorded as dry-runs. Off by default to keep the cockpit read-only.
+  const applyCommands = hasFlag(args, "--apply");
   if (endpoint) {
     const bundle = await loadEndpointBundle(endpoint, io);
-    return { runtime: createRuntime({ status: bundle.status, events: bundle.events }), source: `endpoint ${endpoint}` };
+    return {
+      runtime: createRuntime({ status: bundle.status, events: bundle.events, applyCommands }),
+      source: `endpoint ${endpoint}`
+    };
   }
   const fixturePath = fixture ?? DEFAULT_FIXTURE;
   const bundle = await loadFixtureBundle(fixturePath);
   return {
-    runtime: createRuntime({ status: bundle.status, events: bundle.events, capabilities: bundle.capabilities }),
-    source: `fixture ${fixturePath}`
+    runtime: createRuntime({
+      status: bundle.status,
+      events: bundle.events,
+      capabilities: bundle.capabilities,
+      applyCommands
+    }),
+    source: `fixture ${fixturePath}${applyCommands ? " [apply]" : ""}`
   };
 }
 

--- a/src/v2/daemon/apply-command.ts
+++ b/src/v2/daemon/apply-command.ts
@@ -1,0 +1,146 @@
+// Command reducer: applies a validated OperatorCommand to a SymphonyStatus.
+//
+// Pure: it never mutates its input and never performs IO. Given a status and a
+// command that has already passed validateCommand + checkCommandAvailability,
+// it returns the next status plus a human-readable summary for the audit event.
+// This is the deterministic, in-memory model of "what the command does"; live
+// FizzyPort / CodexRunnerPort side-effects (deferred) would be layered on top.
+
+import type {
+  CardRuntimeStatus,
+  OperatorCommand,
+  ReadinessStatus,
+  RunBuckets,
+  RunStatus,
+  SymphonyStatus,
+  WorktreeStatus
+} from "../core/types.ts";
+
+export interface ApplyResult {
+  status: SymphonyStatus;
+  summary: string;
+}
+
+function recomputeReadiness(readiness: ReadinessStatus): ReadinessStatus {
+  const dispatchPaused = readiness.dispatchPaused === true;
+  let state = readiness.state;
+  if (dispatchPaused) {
+    state = "locked";
+  } else if (readiness.blockers.length > 0) {
+    state = "blocked";
+  } else if (readiness.ready) {
+    state = "ready";
+  } else {
+    state = "unknown";
+  }
+  return { ...readiness, dispatchPaused, state };
+}
+
+function cloneRuns(runs: RunBuckets): RunBuckets {
+  return {
+    queued: [...runs.queued],
+    running: [...runs.running],
+    completed: [...runs.completed],
+    failed: [...runs.failed],
+    cancelled: [...runs.cancelled],
+    preempted: [...runs.preempted]
+  };
+}
+
+function cancelRun(run: RunStatus, at: string): RunStatus {
+  return { ...run, state: "cancelled", updatedAt: at, stalled: false, error: undefined, recommendedAction: undefined };
+}
+
+function clearCardForCancel(card: CardRuntimeStatus): CardRuntimeStatus {
+  return { ...card, state: "cancelled", runId: undefined };
+}
+
+export function applyCommandToStatus(
+  status: SymphonyStatus,
+  command: OperatorCommand,
+  at: string
+): ApplyResult {
+  switch (command.type) {
+    case "dispatch.pause": {
+      const readiness = recomputeReadiness({ ...status.readiness, dispatchPaused: true });
+      return { status: { ...status, readiness, lastUpdatedAt: at }, summary: "Dispatch paused (factory locked)." };
+    }
+    case "dispatch.resume": {
+      const readiness = recomputeReadiness({ ...status.readiness, dispatchPaused: false });
+      return { status: { ...status, readiness, lastUpdatedAt: at }, summary: "Dispatch resumed (factory unlocked)." };
+    }
+    case "run.cancel": {
+      const runs = cloneRuns(status.runs);
+      const run = runs.running.find((entry) => entry.id === command.runId);
+      if (!run) {
+        return { status: { ...status, lastUpdatedAt: at }, summary: `Run ${command.runId} was not running.` };
+      }
+      runs.running = runs.running.filter((entry) => entry.id !== command.runId);
+      runs.cancelled = [...runs.cancelled, cancelRun(run, at)];
+      const cards = status.cards.map((card) =>
+        card.runId === run.id || card.id === run.cardId ? clearCardForCancel(card) : card
+      );
+      return {
+        status: { ...status, runs, cards, lastUpdatedAt: at },
+        summary: `Cancelled run ${command.runId}.`
+      };
+    }
+    case "session.stop": {
+      const runs = cloneRuns(status.runs);
+      const stopped = runs.running.filter((entry) => entry.sessionId === command.sessionId);
+      if (stopped.length === 0) {
+        return { status: { ...status, lastUpdatedAt: at }, summary: `No running runs for session ${command.sessionId}.` };
+      }
+      const stoppedIds = new Set(stopped.map((entry) => entry.id));
+      const stoppedCardIds = new Set(stopped.map((entry) => entry.cardId));
+      runs.running = runs.running.filter((entry) => !stoppedIds.has(entry.id));
+      runs.cancelled = [...runs.cancelled, ...stopped.map((entry) => cancelRun(entry, at))];
+      const cards = status.cards.map((card) =>
+        (card.runId && stoppedIds.has(card.runId)) || stoppedCardIds.has(card.id) ? clearCardForCancel(card) : card
+      );
+      return {
+        status: { ...status, runs, cards, lastUpdatedAt: at },
+        summary: `Stopped session ${command.sessionId} (${stopped.length} run${stopped.length === 1 ? "" : "s"}).`
+      };
+    }
+    case "card.rerun": {
+      const cards = status.cards.map((card) =>
+        card.id === command.cardId ? { ...card, state: "queued" as const, runId: undefined } : card
+      );
+      return { status: { ...status, cards, lastUpdatedAt: at }, summary: `Queued rerun of card ${command.cardId}.` };
+    }
+    case "card.move": {
+      const cards = status.cards.map((card) =>
+        card.id === command.cardId
+          ? { ...card, columnId: command.targetColumnId, columnName: undefined }
+          : card
+      );
+      return {
+        status: { ...status, cards, lastUpdatedAt: at },
+        summary: `Moved card ${command.cardId} to column ${command.targetColumnId}.`
+      };
+    }
+    case "worktree.preserve": {
+      const worktrees: WorktreeStatus[] = status.worktrees.map((worktree) =>
+        worktree.workspaceKey === command.workspaceKey ? { ...worktree, preserved: true } : worktree
+      );
+      return {
+        status: { ...status, worktrees, lastUpdatedAt: at },
+        summary: `Preserved worktree ${command.workspaceKey}.`
+      };
+    }
+    case "worktree.cleanup": {
+      const worktrees: WorktreeStatus[] = status.worktrees.map((worktree) =>
+        worktree.workspaceKey === command.workspaceKey
+          ? { ...worktree, dirty: false, preserved: false, dirtyPaths: [], lastError: undefined, recommendedAction: undefined }
+          : worktree
+      );
+      return {
+        status: { ...status, worktrees, lastUpdatedAt: at },
+        summary: `Cleaned up worktree ${command.workspaceKey}.`
+      };
+    }
+    default:
+      return { status, summary: "No-op." };
+  }
+}

--- a/src/v2/daemon/runtime.ts
+++ b/src/v2/daemon/runtime.ts
@@ -15,6 +15,7 @@ import {
 } from "../core/commands.ts";
 import { createEventLog } from "../core/events.ts";
 import { normalizeStatus } from "../core/status.ts";
+import { applyCommandToStatus } from "./apply-command.ts";
 import type { EventLog } from "../core/events.ts";
 import type {
   Capability,
@@ -49,7 +50,8 @@ export interface SymphonyRuntime {
 
 export function createRuntime(options: RuntimeOptions): SymphonyRuntime {
   const applyCommands = options.applyCommands ?? false;
-  const status = normalizeStatus(options.status);
+  const now = options.now ?? (() => new Date());
+  let status = normalizeStatus(options.status);
   const eventLog: EventLog = createEventLog({ now: options.now });
   for (const event of options.events ?? status.recentEvents ?? []) {
     eventLog.append({
@@ -66,10 +68,12 @@ export function createRuntime(options: RuntimeOptions): SymphonyRuntime {
     });
   }
 
-  const capabilities =
-    options.capabilities && options.capabilities.length > 0
-      ? options.capabilities
-      : deriveCapabilities(status);
+  const explicitCapabilities =
+    options.capabilities && options.capabilities.length > 0 ? options.capabilities : null;
+
+  function currentCapabilities(): Capability[] {
+    return explicitCapabilities ?? deriveCapabilities(status);
+  }
 
   function allRuns() {
     return [
@@ -115,22 +119,29 @@ export function createRuntime(options: RuntimeOptions): SymphonyRuntime {
       };
     }
 
-    // Production wiring would dispatch to FizzyPort / CodexRunnerPort here.
+    // Apply the command to the in-memory status model. Live FizzyPort /
+    // CodexRunnerPort side-effects (deferred) would be layered on top of this.
+    const applied = applyCommandToStatus(status, command, now().toISOString());
+    status = applied.status;
     const event = eventLog.append({
       type: `command.accepted.${command.type}`,
       severity: "info",
-      message: `Accepted command ${command.type}`,
+      message: applied.summary,
+      runId: "runId" in command ? command.runId : undefined,
+      sessionId: "sessionId" in command ? command.sessionId : undefined,
+      cardId: "cardId" in command ? command.cardId : undefined,
+      workspacePath: "workspaceKey" in command ? command.workspaceKey : undefined,
       data: command
     });
-    return { outcome: "accepted", commandType: command.type, message: `Command ${command.type} accepted.`, event };
+    return { outcome: "accepted", commandType: command.type, message: applied.summary, event };
   }
 
   return {
     getStatus() {
-      return { ...status, recentEvents: eventLog.recent(20), capabilities };
+      return { ...status, recentEvents: eventLog.recent(20), capabilities: currentCapabilities() };
     },
     getCapabilities() {
-      return capabilities.map((capability) => ({ ...capability }));
+      return currentCapabilities().map((capability) => ({ ...capability }));
     },
     getEvents(count = 20) {
       return eventLog.recent(count);

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -35,6 +35,7 @@ export { createCodexAdapter } from "./codex/adapter.ts";
 
 export { createRuntime } from "./daemon/runtime.ts";
 export type { SymphonyRuntime } from "./daemon/runtime.ts";
+export { applyCommandToStatus } from "./daemon/apply-command.ts";
 export {
   handleApiRequest,
   createApiServer

--- a/test/v2/commands.test.js
+++ b/test/v2/commands.test.js
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import { validateCommand, checkCommandAvailability } from "../../src/v2/core/commands.ts";
 import { normalizeStatus } from "../../src/v2/core/status.ts";
 import { createRuntime } from "../../src/v2/daemon/runtime.ts";
+import { applyCommandToStatus } from "../../src/v2/daemon/apply-command.ts";
 
 test("validateCommand rejects non-objects and unknown types", () => {
   assert.equal(validateCommand(null).ok, false);
@@ -67,4 +68,140 @@ test("runtime applyCommands mode emits accepted (not dry-run) audit event", () =
   });
   const result = runtime.submitCommand({ type: "dispatch.pause", reason: "maintenance" });
   assert.equal(result.outcome, "accepted");
+});
+
+test("applyCommands: dispatch.pause locks the factory and resume unlocks it", () => {
+  const runtime = createRuntime({
+    status: { readiness: { state: "ready", ready: true, dispatchPaused: false } },
+    applyCommands: true
+  });
+  runtime.submitCommand({ type: "dispatch.pause", reason: "maintenance" });
+  let status = runtime.getStatus();
+  assert.equal(status.readiness.dispatchPaused, true);
+  assert.equal(status.readiness.state, "locked");
+
+  runtime.submitCommand({ type: "dispatch.resume", reason: "back" });
+  status = runtime.getStatus();
+  assert.equal(status.readiness.dispatchPaused, false);
+  assert.equal(status.readiness.state, "ready");
+});
+
+test("applyCommands: run.cancel moves the run to cancelled and clears the card", () => {
+  const runtime = createRuntime({
+    status: {
+      readiness: { state: "ready", ready: true, runnerStatus: "ready" },
+      runs: { running: [{ id: "run_1", state: "running", sessionId: "s_1", cardId: "card_1" }] },
+      cards: [{ id: "card_1", title: "c", boardId: "b", state: "running", golden: false, runId: "run_1" }]
+    },
+    applyCommands: true
+  });
+  const result = runtime.submitCommand({ type: "run.cancel", runId: "run_1", reason: "operator" });
+  assert.equal(result.outcome, "accepted");
+  const status = runtime.getStatus();
+  assert.equal(status.runs.running.length, 0);
+  assert.equal(status.runs.cancelled.length, 1);
+  assert.equal(status.runs.cancelled[0].id, "run_1");
+  assert.equal(status.runs.cancelled[0].state, "cancelled");
+  assert.equal(status.cards[0].state, "cancelled");
+  assert.equal(status.cards[0].runId, undefined);
+});
+
+test("applyCommands: session.stop cancels every run on the session", () => {
+  const runtime = createRuntime({
+    status: {
+      readiness: { state: "ready", ready: true },
+      runs: {
+        running: [
+          { id: "run_1", state: "running", sessionId: "s_1", cardId: "card_1" },
+          { id: "run_2", state: "running", sessionId: "s_1", cardId: "card_2" }
+        ]
+      },
+      cards: [
+        { id: "card_1", title: "a", boardId: "b", state: "running", golden: false, runId: "run_1" },
+        { id: "card_2", title: "b", boardId: "b", state: "running", golden: false, runId: "run_2" }
+      ]
+    },
+    applyCommands: true
+  });
+  runtime.submitCommand({ type: "session.stop", sessionId: "s_1", reason: "operator" });
+  const status = runtime.getStatus();
+  assert.equal(status.runs.running.length, 0);
+  assert.equal(status.runs.cancelled.length, 2);
+  assert.ok(status.cards.every((card) => card.state === "cancelled"));
+});
+
+test("applyCommands: card.rerun queues the card", () => {
+  const runtime = createRuntime({
+    status: {
+      readiness: { state: "ready", ready: true },
+      cards: [{ id: "card_1", title: "c", boardId: "b", state: "failed", golden: false }]
+    },
+    applyCommands: true
+  });
+  runtime.submitCommand({ type: "card.rerun", cardId: "card_1", reason: "retry" });
+  assert.equal(runtime.getStatus().cards[0].state, "queued");
+});
+
+test("applyCommands: card.move changes the column", () => {
+  const runtime = createRuntime({
+    status: {
+      readiness: { state: "ready", ready: true },
+      cards: [{ id: "card_1", title: "c", boardId: "b", state: "idle", golden: false, columnId: "ready" }]
+    },
+    applyCommands: true
+  });
+  runtime.submitCommand({ type: "card.move", cardId: "card_1", targetColumnId: "done", reason: "ship" });
+  assert.equal(runtime.getStatus().cards[0].columnId, "done");
+});
+
+test("applyCommands: worktree preserve then cleanup flips the flags", () => {
+  const runtime = createRuntime({
+    status: {
+      readiness: { state: "ready", ready: true },
+      worktrees: [{ workspaceKey: "ws_1", path: "/w", dirty: true, preserved: false, dirtyPaths: ["a.txt"] }]
+    },
+    applyCommands: true
+  });
+  runtime.submitCommand({ type: "worktree.preserve", workspaceKey: "ws_1", reason: "keep" });
+  assert.equal(runtime.getWorktrees()[0].preserved, true);
+
+  runtime.submitCommand({ type: "worktree.cleanup", workspaceKey: "ws_1", reason: "done" });
+  const worktree = runtime.getWorktrees()[0];
+  assert.equal(worktree.dirty, false);
+  assert.equal(worktree.preserved, false);
+  assert.deepEqual(worktree.dirtyPaths, []);
+});
+
+test("applyCommands: capabilities re-derive after the runner state changes", () => {
+  const runtime = createRuntime({
+    status: {
+      readiness: { state: "ready", ready: true, runnerStatus: "ready" },
+      runs: { running: [{ id: "run_1", state: "running", sessionId: "s_1", cardId: "card_1" }] },
+      cards: [{ id: "card_1", title: "c", boardId: "b", state: "running", golden: false, runId: "run_1" }]
+    },
+    applyCommands: true
+  });
+  const before = runtime.getCapabilities().find((c) => c.id === "codex.cancel");
+  assert.equal(before.enabled, true);
+  runtime.submitCommand({ type: "run.cancel", runId: "run_1", reason: "operator" });
+  const after = runtime.getCapabilities().find((c) => c.id === "codex.cancel");
+  assert.equal(after.enabled, false);
+});
+
+test("applyCommands stays off by default (dry-run does not mutate state)", () => {
+  const runtime = createRuntime({
+    status: { readiness: { state: "ready", ready: true, dispatchPaused: false } }
+  });
+  runtime.submitCommand({ type: "dispatch.pause", reason: "x" });
+  assert.equal(runtime.getStatus().readiness.dispatchPaused, false);
+});
+
+test("applyCommandToStatus is pure and does not mutate its input", () => {
+  const status = normalizeStatus({
+    readiness: { state: "ready", ready: true, dispatchPaused: false }
+  });
+  const next = applyCommandToStatus(status, { type: "dispatch.pause", reason: "x" }, "2026-01-01T00:00:00.000Z");
+  assert.equal(status.readiness.dispatchPaused, false);
+  assert.equal(next.status.readiness.dispatchPaused, true);
+  assert.notEqual(next.status, status);
 });


### PR DESCRIPTION
## Summary

Turns the v2 cockpit's **dry-run-only** command path into **real, deterministic state changes** to the in-memory `SymphonyStatus` model. Builds directly on the merged v2 spike (#42).

- **New pure reducer** `applyCommandToStatus` (`src/v2/daemon/apply-command.ts`) — immutable, no IO. Handles all 8 operator commands:
  - `dispatch.pause` / `dispatch.resume` → flips `dispatchPaused`, recomputes readiness (locks/unlocks factory)
  - `run.cancel` → moves run `running → cancelled`, clears the card
  - `session.stop` → cancels every running run on the session
  - `card.rerun` → re-queues the card
  - `card.move` → changes the card's column
  - `worktree.preserve` / `worktree.cleanup` → flips preserve/dirty flags
- **Runtime wiring** — with `applyCommands: true`, `submitCommand` runs the reducer, mutates status, and **re-derives capabilities on read** (e.g. `codex.cancel` auto-disables once the run is gone). `submitCommand` stays the single choke point; dry-run remains the default.
- **CLI** — new `--apply` flag on `cockpit` (off by default; cockpit stays read-only unless opted in).
- **Barrel** exports `applyCommandToStatus`.

## Tests

- 9 new tests in `test/v2/commands.test.js` — each command's state effect, capability re-derivation, reducer purity, and the dry-run default.
- **Full suite: 437 passing, 0 failing** (438 incl. 1 live-gated skip).

## Docs

- `docs/v2/decision.md` and `docs/v2/cockpit-contract.md` updated to describe command application vs dry-run.

## Scope note

Live FizzyPort / CodexRunnerPort side-effects remain **deferred** — the reducer is the deterministic model layer those adapters will sit beneath in the next increment. No fake controls: commands are validated, availability-checked, and now genuinely applied to the model.