### PR TITLE
feat(v2): drive codex runner on cancel/stop via async command path

### DIFF
--- a/docs/v2/cockpit-contract.md
+++ b/docs/v2/cockpit-contract.md
@@ -112,6 +112,27 @@ worktree.cleanup { workspaceKey, reason }
 > No render or model path ever submits a command or mutates state. Commands flow
 > only through `submitCommand`.
 
+### Port effects — driving the live runner (`submitCommandAsync`)
+
+`submitCommand` is synchronous and model-only (it keeps the pure API router and
+the interactive loop deterministic). The live HTTP server instead calls
+`submitCommandAsync`, which performs the same validate → availability → reducer
+steps and then awaits runner side effects via
+`dispatchPortEffects` (`src/v2/daemon/port-effects.ts`):
+
+- **`run.cancel`** → `codex.cancelTurn({ turn, reason })` for the run's active
+  turn. A run with no `turnId` yields a `warning` audit event; a runner failure
+  yields an `error` event with code `RUNNER_CANCEL_FAILED`.
+- **`session.stop`** → `codex.stopSession({ session, reason })` then
+  `codex.terminateOwnedProcess` (when implemented) for every running run in the
+  session; failures yield `RUNNER_STOP_FAILED`.
+
+The dispatcher receives the status snapshot taken *before* the reducer ran (so
+the affected run is still `running`), never mutates status itself, and appends
+`command.effect.<type>` events describing what the runner did. When no codex port
+is wired (or `applyCommands` is `false`), `submitCommandAsync` is model-only and
+emits no effect events. The `FizzyPort` side effects remain deferred.
+
 ---
 
 ## 4. Capabilities — honest feature advertisement

