### PR TITLE
feat(v2): drive fizzy board on card move/rerun via async command path

### DIFF
--- a/docs/v2/cockpit-contract.md
+++ b/docs/v2/cockpit-contract.md
@@ -112,12 +112,12 @@ worktree.cleanup { workspaceKey, reason }
 > No render or model path ever submits a command or mutates state. Commands flow
 > only through `submitCommand`.
 
-### Port effects — driving the live runner (`submitCommandAsync`)
+### Port effects — driving the live ports (`submitCommandAsync`)
 
 `submitCommand` is synchronous and model-only (it keeps the pure API router and
 the interactive loop deterministic). The live HTTP server instead calls
 `submitCommandAsync`, which performs the same validate → availability → reducer
-steps and then awaits runner side effects via
+steps and then awaits port side effects via
 `dispatchPortEffects` (`src/v2/daemon/port-effects.ts`):
 
 - **`run.cancel`** → `codex.cancelTurn({ turn, reason })` for the run's active
@@ -126,12 +126,16 @@ steps and then awaits runner side effects via
 - **`session.stop`** → `codex.stopSession({ session, reason })` then
   `codex.terminateOwnedProcess` (when implemented) for every running run in the
   session; failures yield `RUNNER_STOP_FAILED`.
+- **`card.move`** → `fizzy.moveCard({ cardId, targetColumnId })`; failures yield
+  an `error` event with code `FIZZY_MOVE_FAILED`.
+- **`card.rerun`** → `fizzy.createComment(...)` recording the rerun request on the
+  card as a board-visible audit note; failures yield `FIZZY_RERUN_FAILED`.
 
 The dispatcher receives the status snapshot taken *before* the reducer ran (so
 the affected run is still `running`), never mutates status itself, and appends
-`command.effect.<type>` events describing what the runner did. When no codex port
-is wired (or `applyCommands` is `false`), `submitCommandAsync` is model-only and
-emits no effect events. The `FizzyPort` side effects remain deferred.
+`command.effect.<type>` events describing what each port did. When the relevant
+port is not wired (or `applyCommands` is `false`), `submitCommandAsync` is
+model-only and emits no effect events for that command.
 
 ---
 