--- a/src/v2/daemon/api.ts
+++ b/src/v2/daemon/api.ts
@@ -70,16 +70,17 @@ export function handleApiRequest(
 
   if (method === "POST" && pathname === "/v2/commands") {
     const result = runtime.submitCommand(body);
-    const code =
-      result.outcome === "accepted" || result.outcome === "dry-run"
-        ? 202
-        : result.outcome === "unavailable"
-          ? 409
-          : 400;
-    return { statusCode: code, body: result };
+    return { statusCode: commandHttpStatus(result), body: result };
   }
 
   return { statusCode: 404, body: { error: "NOT_FOUND", path: pathname, method } };
+}
+
+// Map a command outcome to its HTTP status code.
+export function commandHttpStatus(result: { outcome: string }): number {
+  if (result.outcome === "accepted" || result.outcome === "dry-run") return 202;
+  if (result.outcome === "unavailable") return 409;
+  return 400;
 }
 
 async function readJsonBody(req: IncomingMessage): Promise<unknown> {
@@ -114,7 +115,14 @@ export function createApiServer(runtime: SymphonyRuntime, options: ApiServerOpti
     let result: ApiHandlerResult;
     try {
       const body = method === "POST" ? await readJsonBody(req) : undefined;
-      result = handleApiRequest(runtime, method, url.pathname, body);
+      if (method === "POST" && url.pathname === "/v2/commands") {
+        // The live server awaits port side effects (cancel/stop) via the async
+        // command path; the pure router stays model-only for deterministic tests.
+        const commandResult = await runtime.submitCommandAsync(body);
+        result = { statusCode: commandHttpStatus(commandResult), body: commandResult };
+      } else {
+        result = handleApiRequest(runtime, method, url.pathname, body);
+      }
     } catch (error) {
       result = { statusCode: 400, body: { error: "BAD_REQUEST", message: (error as Error).message } };
     }

--- a/src/v2/daemon/port-effects.ts
+++ b/src/v2/daemon/port-effects.ts
@@ -1,0 +1,109 @@
+// Port effects: translate accepted operator commands into live CodexRunnerPort
+// calls. This is the layer the deferred adapters sit beneath — given the status
+// snapshot taken *before* the model reducer ran (so the affected run is still in
+// `running`), it dispatches cancel/stop to the runner and returns audit events
+// describing what the runner did. It never mutates status; the reducer owns that.
+
+import type {
+  CodexRunnerPort,
+  OperatorCommand,
+  RuntimeEvent,
+  SymphonyStatus
+} from "../core/types.ts";
+
+export type PortEffectDraft = Omit<RuntimeEvent, "id" | "at">;
+
+export interface PortEffectContext {
+  codex?: CodexRunnerPort;
+}
+
+// Dispatch the runner-facing side effects for a command. `preStatus` MUST be the
+// status snapshot from before the reducer ran. Returns the audit events to
+// append (empty when there is nothing to do or no runner is wired).
+export async function dispatchPortEffects(
+  command: OperatorCommand,
+  preStatus: SymphonyStatus,
+  ctx: PortEffectContext
+): Promise<PortEffectDraft[]> {
+  const codex = ctx.codex;
+  if (!codex) return [];
+
+  switch (command.type) {
+    case "run.cancel": {
+      const run = preStatus.runs.running.find((entry) => entry.id === command.runId);
+      if (!run) return [];
+      if (!run.turnId) {
+        return [
+          {
+            type: "command.effect.run.cancel",
+            severity: "warning",
+            message: `Run ${command.runId} has no active turn; nothing to cancel on the runner.`,
+            runId: command.runId,
+            sessionId: run.sessionId
+          }
+        ];
+      }
+      try {
+        const result = await codex.cancelTurn({
+          turn: { turnId: run.turnId, sessionId: run.sessionId ?? "" },
+          reason: command.reason
+        });
+        return [
+          {
+            type: "command.effect.run.cancel",
+            severity: "info",
+            message: `Runner cancelled turn ${run.turnId} (${result.status}).`,
+            runId: command.runId,
+            sessionId: run.sessionId,
+            data: result
+          }
+        ];
+      } catch (error) {
+        return [
+          {
+            type: "command.effect.run.cancel",
+            severity: "error",
+            message: `Runner cancel failed for run ${command.runId}: ${(error as Error).message}`,
+            runId: command.runId,
+            sessionId: run.sessionId,
+            data: { code: "RUNNER_CANCEL_FAILED" }
+          }
+        ];
+      }
+    }
+    case "session.stop": {
+      const runs = preStatus.runs.running.filter((entry) => entry.sessionId === command.sessionId);
+      if (runs.length === 0) return [];
+      const workspacePath = runs.find((entry) => entry.workspacePath)?.workspacePath ?? "";
+      try {
+        await codex.stopSession({
+          session: { sessionId: command.sessionId, workspacePath },
+          reason: command.reason
+        });
+        if (codex.terminateOwnedProcess) {
+          await codex.terminateOwnedProcess({ sessionId: command.sessionId, reason: command.reason });
+        }
+        return [
+          {
+            type: "command.effect.session.stop",
+            severity: "info",
+            message: `Runner stopped session ${command.sessionId} (${runs.length} run${runs.length === 1 ? "" : "s"}).`,
+            sessionId: command.sessionId
+          }
+        ];
+      } catch (error) {
+        return [
+          {
+            type: "command.effect.session.stop",
+            severity: "error",
+            message: `Runner stop failed for session ${command.sessionId}: ${(error as Error).message}`,
+            sessionId: command.sessionId,
+            data: { code: "RUNNER_STOP_FAILED" }
+          }
+        ];
+      }
+    }
+    default:
+      return [];
+  }
+}

--- a/src/v2/daemon/runtime.ts
+++ b/src/v2/daemon/runtime.ts
@@ -16,12 +16,14 @@ import {
 import { createEventLog } from "../core/events.ts";
 import { normalizeStatus } from "../core/status.ts";
 import { applyCommandToStatus } from "./apply-command.ts";
+import { dispatchPortEffects } from "./port-effects.ts";
 import type { EventLog } from "../core/events.ts";
 import type {
   Capability,
   CodexRunnerPort,
   CommandResult,
   FizzyPort,
+  OperatorCommand,
   RuntimeEvent,
   SymphonyStatus
 } from "../core/types.ts";
@@ -45,6 +47,7 @@ export interface SymphonyRuntime {
   getRun(runId: string): SymphonyStatus["runs"]["running"][number] | undefined;
   getWorktrees(): SymphonyStatus["worktrees"];
   submitCommand(payload: unknown): CommandResult;
+  submitCommandAsync(payload: unknown): Promise<CommandResult>;
   describePorts(): { fizzy: ReturnType<FizzyPort["describe"]> | null; codex: ReturnType<CodexRunnerPort["describe"]> | null };
 }
 
@@ -102,25 +105,62 @@ export function createRuntime(options: RuntimeOptions): SymphonyRuntime {
     }
 
     if (!applyCommands) {
-      const event = eventLog.append({
-        type: `command.dry-run.${command.type}`,
-        severity: "info",
-        message: `Dry-run accepted command ${command.type}`,
-        runId: "runId" in command ? command.runId : undefined,
-        sessionId: "sessionId" in command ? command.sessionId : undefined,
-        cardId: "cardId" in command ? command.cardId : undefined,
-        data: command
-      });
-      return {
-        outcome: "dry-run",
-        commandType: command.type,
-        message: `Command ${command.type} accepted as dry-run (spike build).`,
-        event
-      };
+      return dryRunResult(command);
+    }
+    return applyToModel(command);
+  }
+
+  // Async variant: applies the command to the model, then awaits any live
+  // CodexRunnerPort side effects (cancel/stop). The synchronous submitCommand
+  // stays model-only so the pure API router and the interactive loop remain
+  // synchronous; the HTTP server uses this path when a runner is wired.
+  async function submitCommandAsync(payload: unknown): Promise<CommandResult> {
+    const validation = validateCommand(payload);
+    if (!validation.ok || !validation.command) {
+      return rejectedResult(validation.code ?? "INVALID_COMMAND", validation.message ?? "Invalid command.");
+    }
+    const command = validation.command;
+    const availability = checkCommandAvailability(command, status);
+    if (!availability.available) {
+      return unavailableResult(
+        command.type,
+        availability.code ?? "UNAVAILABLE",
+        availability.reason ?? "Command unavailable."
+      );
     }
 
-    // Apply the command to the in-memory status model. Live FizzyPort /
-    // CodexRunnerPort side-effects (deferred) would be layered on top of this.
+    if (!applyCommands) {
+      return dryRunResult(command);
+    }
+
+    const preStatus = status;
+    const result = applyToModel(command);
+    const effects = await dispatchPortEffects(command, preStatus, { codex: options.codex });
+    for (const effect of effects) {
+      eventLog.append(effect);
+    }
+    return result;
+  }
+
+  function dryRunResult(command: OperatorCommand): CommandResult {
+    const event = eventLog.append({
+      type: `command.dry-run.${command.type}`,
+      severity: "info",
+      message: `Dry-run accepted command ${command.type}`,
+      runId: "runId" in command ? command.runId : undefined,
+      sessionId: "sessionId" in command ? command.sessionId : undefined,
+      cardId: "cardId" in command ? command.cardId : undefined,
+      data: command
+    });
+    return {
+      outcome: "dry-run",
+      commandType: command.type,
+      message: `Command ${command.type} accepted as dry-run (spike build).`,
+      event
+    };
+  }
+
+  function applyToModel(command: OperatorCommand): CommandResult {
     const applied = applyCommandToStatus(status, command, now().toISOString());
     status = applied.status;
     const event = eventLog.append({
@@ -153,6 +193,7 @@ export function createRuntime(options: RuntimeOptions): SymphonyRuntime {
       return status.worktrees.map((worktree) => ({ ...worktree }));
     },
     submitCommand,
+    submitCommandAsync,
     describePorts() {
       return {
         fizzy: options.fizzy ? options.fizzy.describe() : null,

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -36,6 +36,7 @@ export { createCodexAdapter } from "./codex/adapter.ts";
 export { createRuntime } from "./daemon/runtime.ts";
 export type { SymphonyRuntime } from "./daemon/runtime.ts";
 export { applyCommandToStatus } from "./daemon/apply-command.ts";
+export { dispatchPortEffects } from "./daemon/port-effects.ts";
 export {
   handleApiRequest,
   createApiServer

--- a/test/v2/api.test.js
+++ b/test/v2/api.test.js
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import { handleApiRequest, createApiServer } from "../../src/v2/daemon/api.ts";
 import { createRuntime } from "../../src/v2/daemon/runtime.ts";
 
+import { createFakeCodexRunner } from "../../src/v2/codex/fake.ts";
 function runtimeWithRun() {
   return createRuntime({
     status: {
@@ -70,6 +71,47 @@ test("createApiServer serves over a real socket", async () => {
     assert.equal(cmdRes.status, 202);
     const cmd = await cmdRes.json();
     assert.equal(cmd.outcome, "dry-run");
+  } finally {
+    await api.close();
+  }
+});
+
+
+
+test("live command endpoint drives the codex runner when apply is enabled", async () => {
+  const calls = [];
+  const base = createFakeCodexRunner();
+  const codex = {
+    ...base,
+    async cancelTurn(input) {
+      calls.push(input);
+      return base.cancelTurn(input);
+    }
+  };
+  const runtime = createRuntime({
+    status: {
+      instance: { id: "instance-test" },
+      readiness: { state: "ready", ready: true, runnerStatus: "ready" },
+      runs: { running: [{ id: "run_1", state: "running", sessionId: "s_1", turnId: "turn_1", cardId: "card_1" }] },
+      cards: [{ id: "card_1", title: "c", boardId: "b", state: "running", golden: false, runId: "run_1" }]
+    },
+    codex,
+    applyCommands: true
+  });
+  const api = createApiServer(runtime);
+  const { url } = await api.listen();
+  try {
+    const res = await fetch(`${url}/v2/commands`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "run.cancel", runId: "run_1", reason: "operator" })
+    });
+    assert.equal(res.status, 202);
+    const body = await res.json();
+    assert.equal(body.outcome, "accepted");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].turn.turnId, "turn_1");
+    assert.ok(runtime.getEvents(20).some((e) => e.type === "command.effect.run.cancel"));
   } finally {
     await api.close();
   }

--- a/test/v2/runner-commands.test.js
+++ b/test/v2/runner-commands.test.js
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createRuntime } from "../../src/v2/daemon/runtime.ts";
+import { dispatchPortEffects } from "../../src/v2/daemon/port-effects.ts";
+import { normalizeStatus } from "../../src/v2/core/status.ts";
+import { createFakeCodexRunner } from "../../src/v2/codex/fake.ts";
+
+function runningStatus() {
+  return {
+    readiness: { state: "ready", ready: true, runnerStatus: "ready" },
+    runs: {
+      running: [
+        { id: "run_1", state: "running", sessionId: "s_1", turnId: "turn_1", workspacePath: "/ws", cardId: "card_1" }
+      ]
+    },
+    cards: [{ id: "card_1", title: "c", boardId: "b", state: "running", golden: false, runId: "run_1" }]
+  };
+}
+
+// Records every CodexRunnerPort call so tests can assert the runner was driven.
+function spyRunner(overrides = {}) {
+  const calls = [];
+  const base = createFakeCodexRunner();
+  return {
+    calls,
+    port: {
+      ...base,
+      async cancelTurn(input) {
+        calls.push(["cancelTurn", input]);
+        if (overrides.cancelTurn) return overrides.cancelTurn(input);
+        return base.cancelTurn(input);
+      },
+      async stopSession(input) {
+        calls.push(["stopSession", input]);
+        if (overrides.stopSession) return overrides.stopSession(input);
+        return base.stopSession(input);
+      },
+      async terminateOwnedProcess(input) {
+        calls.push(["terminateOwnedProcess", input]);
+      }
+    }
+  };
+}
+
+test("submitCommandAsync drives the runner cancelTurn on run.cancel", async () => {
+  const runner = spyRunner();
+  const runtime = createRuntime({ status: runningStatus(), codex: runner.port, applyCommands: true });
+  const result = await runtime.submitCommandAsync({ type: "run.cancel", runId: "run_1", reason: "operator" });
+  assert.equal(result.outcome, "accepted");
+
+  const cancel = runner.calls.find((c) => c[0] === "cancelTurn");
+  assert.ok(cancel, "cancelTurn should have been called");
+  assert.equal(cancel[1].turn.turnId, "turn_1");
+  assert.equal(cancel[1].reason, "operator");
+
+  const status = runtime.getStatus();
+  assert.equal(status.runs.running.length, 0);
+  assert.ok(runtime.getEvents(20).some((e) => e.type === "command.effect.run.cancel"));
+});
+
+test("submitCommandAsync drives stopSession + terminateOwnedProcess on session.stop", async () => {
+  const runner = spyRunner();
+  const status = {
+    readiness: { state: "ready", ready: true },
+    runs: {
+      running: [
+        { id: "run_1", state: "running", sessionId: "s_1", turnId: "t_1", workspacePath: "/ws", cardId: "card_1" },
+        { id: "run_2", state: "running", sessionId: "s_1", turnId: "t_2", workspacePath: "/ws", cardId: "card_2" }
+      ]
+    },
+    cards: [
+      { id: "card_1", title: "a", boardId: "b", state: "running", golden: false, runId: "run_1" },
+      { id: "card_2", title: "b", boardId: "b", state: "running", golden: false, runId: "run_2" }
+    ]
+  };
+  const runtime = createRuntime({ status, codex: runner.port, applyCommands: true });
+  await runtime.submitCommandAsync({ type: "session.stop", sessionId: "s_1", reason: "operator" });
+
+  assert.ok(runner.calls.some((c) => c[0] === "stopSession"));
+  assert.ok(runner.calls.some((c) => c[0] === "terminateOwnedProcess"));
+  assert.equal(runtime.getStatus().runs.running.length, 0);
+});
+
+test("submitCommandAsync records a runner failure as an error effect event", async () => {
+  const runner = spyRunner({
+    cancelTurn() {
+      throw new Error("runner offline");
+    }
+  });
+  const runtime = createRuntime({ status: runningStatus(), codex: runner.port, applyCommands: true });
+  const result = await runtime.submitCommandAsync({ type: "run.cancel", runId: "run_1", reason: "x" });
+  // The model change still applies; the failure is surfaced as an audit event.
+  assert.equal(result.outcome, "accepted");
+  const failure = runtime.getEvents(20).find((e) => e.type === "command.effect.run.cancel");
+  assert.equal(failure.severity, "error");
+  assert.equal(failure.data.code, "RUNNER_CANCEL_FAILED");
+});
+
+test("submitCommandAsync without a runner is model-only (no effect events)", async () => {
+  const runtime = createRuntime({ status: runningStatus(), applyCommands: true });
+  await runtime.submitCommandAsync({ type: "run.cancel", runId: "run_1", reason: "x" });
+  assert.ok(!runtime.getEvents(20).some((e) => e.type.startsWith("command.effect.")));
+});
+
+test("submitCommandAsync stays dry-run when applyCommands is off and skips the runner", async () => {
+  const runner = spyRunner();
+  const runtime = createRuntime({ status: runningStatus(), codex: runner.port });
+  const result = await runtime.submitCommandAsync({ type: "run.cancel", runId: "run_1", reason: "x" });
+  assert.equal(result.outcome, "dry-run");
+  assert.equal(runner.calls.length, 0);
+  assert.equal(runtime.getStatus().runs.running.length, 1);
+});
+
+test("dispatchPortEffects warns when a run has no active turn", async () => {
+  const runner = spyRunner();
+  const status = normalizeStatus({
+    runs: { running: [{ id: "run_1", state: "running", sessionId: "s_1", cardId: "card_1" }] }
+  });
+  const effects = await dispatchPortEffects(
+    { type: "run.cancel", runId: "run_1", reason: "x" },
+    status,
+    { codex: runner.port }
+  );
+  assert.equal(effects.length, 1);
+  assert.equal(effects[0].severity, "warning");
+  assert.equal(runner.calls.length, 0);
+});


### PR DESCRIPTION
## Summary

Wires the `CodexRunnerPort` so accepted `run.cancel` / `session.stop` commands actually drive a live (or fake) runner, building on the pure reducer from #43.

## What changed

- **New `src/v2/daemon/port-effects.ts`** — `dispatchPortEffects(command, preStatus, ctx)` translates accepted commands into runner calls:
  - `run.cancel` → `codex.cancelTurn({ turn, reason })`. A run with no `turnId` yields a `warning` event; a runner throw yields an `error` event (`RUNNER_CANCEL_FAILED`).
  - `session.stop` → `codex.stopSession({ session, reason })` then `codex.terminateOwnedProcess` (when present) for every running run in the session; failures yield `RUNNER_STOP_FAILED`.
  - Receives the status snapshot taken **before** the reducer ran (affected run still `running`), never mutates status, and only emits `command.effect.<type>` audit events.
- **`runtime.ts`** — added `submitCommandAsync` (model + awaited port effects) alongside the existing synchronous, model-only `submitCommand`. The sync path keeps the pure API router and interactive loop deterministic.
- **`api.ts`** — the live HTTP server routes `POST /v2/commands` through `submitCommandAsync`; `handleApiRequest` stays synchronous/model-only for the pure-router tests. Extracted `commandHttpStatus` helper.
- **`index.ts`** — exports `dispatchPortEffects`.
- **docs/v2/cockpit-contract.md** — documents the port-effects layer and `submitCommandAsync` (FizzyPort effects remain deferred).

## Tests

- New `test/v2/runner-commands.test.js` (6 tests): cancel drives `cancelTurn`; stop drives `stopSession` + `terminateOwnedProcess`; runner failure → error effect event; no runner → model-only; `applyCommands` off → dry-run skips runner; no active turn → warning.
- New live-server test in `test/v2/api.test.js`: `POST /v2/commands` with `--apply` drives the fake codex runner and appends `command.effect.run.cancel`.

Full suite: **445 tests, 0 failures** (1 live-e2e smoke skipped).