--- a/src/v2/daemon/port-effects.ts
+++ b/src/v2/daemon/port-effects.ts
@@ -1,11 +1,13 @@
-// Port effects: translate accepted operator commands into live CodexRunnerPort
-// calls. This is the layer the deferred adapters sit beneath — given the status
-// snapshot taken *before* the model reducer ran (so the affected run is still in
-// `running`), it dispatches cancel/stop to the runner and returns audit events
-// describing what the runner did. It never mutates status; the reducer owns that.
+// Port effects: translate accepted operator commands into live port calls. This
+// is the layer the deferred adapters sit beneath — given the status snapshot
+// taken *before* the model reducer ran (so the affected run is still in
+// `running`), it dispatches cancel/stop to the CodexRunnerPort and card
+// move/rerun to the FizzyPort, returning audit events describing what each port
+// did. It never mutates status; the reducer owns that.
 
 import type {
   CodexRunnerPort,
+  FizzyPort,
   OperatorCommand,
   RuntimeEvent,
   SymphonyStatus
@@ -15,21 +17,23 @@ export type PortEffectDraft = Omit<RuntimeEvent, "id" | "at">;
 
 export interface PortEffectContext {
   codex?: CodexRunnerPort;
+  fizzy?: FizzyPort;
 }
 
-// Dispatch the runner-facing side effects for a command. `preStatus` MUST be the
+// Dispatch the port-facing side effects for a command. `preStatus` MUST be the
 // status snapshot from before the reducer ran. Returns the audit events to
-// append (empty when there is nothing to do or no runner is wired).
+// append (empty when there is nothing to do or no relevant port is wired).
 export async function dispatchPortEffects(
   command: OperatorCommand,
   preStatus: SymphonyStatus,
   ctx: PortEffectContext
 ): Promise<PortEffectDraft[]> {
   const codex = ctx.codex;
-  if (!codex) return [];
+  const fizzy = ctx.fizzy;
 
   switch (command.type) {
     case "run.cancel": {
+      if (!codex) return [];
       const run = preStatus.runs.running.find((entry) => entry.id === command.runId);
       if (!run) return [];
       if (!run.turnId) {
@@ -72,6 +76,7 @@ export async function dispatchPortEffects(
       }
     }
     case "session.stop": {
+      if (!codex) return [];
       const runs = preStatus.runs.running.filter((entry) => entry.sessionId === command.sessionId);
       if (runs.length === 0) return [];
       const workspacePath = runs.find((entry) => entry.workspacePath)?.workspacePath ?? "";
@@ -99,6 +104,68 @@ export async function dispatchPortEffects(
             message: `Runner stop failed for session ${command.sessionId}: ${(error as Error).message}`,
             sessionId: command.sessionId,
             data: { code: "RUNNER_STOP_FAILED" }
+          }
+        ];
+      }
+    }
+    case "card.move": {
+      if (!fizzy) return [];
+      const card = preStatus.cards.find((entry) => entry.id === command.cardId);
+      try {
+        const moved = await fizzy.moveCard({
+          cardId: command.cardId,
+          targetColumnId: command.targetColumnId
+        });
+        return [
+          {
+            type: "command.effect.card.move",
+            severity: "info",
+            message: `Fizzy moved card ${command.cardId} to column ${command.targetColumnId}.`,
+            cardId: command.cardId,
+            boardId: card?.boardId,
+            data: moved
+          }
+        ];
+      } catch (error) {
+        return [
+          {
+            type: "command.effect.card.move",
+            severity: "error",
+            message: `Fizzy move failed for card ${command.cardId}: ${(error as Error).message}`,
+            cardId: command.cardId,
+            boardId: card?.boardId,
+            data: { code: "FIZZY_MOVE_FAILED" }
+          }
+        ];
+      }
+    }
+    case "card.rerun": {
+      if (!fizzy) return [];
+      const card = preStatus.cards.find((entry) => entry.id === command.cardId);
+      try {
+        const comment = await fizzy.createComment({
+          cardId: command.cardId,
+          body: `Rerun requested by operator: ${command.reason}`
+        });
+        return [
+          {
+            type: "command.effect.card.rerun",
+            severity: "info",
+            message: `Recorded rerun request for card ${command.cardId} on Fizzy.`,
+            cardId: command.cardId,
+            boardId: card?.boardId,
+            data: comment
+          }
+        ];
+      } catch (error) {
+        return [
+          {
+            type: "command.effect.card.rerun",
+            severity: "error",
+            message: `Fizzy rerun note failed for card ${command.cardId}: ${(error as Error).message}`,
+            cardId: command.cardId,
+            boardId: card?.boardId,
+            data: { code: "FIZZY_RERUN_FAILED" }
           }
         ];
       }

--- a/src/v2/daemon/runtime.ts
+++ b/src/v2/daemon/runtime.ts
@@ -110,10 +110,11 @@ export function createRuntime(options: RuntimeOptions): SymphonyRuntime {
     return applyToModel(command);
   }
 
-  // Async variant: applies the command to the model, then awaits any live
-  // CodexRunnerPort side effects (cancel/stop). The synchronous submitCommand
-  // stays model-only so the pure API router and the interactive loop remain
-  // synchronous; the HTTP server uses this path when a runner is wired.
+  // Async variant: applies the command to the model, then awaits any live port
+  // side effects (CodexRunnerPort cancel/stop, FizzyPort card move/rerun). The
+  // synchronous submitCommand stays model-only so the pure API router and the
+  // interactive loop remain synchronous; the HTTP server uses this path when a
+  // port is wired.
   async function submitCommandAsync(payload: unknown): Promise<CommandResult> {
     const validation = validateCommand(payload);
     if (!validation.ok || !validation.command) {
@@ -135,7 +136,10 @@ export function createRuntime(options: RuntimeOptions): SymphonyRuntime {
 
     const preStatus = status;
     const result = applyToModel(command);
-    const effects = await dispatchPortEffects(command, preStatus, { codex: options.codex });
+    const effects = await dispatchPortEffects(command, preStatus, {
+      codex: options.codex,
+      fizzy: options.fizzy
+    });
     for (const effect of effects) {
       eventLog.append(effect);
     }

--- a/test/v2/fizzy-commands.test.js
+++ b/test/v2/fizzy-commands.test.js
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createRuntime } from "../../src/v2/daemon/runtime.ts";
+import { dispatchPortEffects } from "../../src/v2/daemon/port-effects.ts";
+import { normalizeStatus } from "../../src/v2/core/status.ts";
+import { createFakeFizzyPort } from "../../src/v2/fizzy/fake.ts";
+
+function boardStatus() {
+  return {
+    readiness: { state: "ready", ready: true },
+    cards: [{ id: "card_1", title: "c", boardId: "board_1", columnId: "col_a", state: "running", golden: false }]
+  };
+}
+
+// Records every FizzyPort call so tests can assert the board was driven.
+function spyFizzy(overrides = {}) {
+  const calls = [];
+  const base = createFakeFizzyPort({
+    boards: [{ id: "board_1", name: "Board" }],
+    cards: [{ id: "card_1", title: "c", boardId: "board_1", columnId: "col_a" }]
+  });
+  return {
+    calls,
+    port: {
+      ...base,
+      async moveCard(input) {
+        calls.push(["moveCard", input]);
+        if (overrides.moveCard) return overrides.moveCard(input);
+        return base.moveCard(input);
+      },
+      async createComment(input) {
+        calls.push(["createComment", input]);
+        if (overrides.createComment) return overrides.createComment(input);
+        return base.createComment(input);
+      }
+    }
+  };
+}
+
+test("submitCommandAsync drives Fizzy moveCard on card.move", async () => {
+  const fizzy = spyFizzy();
+  const runtime = createRuntime({ status: boardStatus(), fizzy: fizzy.port, applyCommands: true });
+  const result = await runtime.submitCommandAsync({
+    type: "card.move",
+    cardId: "card_1",
+    targetColumnId: "col_b",
+    reason: "operator"
+  });
+  assert.equal(result.outcome, "accepted");
+
+  const move = fizzy.calls.find((c) => c[0] === "moveCard");
+  assert.ok(move, "moveCard should have been called");
+  assert.equal(move[1].cardId, "card_1");
+  assert.equal(move[1].targetColumnId, "col_b");
+
+  const effect = runtime.getEvents(20).find((e) => e.type === "command.effect.card.move");
+  assert.ok(effect);
+  assert.equal(effect.boardId, "board_1");
+});
+
+test("submitCommandAsync records a rerun note on card.rerun", async () => {
+  const fizzy = spyFizzy();
+  const status = {
+    readiness: { state: "ready", ready: true },
+    cards: [{ id: "card_1", title: "c", boardId: "board_1", columnId: "col_a", state: "failed", golden: false }]
+  };
+  const runtime = createRuntime({ status, fizzy: fizzy.port, applyCommands: true });
+  await runtime.submitCommandAsync({ type: "card.rerun", cardId: "card_1", reason: "flaky" });
+
+  const comment = fizzy.calls.find((c) => c[0] === "createComment");
+  assert.ok(comment, "createComment should have been called");
+  assert.match(comment[1].body, /Rerun requested by operator: flaky/);
+  assert.ok(runtime.getEvents(20).some((e) => e.type === "command.effect.card.rerun"));
+});
+
+test("submitCommandAsync records a Fizzy failure as an error effect event", async () => {
+  const fizzy = spyFizzy({
+    moveCard() {
+      throw new Error("board offline");
+    }
+  });
+  const runtime = createRuntime({ status: boardStatus(), fizzy: fizzy.port, applyCommands: true });
+  const result = await runtime.submitCommandAsync({
+    type: "card.move",
+    cardId: "card_1",
+    targetColumnId: "col_b",
+    reason: "x"
+  });
+  assert.equal(result.outcome, "accepted");
+  const failure = runtime.getEvents(20).find((e) => e.type === "command.effect.card.move");
+  assert.equal(failure.severity, "error");
+  assert.equal(failure.data.code, "FIZZY_MOVE_FAILED");
+});
+
+test("submitCommandAsync without a Fizzy port is model-only (no effect events)", async () => {
+  const runtime = createRuntime({ status: boardStatus(), applyCommands: true });
+  await runtime.submitCommandAsync({ type: "card.move", cardId: "card_1", targetColumnId: "col_b", reason: "x" });
+  assert.ok(!runtime.getEvents(20).some((e) => e.type.startsWith("command.effect.")));
+});
+
+test("dispatchPortEffects returns no effects for card.move without a Fizzy port", async () => {
+  const status = normalizeStatus(boardStatus());
+  const effects = await dispatchPortEffects(
+    { type: "card.move", cardId: "card_1", targetColumnId: "col_b", reason: "x" },
+    status,
+    {}
+  );
+  assert.deepEqual(effects, []);
+});


### PR DESCRIPTION
## Summary

Extends the port-effects layer (introduced for the codex runner in #44) to the **FizzyPort**, so accepted `card.move` / `card.rerun` commands drive the live (or fake) board.

## What changed

- **`src/v2/daemon/port-effects.ts`**
  - Added `fizzy?: FizzyPort` to `PortEffectContext`; each command now checks only its own required port (the early `if (!codex) return []` is gone), so codex and fizzy effects are independent.
  - **`card.move`** → `fizzy.moveCard({ cardId, targetColumnId })`; failure → `error` event `FIZZY_MOVE_FAILED`.
  - **`card.rerun`** → `fizzy.createComment(...)` recording a board-visible "Rerun requested by operator: …" audit note; failure → `FIZZY_RERUN_FAILED`.
  - Still uses the pre-reducer status snapshot, never mutates status, emits `command.effect.<type>` events.
- **`runtime.ts`** — `submitCommandAsync` now passes `fizzy: options.fizzy` to the dispatcher; comments updated.
- **docs/v2/cockpit-contract.md** — documents the two new FizzyPort effects.

## Tests

New `test/v2/fizzy-commands.test.js` (5 tests): move drives `moveCard`; rerun records a comment; a throwing port → error effect event; no fizzy port → model-only (no effect events); `dispatchPortEffects` returns `[]` for `card.move` with no port.

Full suite: **450 tests, 0 failures** (1 live-e2e smoke skipped).