### PR TITLE
Make cockpit the default operator surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Run these from the repository root:
 
 ```sh
 npm install
+node bin/fizzy-symphony.js
 node bin/fizzy-symphony.js setup
 node bin/fizzy-symphony.js boards
 node bin/fizzy-symphony.js start
-node bin/fizzy-symphony.js dashboard
+node bin/fizzy-symphony.js cockpit
 node bin/fizzy-symphony.js status
 node bin/fizzy-symphony.js worktrees
 node bin/fizzy-symphony.js doctor --goal
@@ -103,11 +104,15 @@ clean-source policy is enabled; commit, stash, or change the policy deliberately
 default, `--once` prints a static snapshot, and non-TTY, CI, or dumb terminals use the same text
 fallback. It does not define a separate workflow model.
 
-`cockpit` and `capabilities` are the v2 operator spike. With no source flags they first look for a
-local daemon through the instance registry and default endpoint. If none is reachable, `cockpit`
-falls back to its packaged demo fixture and `capabilities` prints the static catalogue. Use
-`--endpoint URL` to require a specific live daemon or `--fixture PATH` to force fixture mode; the
-daemon serves `/status` and `/v2/status` from the same base URL used by `dashboard`.
+Bare `fizzy-symphony` launches the cockpit. `cockpit --once` is the default one-command operator
+check for route status and backend posture.
+
+`cockpit` and `capabilities` are the v2 operator surfaces. With no source flags, `cockpit` resolves
+one mode: `SETUP` when config is missing, `OFFLINE` when config exists but no daemon is reachable,
+or `LIVE` when the local registry/default endpoint answers `/v2/status`. `DEMO` requires an explicit
+fixture, for example `cockpit --fixture src/v2/fixtures/ready.json --once`. Use `--endpoint URL` to
+require a specific live daemon; the daemon serves `/status` and `/v2/status` from the same base URL
+used by `dashboard`.
 
 `worktrees` inspects Symphony-created worktrees and their metadata, including dirty file paths,
 branch, run id, last error, and recommended action. Use `--dirty-only`, `--card 426`, or `--json`

--- a/bin/fizzy-symphony.js
+++ b/bin/fizzy-symphony.js
@@ -39,7 +39,7 @@ export async function main(args = process.argv.slice(2), io = defaultIo()) {
       return usage(0, io);
     } else if (!command) {
       if (!bareEntryArgsAllowed(commandArgs)) return usage(1, io);
-      return await smartEntryCommand(commandArgs, io);
+      return await bareCockpitCommand(commandArgs, io);
     } else if (command === "init") {
       return await initCommand(commandArgs, io);
     } else if (command === "setup") {
@@ -130,14 +130,15 @@ async function initCommand(args, io) {
   });
 }
 
-async function smartEntryCommand(args, io) {
-  const configPath = optionValue(args, "--config") ?? ".fizzy-symphony/config.yml";
-  try {
-    await access(configPath);
-    return runDashboardCommand(args, io, { fetch: io.fetch });
-  } catch {
-    return setupCommand(args, io);
-  }
+async function bareCockpitCommand(args, io) {
+  const { runCockpitCommand } = await import("../src/v2/cli/cockpit.ts");
+  return runCockpitCommand(args, {
+    stdout: io.stdout,
+    stderr: io.stderr,
+    env: io.env ?? process.env,
+    fetch: io.fetch,
+    stdoutIsTTY: Boolean(io.stdout?.isTTY)
+  });
 }
 
 async function setupCommandWithOptions(args, io, commandOptions = {}) {
@@ -875,6 +876,9 @@ function isHelpCommand(args) {
 function usage(exitCode, io) {
   const text = [
     "Usage:",
+    "  fizzy-symphony [--config path] [--endpoint url] [--registry-dir path] [--once]",
+    "",
+    "Advanced commands:",
     "  fizzy-symphony setup",
     "  fizzy-symphony setup --template-only [--config path]",
     "  fizzy-symphony setup --mode create-starter [--api-url url] [--token token] [--dotenv path] [--repo url|--git-repo url|--workspace-repo path-or-url] [--ref ref] [--source-cache path] [--model model] [--reasoning-effort level] [--max-agents n] [--agent-access protected|full] [--worktree|--no-dispatch] [--create-starter-workflow|--no-workflow-change]",

--- a/config.example.yml
+++ b/config.example.yml
@@ -166,8 +166,10 @@ agent:
   max_retry_backoff_ms: 300000
 
   # Required: no. Default: codex.
-  # MVP valid value: codex. This field exists so route records are explicit; it is not an arbitrary
-  # backend plugin surface in MVP.
+  # Valid: claude, codex, opencode, anthropic, openai, command.
+  # Use route tags `#codex` or `#backend-codex` to force a route to Codex.
+  # Non-codex route backends are parsed and shown as disabled until runtime harnesses land.
+  # This field exists so route records are explicit; it is not an arbitrary runtime plugin surface.
   default_backend: codex
 
   # Required: no. Default: gpt-5.5.

--- a/docs/superpowers/plans/2026-05-31-single-cockpit-and-harnesses.md
+++ b/docs/superpowers/plans/2026-05-31-single-cockpit-and-harnesses.md
@@ -1,0 +1,84 @@
+# Single Cockpit And Harnesses Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `fizzy-symphony` launch a mode-aware terminal cockpit by default, keep advanced commands scriptable, and make the product language/route model ready for easy Claude/Codex harness selection.
+
+**Architecture:** Add a v2 cockpit app-state layer that resolves `SETUP`, `OFFLINE`, `LIVE`, and `DEMO` before building the existing pure cockpit model. Extend the cockpit model with app shell sections, palette entries, safe settings, and advanced command guidance, while keeping daemon mutations behind `/v2/commands` and preserving existing v2 ports. Keep Claude/Codex harness work small in this pass: allow known backend tags and surface them in setup/docs/cockpit without rewriting the whole runner lifecycle.
+
+**Tech Stack:** Node ESM with native TypeScript stripping, Terminal Kit for TTY UI, Node test runner, current v2 runtime and daemon ports.
+
+---
+
+### Task 1: Mode-Aware Cockpit Source Resolution
+
+**Files:**
+- Create: `src/v2/cockpit/app-state.ts`
+- Modify: `src/v2/cli/cockpit.ts`
+- Test: `test/v2/cockpit-cli.test.js`
+
+- [ ] Add tests for missing config -> `SETUP`, config without daemon -> `OFFLINE`, explicit fixture -> `DEMO`, explicit endpoint strict failure, and live registry discovery -> `LIVE`.
+- [ ] Add `resolveCockpitApp()` that reads `--config`, `--fixture`, `--endpoint`, registry/default endpoint discovery, and returns `{ app, runtime }`.
+- [ ] Generate synthetic empty statuses for `SETUP` and `OFFLINE` so render/model code has no fixture lie.
+- [ ] Remove silent default fixture fallback from no-source mode; fixture demo must be explicit.
+- [ ] Run `node --test test/v2/cockpit-cli.test.js`.
+
+### Task 2: Bare Command Routes To Cockpit
+
+**Files:**
+- Modify: `bin/fizzy-symphony.js`
+- Test: `test/cli-production-clients.test.js`
+
+- [ ] Update the old bare-dashboard test to expect cockpit `LIVE`.
+- [ ] Add a missing-config bare-command test that expects `SETUP` and does not construct Fizzy/runner clients.
+- [ ] Route `!command` through `runCockpitCommand()` after existing bare flag validation.
+- [ ] Update usage copy so `fizzy-symphony` is the main command and setup/start/dashboard/status/capabilities/worktrees/doctor are advanced/scriptable.
+- [ ] Run `node --test test/cli-production-clients.test.js`.
+
+### Task 3: App Shell Model, Renderer, And Palette
+
+**Files:**
+- Modify: `src/v2/core/types.ts`
+- Modify: `src/v2/cockpit/model.ts`
+- Modify: `src/v2/cockpit/renderer.ts`
+- Modify: `src/v2/cockpit/interactive.ts`
+- Test: `test/v2/cockpit-model.test.js`
+- Test: `test/v2/interactive.test.js`
+
+- [ ] Extend model types with mode banner, section ids, palette entries, next actions, safe settings, and advanced commands.
+- [ ] Build sections for Factory, Runs, Worktrees, Doctor, Manual, Events, Settings, and Advanced from one pure model function.
+- [ ] Build palette rows with enabled/disabled, disabled reason, mutability, and backing command/endpoint.
+- [ ] Render mode banner first in every text frame; render `SETUP` and `OFFLINE` next actions above factory data.
+- [ ] Add minimal Terminal Kit shell state for section switching and `Ctrl-P` palette.
+- [ ] Run `node --test test/v2/cockpit-model.test.js test/v2/interactive.test.js`.
+
+### Task 4: Harness-Aware Product Path
+
+**Files:**
+- Modify: `src/validation.js`
+- Modify: `config.example.yml`
+- Modify: `docs/user-guide.md`
+- Modify: `README.md`
+- Modify: `docs/v2/cockpit-contract.md`
+- Modify: `docs/v2/decision.md`
+- Tests: `test/validation.test.js`, docs copy tests if added
+
+- [ ] Allow known backend tags `claude`, `codex`, `opencode`, `anthropic`, `openai`, and `command` in route parsing without treating non-Codex as unknown managed tags.
+- [ ] Keep dispatch honest: non-Codex routes can be configured and shown, but must be disabled for live Codex-only execution until a runner harness exists.
+- [ ] Update docs around one-command cockpit flow and easy backend tags (`#claude`, `#codex`) like `fizzy-popper`.
+- [ ] Move command lists to Advanced CLI Reference.
+- [ ] Run targeted validation/docs tests.
+
+### Task 5: Full Verification
+
+**Files:**
+- All changed files
+
+- [ ] Run `npm test`.
+- [ ] Run `npm run build`.
+- [ ] Run `git diff --check`.
+- [ ] Run `npm pack --dry-run --json` and verify `src/v2/fixtures/ready.json` is included.
+- [ ] Run `node bin/fizzy-symphony.js --once`.
+- [ ] Run `node bin/fizzy-symphony.js cockpit --fixture src/v2/fixtures/ready.json --once`.
+- [ ] Run `node bin/fizzy-symphony.js capabilities --no-default-endpoint`.
+- [ ] Audit the goal requirement-by-requirement before marking complete.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -8,7 +8,7 @@ Run these from the repo root on your Bluefin host or another Linux shell:
 npm install
 fizzy-symphony setup
 fizzy-symphony start
-fizzy-symphony dashboard
+fizzy-symphony cockpit
 ```
 
 In the repo checkout, the same commands are:
@@ -16,10 +16,11 @@ In the repo checkout, the same commands are:
 ```sh
 node bin/fizzy-symphony.js setup
 node bin/fizzy-symphony.js start
-node bin/fizzy-symphony.js dashboard
+node bin/fizzy-symphony.js cockpit
 ```
 
-That is the normal path.
+That is the normal path. `cockpit` is the primary operator surface for one-command visibility of route
+status and dispatch posture.
 
 `setup` is the normal first-run path. `init` still works, but it is only a deprecated compatibility alias for `setup`.
 
@@ -52,6 +53,9 @@ agent:
   max_concurrent: 1
 ```
 
+If a route card does not include a backend tag, the board route default is used first; when that is
+absent, `agent.default_backend` is used. The default is typically `codex`.
+
 Maximum active agents stays on `--max-agents` and `agent.max_concurrent`; starter-board setup defaults it to `1`.
 
 Agent access is a separate setup choice. `protected` is the default: workspace writes are allowed,
@@ -62,11 +66,17 @@ Generated setup state under `.fizzy-symphony/` is ignored by source protection, 
 
 `start` runs the local daemon.
 
-`dashboard` reads the daemon's existing `/status` endpoint and renders that status. In a TTY it refreshes by default; use `--once` for a static snapshot. In non-TTY, CI, or dumb terminals it prints the same information as text. It is not a clickable workflow editor and does not keep a separate workflow model.
+`cockpit` is the default operator surface. In a TTY it refreshes by default, and `--once` prints a
+single static snapshot. `dashboard` is still available for status-only reads.
 
-`cockpit` is the v2 operator spike. With no source flags it first looks for a local daemon through the instance registry and default endpoint. If none is reachable, it renders a packaged demo fixture so the command works after install. Use `--endpoint URL` to require a specific live daemon or `--fixture PATH` to force fixture mode; `start` serves both the v1 `/status` endpoint and the v2 `/v2/status` cockpit endpoint.
+`capabilities` is an advanced control surface for capability inspection.
+With no source flags it looks for a reachable daemon first; otherwise it renders the static catalogue.
+With no source flags, cockpit shows `SETUP` when config is missing, `OFFLINE` when config exists but
+no daemon is reachable, and `LIVE` when the local registry/default endpoint answers. Use
+`--endpoint URL` to require a specific live daemon or `--fixture PATH` to force explicit `DEMO` mode.
+The CLI serves both the v1 `/status` endpoint and the v2 `/v2/status` cockpit endpoint.
 
-`capabilities` prints the v2 capability catalogue. With no source flags it uses a discovered live daemon when one is reachable, otherwise it shows the static feature list. With `--fixture` or `--endpoint`, it derives disabled reasons from that status snapshot.
+`status`, `worktrees`, and `dashboard` are escape-hatch views for scripts and targeted triage.
 
 ## What You Do In Fizzy
 
@@ -153,7 +163,10 @@ If the board already has the starter route and you want setup to use starter def
 fizzy-symphony setup --adopt-starter --board BOARD_ID --workspace-repo .
 ```
 
-Existing routes still use the same board-native contract: a native golden card tagged `agent-instructions`, `codex`, and one completion tag like `move-to-done`, `close-on-complete`, or `comment-once`.
+Existing routes still use the same board-native contract: a native golden card tagged `agent-instructions`,
+one backend tag (`#codex`, `#backend-codex`, `#claude`, `#backend-claude`, `#opencode`, `#backend-opencode`,
+`#anthropic`, `#backend-anthropic`, `#openai`, `#backend-openai`, `#command`, `#backend-command`), and one
+completion tag like `move-to-done`, `close-on-complete`, or `comment-once`.
 
 ## Gated Live E2E Smoke
 

--- a/docs/v2/cockpit-contract.md
+++ b/docs/v2/cockpit-contract.md
@@ -49,6 +49,8 @@ events, capabilities, selection, filter) it returns a fully resolved view:
 
 - `header` — instance, endpoint, readiness, factory state, counts.
 - `lanes[]` — one per route; each lane carries themed cards with a `hazard` flag.
+  Lane enablement mirrors the route `enabled` field and surfaces `disabledReason` from the backend-aware
+  route parser (for example, non-Codex routes are visible but not dispatchable in MVP).
 - `selected` — the selected item; `raw` holds the unembellished truth
   (`boardId/cardId/runId/sessionId/workspacePath/error`) used to build commands.
 - `panels` — `activeRuns`, `worktrees`, `doctor`, `events`, `capabilities`.
@@ -173,10 +175,11 @@ wraps it in a real `http` server.
 | `GET /v2/worktrees` | Worktree summaries. |
 | `POST /v2/commands` | `202` dry-run/accepted, `409` unavailable, `400` rejected. |
 
-The cockpit CLI can drive itself from a discovered local daemon, a required live
-endpoint (`--endpoint`), or a fixture (`--fixture`), proving the same model
-renders identically from either source. If no local daemon is reachable, the
-no-source command falls back to the packaged fixture.
+The cockpit CLI resolves an explicit app mode before rendering: `SETUP` when no
+config exists, `OFFLINE` when config exists but no daemon is reachable, `LIVE`
+when a discovered or required endpoint answers `/v2/status`, and `DEMO` only
+when a fixture is explicitly requested with `--fixture`. The no-source command
+never silently falls back to the packaged fixture.
 
 ---
 

--- a/docs/v2/decision.md
+++ b/docs/v2/decision.md
@@ -82,13 +82,15 @@
   mirrors the Codex app-server/SDK lifecycle. Both SDK and app-server modes are
   live adapters behind the same port contract.
 
-## 6. Default cockpit fixture
+## 6. Cockpit app modes
 
-- **Decision:** `fizzy-symphony cockpit` with no source flags loads
-  `src/v2/fixtures/ready.json`.
-- **Why:** A spike needs a zero-arg happy path for demos, and the default fixture
-  must be present after npm/Homebrew packaging. Test fixtures remain under
-  `test/fixtures/v2/`.
+- **Decision:** `fizzy-symphony` and `fizzy-symphony cockpit` resolve exactly one
+  app mode before rendering: `SETUP`, `OFFLINE`, `LIVE`, or `DEMO`.
+- **Decision:** `DEMO` requires an explicit fixture (`--fixture`). No-source
+  mode never silently loads `src/v2/fixtures/ready.json`.
+- **Why:** The cockpit is the app path, so first-run and stopped-daemon states
+  need honest guidance instead of demo data that looks live. The packaged fixture
+  remains available for explicit demos and packaging verification.
 
 ## 7. Non-TTY behavior preserved
 
@@ -110,11 +112,23 @@
 - **Decision:** The existing daemon now serves `/v2/*` from the same local HTTP
   listener as `/status`, projecting the v1 status snapshot into
   `SymphonyStatus` on demand. The v2 CLIs use the existing instance registry and
-  default endpoint for no-source live discovery, while explicit `--fixture`
-  remains fixture-only.
+  default endpoint for no-source live discovery, while unreachable configured
+  projects render `OFFLINE` guidance and explicit `--fixture` remains fixture-only.
 - **Why:** This keeps fixture mode intact while letting `cockpit` and
   `capabilities` observe a real local daemon without starting a second server or
   making operators paste the endpoint for the common local case.
+
+## 10. Route-level backend harness readiness
+
+- **Decision:** Route tags now accept known backend aliases in both bare and
+  `backend-*` forms (`claude`, `codex`, `opencode`, `anthropic`, `openai`,
+  `command`) and reject unknown `backend-*` aliases as invalid.
+- **Decision:** Route discovery records `enabled: false` and a specific
+  `disabledReason` for routes that select non-Codex backends. A non-codex route
+  can still be configured and shown, but it does not dispatch until the runtime
+  harness exists.
+- **Why:** This keeps workflow intent first-class while preserving honesty in live
+  execution posture.
 
 ## Reversal notes
 

--- a/src/router.js
+++ b/src/router.js
@@ -49,6 +49,10 @@ export function routeCard({
     return ignoreDecision({ reason: "no-route", card, rerunRequested });
   }
 
+  if (route.enabled === false) {
+    return ignoreDecision({ reason: "route-disabled", card, route, rerunRequested });
+  }
+
   if (hasLiveUnexpiredClaim(activeClaims, card)) {
     return ignoreDecision({ reason: "live-claim", card, route, rerunRequested });
   }

--- a/src/v2/cli/cockpit.ts
+++ b/src/v2/cli/cockpit.ts
@@ -1,26 +1,19 @@
 // `fizzy-symphony cockpit` command.
 //
 // Modes:
-//   cockpit                         interactive (TTY) or static (non-TTY)
-//   cockpit --endpoint URL          read snapshot from a running v2 daemon
-//   cockpit --fixture PATH          read a fixture bundle
+//   cockpit --endpoint URL          read a snapshot from a running v2 daemon (strict)
+//   cockpit --fixture PATH          read a fixture bundle (demo mode)
 //   cockpit --once                  print one static frame and exit
-//   cockpit --json                  print the cockpit model as JSON and exit
+//   cockpit                        auto-resolve mode from config/daemon/fixtures
 //
-// Layering rule: this command builds a runtime (fixture or snapshot), derives
-// the pure cockpit model, then renders. It never reaches into Fizzy/Codex.
-
-import { readFile } from "node:fs/promises";
-import { dirname, isAbsolute, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+// Layering rule: resolve source/mode in app-state, then derive runtime and render.
 
 import { createCockpitModel } from "../cockpit/model.ts";
 import { renderCockpitText } from "../cockpit/renderer.ts";
 import { startInteractiveCockpit } from "../cockpit/interactive.ts";
-import { createRuntime } from "../daemon/runtime.ts";
-import { discoverV2StatusSource, hasFlag, optionValue, trimEndpoint } from "./status-source.ts";
-import type { SymphonyRuntime } from "../daemon/runtime.ts";
-import type { FixtureBundle, SymphonyStatus } from "../core/types.ts";
+import { optionValue } from "./status-source.ts";
+import { resolveCockpitApp } from "../cockpit/app-state.ts";
+import type { CockpitAppState } from "../cockpit/app-state.ts";
 
 export interface CockpitIo {
   stdout: { write(text: string): void };
@@ -30,112 +23,37 @@ export interface CockpitIo {
   stdoutIsTTY?: boolean;
 }
 
-const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
-const DEFAULT_FIXTURE = join(PACKAGE_ROOT, "src", "v2", "fixtures", "ready.json");
-
-function asBundle(raw: unknown): FixtureBundle {
-  if (raw && typeof raw === "object" && "status" in (raw as Record<string, unknown>)) {
-    return raw as FixtureBundle;
-  }
-  return { status: raw as Partial<SymphonyStatus> as SymphonyStatus };
-}
-
-async function loadFixtureBundle(path: string): Promise<FixtureBundle> {
-  const resolved = isAbsolute(path) ? path : resolve(process.cwd(), path);
-  const text = await readFile(resolved, "utf8");
-  return asBundle(JSON.parse(text));
-}
-
-async function loadEndpointBundle(endpoint: string, io: CockpitIo): Promise<FixtureBundle> {
-  const doFetch = io.fetch ?? fetch;
-  const base = trimEndpoint(endpoint);
-  const statusRes = await doFetch(`${base}/v2/status`);
-  if (!statusRes.ok) throw new Error(`GET /v2/status failed: ${statusRes.status}`);
-  const status = (await statusRes.json()) as SymphonyStatus;
-  let events;
-  try {
-    const eventsRes = await doFetch(`${base}/v2/events`);
-    if (eventsRes.ok) events = ((await eventsRes.json()) as { events?: unknown }).events as FixtureBundle["events"];
-  } catch {
-    // events are optional
-  }
-  return { status, events };
-}
-
-async function loadEndpointEvents(endpoint: string, io: CockpitIo): Promise<FixtureBundle["events"]> {
-  const doFetch = io.fetch ?? fetch;
-  try {
-    const eventsRes = await doFetch(`${trimEndpoint(endpoint)}/v2/events`);
-    if (eventsRes.ok) return ((await eventsRes.json()) as { events?: unknown }).events as FixtureBundle["events"];
-  } catch {
-    // events are optional
-  }
-  return undefined;
-}
-
-async function buildRuntime(args: string[], io: CockpitIo): Promise<{ runtime: SymphonyRuntime; source: string }> {
-  const endpoint = optionValue(args, "--endpoint");
-  const fixture = optionValue(args, "--fixture");
-  // --apply makes operator commands mutate the in-memory status model instead
-  // of being recorded as dry-runs. Off by default to keep the cockpit read-only.
-  const applyCommands = hasFlag(args, "--apply");
-  if (endpoint) {
-    const bundle = await loadEndpointBundle(endpoint, io);
-    return {
-      runtime: createRuntime({ status: bundle.status, events: bundle.events, applyCommands }),
-      source: `endpoint ${endpoint}`
-    };
-  }
-  if (!fixture) {
-    const live = await discoverV2StatusSource(args, io);
-    if (live) {
-      return {
-        runtime: createRuntime({
-          status: live.status,
-          events: await loadEndpointEvents(live.endpoint, io),
-          applyCommands
-        }),
-        source: `endpoint ${live.endpoint}`
-      };
-    }
-  }
-
-  const fixturePath = fixture ?? DEFAULT_FIXTURE;
-  const bundle = await loadFixtureBundle(fixturePath);
-  return {
-    runtime: createRuntime({
-      status: bundle.status,
-      events: bundle.events,
-      capabilities: bundle.capabilities,
-      applyCommands
-    }),
-    source: `fixture ${fixturePath}${applyCommands ? " [apply]" : ""}`
-  };
-}
-
 export async function runCockpitCommand(args: string[], io: CockpitIo): Promise<number> {
-  let runtime: SymphonyRuntime;
-  let source: string;
+  let appState: CockpitAppState;
   try {
-    ({ runtime, source } = await buildRuntime(args, io));
+    appState = await resolveCockpitApp(args, io);
   } catch (error) {
     io.stderr.write(`cockpit: failed to load source: ${(error as Error).message}\n`);
     return 1;
   }
 
-  const wantJson = hasFlag(args, "--json");
-  const wantOnce = hasFlag(args, "--once");
+  const { runtime, source, mode, configPath } = appState;
+  const wantJson = args.includes("--json");
+  const wantOnce = args.includes("--once");
   const isTty = io.stdoutIsTTY ?? Boolean((io.stdout as { isTTY?: boolean }).isTTY);
+
+  const app = {
+    mode,
+    source,
+    configPath,
+    endpoint: appState.endpoint
+  };
 
   const model = createCockpitModel({
     status: runtime.getStatus(),
     events: runtime.getEvents(20),
     capabilities: runtime.getCapabilities(),
-    selectedId: optionValue(args, "--select")
+    selectedId: optionValue(args, "--select"),
+    app
   });
 
   if (wantJson) {
-    io.stdout.write(`${JSON.stringify(model, null, 2)}\n`);
+    io.stdout.write(`${JSON.stringify({ app: "cockpit", mode, source, model }, null, 2)}\n`);
     return 0;
   }
 
@@ -149,7 +67,7 @@ export async function runCockpitCommand(args: string[], io: CockpitIo): Promise<
 
   // Interactive TTY mode.
   try {
-    const session = await startInteractiveCockpit({ runtime });
+    const session = await startInteractiveCockpit({ runtime, app });
     await session.done;
     return 0;
   } catch (error) {

--- a/src/v2/cockpit/app-state.ts
+++ b/src/v2/cockpit/app-state.ts
@@ -1,0 +1,201 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { isAbsolute, resolve as resolvePath } from "node:path";
+
+import { createRuntime } from "../daemon/runtime.ts";
+import { discoverStatusEndpoints } from "../../status-discovery.js";
+import { loadConfig } from "../../config.js";
+import type { FixtureBundle, SymphonyRuntime, SymphonyStatus } from "../core/types.ts";
+import {
+  fetchV2Status,
+  hasFlag,
+  optionValue,
+  trimEndpoint
+} from "../cli/status-source.ts";
+
+export type CockpitMode = "SETUP" | "OFFLINE" | "LIVE" | "DEMO";
+
+export interface CockpitAppState {
+  mode: CockpitMode;
+  source: string;
+  runtime: SymphonyRuntime;
+  configPath: string;
+  endpoint?: string | null;
+}
+
+export interface CockpitAppStateIo {
+  fetch?: typeof fetch;
+  env?: Record<string, string | undefined>;
+}
+
+const DEFAULT_CONFIG_PATH = ".fizzy-symphony/config.yml";
+const DISCOVERY_PLACEHOLDER_ENV = new Set([
+  "FIZZY_API_TOKEN",
+  "FIZZY_WEBHOOK_SECRET"
+]);
+
+function asFixtureBundle(raw: unknown): FixtureBundle {
+  if (raw && typeof raw === "object" && "status" in (raw as Record<string, unknown>)) {
+    return raw as FixtureBundle;
+  }
+  return { status: raw as Partial<SymphonyStatus> as SymphonyStatus };
+}
+
+async function loadFixtureBundle(path: string): Promise<FixtureBundle> {
+  const resolvedPath = isAbsolute(path) ? path : resolvePath(process.cwd(), path);
+  const text = await readFile(resolvedPath, "utf8");
+  return asFixtureBundle(JSON.parse(text));
+}
+
+async function loadEndpointBundle(endpoint: string, io: CockpitAppStateIo): Promise<{ status: SymphonyStatus; events?: FixtureBundle["events"] }> {
+  const base = trimEndpoint(endpoint);
+  const status = await fetchV2Status(base, io);
+  let events;
+  const doFetch = io.fetch ?? fetch;
+  if (!doFetch) {
+    return { status };
+  }
+
+  try {
+    const eventsRes = await doFetch(`${base}/v2/events`);
+    if (eventsRes.ok) events = ((await eventsRes.json()) as { events?: unknown }).events as FixtureBundle["events"];
+  } catch {
+    // Events are optional for cockpit runtime.
+  }
+
+  return { status, events };
+}
+
+function resolveConfigPath(pathOverride?: string) {
+  const raw = pathOverride ?? DEFAULT_CONFIG_PATH;
+  return isAbsolute(raw) ? raw : resolvePath(process.cwd(), raw);
+}
+
+function emptyStatusForMode(mode: CockpitMode): Partial<SymphonyStatus> {
+  return {
+    instance: { id: `cockpit-${mode.toLowerCase()}`, label: `${mode.toLowerCase()} mode` },
+    readiness: { state: "unknown", ready: false, blockers: [] },
+    doctor: { goalClosable: true, blockers: [] }
+  };
+}
+
+async function configEndpoints(configPath: string, args: string[], io: CockpitAppStateIo) {
+  const config = await loadConfig(configPath, { env: lenientDiscoveryEnv(io.env ?? process.env) });
+  const registryDir = optionValue(args, "--registry-dir");
+  const discoveryConfig = registryDir
+    ? { ...config, server: { ...(config.server ?? {}), registry_dir: registryDir } }
+    : config;
+  const discovery = await discoverStatusEndpoints(discoveryConfig, {
+    instanceId: optionValue(args, "--instance"),
+    now: new Date()
+  });
+  const instances = hasFlag(args, "--no-default-endpoint")
+    ? discovery.instances.filter((entry) => entry.source !== "fallback")
+    : discovery.instances;
+
+  return instances.map((entry) => entry.base_url);
+}
+
+function lenientDiscoveryEnv(env: Record<string, string | undefined>) {
+  return new Proxy(env, {
+    get(target, property) {
+      if (typeof property !== "string") return Reflect.get(target, property);
+      const value = Reflect.get(target, property);
+      if (value !== undefined) return value;
+      return DISCOVERY_PLACEHOLDER_ENV.has(property) ? "" : undefined;
+    },
+    getOwnPropertyDescriptor(target, property) {
+      if (typeof property !== "string") return Reflect.getOwnPropertyDescriptor(target, property);
+      const descriptor = Reflect.getOwnPropertyDescriptor(target, property);
+      if (descriptor || !DISCOVERY_PLACEHOLDER_ENV.has(property)) return descriptor;
+      return {
+        configurable: true,
+        enumerable: false,
+        value: "",
+        writable: false
+      };
+    },
+    has(target, property) {
+      if (typeof property !== "string") return Reflect.has(target, property);
+      return Reflect.has(target, property) || DISCOVERY_PLACEHOLDER_ENV.has(property);
+    }
+  });
+}
+
+export async function resolveCockpitApp(args: string[], io: CockpitAppStateIo = {}): Promise<CockpitAppState> {
+  const endpoint = optionValue(args, "--endpoint");
+  if (endpoint) {
+    const normalizedEndpoint = trimEndpoint(endpoint);
+    const bundle = await loadEndpointBundle(endpoint, io);
+    return {
+      mode: "LIVE",
+      source: `endpoint ${normalizedEndpoint}`,
+      endpoint: normalizedEndpoint,
+      runtime: createRuntime({
+        status: bundle.status,
+        events: bundle.events,
+        applyCommands: hasFlag(args, "--apply")
+      }),
+      configPath: resolveConfigPath(optionValue(args, "--config"))
+    };
+  }
+
+  const fixture = optionValue(args, "--fixture");
+  if (fixture) {
+    const bundle = await loadFixtureBundle(fixture);
+    return {
+      mode: "DEMO",
+      source: `fixture ${isAbsolute(fixture) ? fixture : resolvePath(process.cwd(), fixture)}`,
+      runtime: createRuntime({
+        status: bundle.status,
+        events: bundle.events,
+        capabilities: bundle.capabilities,
+        applyCommands: hasFlag(args, "--apply")
+      }),
+      configPath: resolveConfigPath(optionValue(args, "--config"))
+    };
+  }
+
+  const configPath = resolveConfigPath(optionValue(args, "--config"));
+  if (!existsSync(configPath)) {
+    return {
+      mode: "SETUP",
+      source: `config missing ${configPath}`,
+      runtime: createRuntime({
+        status: emptyStatusForMode("SETUP"),
+        applyCommands: hasFlag(args, "--apply")
+      }),
+      configPath
+    };
+  }
+
+  const discoveredEndpoints = await configEndpoints(configPath, args, io);
+  for (const discovered of discoveredEndpoints) {
+    try {
+      const bundle = await loadEndpointBundle(discovered, io);
+      return {
+        mode: "LIVE",
+        source: `endpoint ${discovered}`,
+        endpoint: discovered,
+        runtime: createRuntime({
+          status: bundle.status,
+          events: bundle.events,
+          applyCommands: hasFlag(args, "--apply")
+        }),
+        configPath
+      };
+    } catch {
+      // Continue to the next candidate endpoint.
+    }
+  }
+
+  return {
+    mode: "OFFLINE",
+    source: `config ${configPath}`,
+    runtime: createRuntime({
+      status: emptyStatusForMode("OFFLINE"),
+      applyCommands: hasFlag(args, "--apply")
+    }),
+    configPath
+  };
+}

--- a/src/v2/cockpit/interactive.ts
+++ b/src/v2/cockpit/interactive.ts
@@ -11,10 +11,11 @@
 import { createCockpitModel } from "./model.ts";
 import { renderCockpitText } from "./renderer.ts";
 import type { SymphonyRuntime } from "../daemon/runtime.ts";
-import type { CockpitModel, SymphonyStatus } from "../core/types.ts";
+import type { CockpitAdvancedCommand, CockpitApp, CockpitModel, CockpitSectionId, SymphonyStatus } from "../core/types.ts";
 
 export interface InteractiveCockpitOptions {
   runtime: SymphonyRuntime;
+  app?: CockpitApp;
   // Injected for tests; defaults to dynamically importing terminal-kit.
   terminalFactory?: () => Promise<TerminalLike>;
 }
@@ -47,6 +48,25 @@ const ACTION_KEY_TO_ID: Record<string, string> = {
   R: "card.rerun"
 };
 
+const SECTION_BY_KEY: Record<string, string> = {
+  f: "factory",
+  "1": "factory",
+  "2": "runs",
+  w: "worktrees",
+  "3": "worktrees",
+  d: "doctor",
+  "4": "doctor",
+  m: "manual",
+  "5": "manual",
+  e: "events",
+  "6": "events",
+  S: "settings",
+  "7": "settings",
+  "8": "advanced"
+};
+
+type PalettePrefix = "action" | "advanced";
+
 async function defaultTerminalFactory(): Promise<TerminalLike> {
   const mod = await import("terminal-kit");
   return (mod.terminal ?? (mod as { default?: { terminal: TerminalLike } }).default?.terminal) as TerminalLike;
@@ -71,6 +91,9 @@ export async function startInteractiveCockpit(
   let selectedIndex = 0;
   let filter: string | undefined;
   let statusLine = "Ready. Press ? for the Factory Manual, q to quit.";
+  let selectedSectionId: CockpitSectionId = "factory";
+  let commandPaletteOpen = false;
+  let palettePrefix: PalettePrefix | undefined;
   let resolveDone!: () => void;
   const done = new Promise<void>((resolve) => {
     resolveDone = resolve;
@@ -85,7 +108,10 @@ export async function startInteractiveCockpit(
       events: runtime.getEvents(20),
       capabilities: runtime.getCapabilities(),
       selectedId,
-      filter
+      filter,
+      selectedSectionId,
+      commandPaletteOpen,
+      app: options.app
     });
   }
 
@@ -117,10 +143,99 @@ export async function startInteractiveCockpit(
     statusLine = `${result.outcome.toUpperCase()}: ${result.message}`;
   }
 
+  function showAdvancedCommand(command: CockpitAdvancedCommand): void {
+    if (!command.enabled) {
+      statusLine = `${command.label} disabled: ${command.disabledReason ?? "unavailable"}`;
+      return;
+    }
+    statusLine = `${command.label}: ${command.command}`;
+  }
+
+  function dispatchPalette(prefix: PalettePrefix, key: string): void {
+    const current = model();
+    if (prefix === "action") {
+      const action = current.actions.find((entry) => entry.key === key);
+      if (!action) {
+        statusLine = `Palette action ${key} not available.`;
+        return;
+      }
+      submit(action.id);
+      return;
+    }
+
+    const command = current.advancedCommands.find((entry) => entry.key === key);
+    if (!command) {
+      statusLine = `Palette command ${key} not available.`;
+      return;
+    }
+    showAdvancedCommand(command);
+  }
+
+  function handlePaletteKey(name: string): boolean {
+    const directPaletteKey = /^([AV]):(.+)$/u.exec(name);
+    if (directPaletteKey) {
+      dispatchPalette(directPaletteKey[1] === "A" ? "action" : "advanced", directPaletteKey[2]);
+      palettePrefix = undefined;
+      commandPaletteOpen = false;
+      draw();
+      return true;
+    }
+
+    if (palettePrefix) {
+      const prefix = palettePrefix;
+      palettePrefix = undefined;
+      dispatchPalette(prefix, name);
+      commandPaletteOpen = false;
+      draw();
+      return true;
+    }
+
+    if (name === "A") {
+      palettePrefix = "action";
+      statusLine = "Palette action prefix: press an action key.";
+      draw();
+      return true;
+    }
+
+    if (name === "V") {
+      palettePrefix = "advanced";
+      statusLine = "Palette advanced prefix: press a command key.";
+      draw();
+      return true;
+    }
+
+    const sectionRow = model().commandPalette.find((row) => row.key === name && row.section);
+    if (sectionRow?.section) {
+      selectedSectionId = sectionRow.section;
+      commandPaletteOpen = false;
+      statusLine = `Section: ${selectedSectionId}`;
+      draw();
+      return true;
+    }
+
+    return false;
+  }
+
   function handleKey(name: string): void {
     const ids = selectableIds(runtime.getStatus());
+    if (commandPaletteOpen && handlePaletteKey(name)) {
+      return;
+    }
     if (name === "q" || name === "ESCAPE" || name === "CTRL_C") {
       cleanup();
+      return;
+    }
+    if (name === "CTRL_P") {
+      commandPaletteOpen = !commandPaletteOpen;
+      palettePrefix = undefined;
+      statusLine = commandPaletteOpen ? "Command palette open." : "Command palette closed.";
+      draw();
+      return;
+    }
+    if (name in SECTION_BY_KEY) {
+      selectedSectionId = SECTION_BY_KEY[name] as typeof selectedSectionId;
+      statusLine = `Section: ${selectedSectionId}`;
+      draw();
       return;
     }
     if (name === "r") {

--- a/src/v2/cockpit/model.ts
+++ b/src/v2/cockpit/model.ts
@@ -28,7 +28,14 @@ import {
 import type {
   Capability,
   CapabilitySummary,
+  CockpitAdvancedCommand,
+  CockpitApp,
+  CockpitMode,
+  CockpitNextAction,
+  CockpitPaletteRow,
   CockpitAction,
+  CockpitSection,
+  CockpitSectionId,
   CockpitEventSummary,
   CockpitLane,
   CockpitLaneCard,
@@ -38,11 +45,24 @@ import type {
   CockpitSelection,
   CockpitWorktreeSummary,
   OperatorCommand,
+  OperatorCommandType,
   RuntimeEvent,
   SymphonyStatus
 } from "../core/types.ts";
 
 const CARD_HAZARD_STATES = new Set(["failed", "blocked"]);
+const DEFAULT_SECTION_ID: CockpitSectionId = "factory";
+
+const DEFAULT_SECTIONS: CockpitSection[] = [
+  { id: "factory", label: "Factory", key: "f" },
+  { id: "runs", label: "Runs", key: "2" },
+  { id: "worktrees", label: "Worktrees", key: "w" },
+  { id: "doctor", label: "Doctor", key: "d" },
+  { id: "manual", label: "Manual", key: "m" },
+  { id: "events", label: "Events", key: "e" },
+  { id: "settings", label: "Settings", key: "S" },
+  { id: "advanced", label: "Advanced", key: "8" }
+];
 
 function matchesFilter(text: string, filter?: string): boolean {
   if (!filter) return true;
@@ -189,6 +209,178 @@ function buildSelection(status: SymphonyStatus, selectedId?: string): CockpitSel
   return { kind: "none", raw: { selectedId } };
 }
 
+function appShell(input: CockpitModelInput["app"]): CockpitApp {
+  return (
+    input ?? {
+      mode: "DEMO",
+      source: "unknown",
+      configPath: process.cwd(),
+      endpoint: undefined
+    }
+  );
+}
+
+function nextActions(mode: CockpitMode, app: CockpitApp): CockpitNextAction[] {
+  if (mode !== "SETUP" && mode !== "OFFLINE" && mode !== "DEMO") return [];
+  if (mode === "SETUP") {
+    return [
+      {
+        id: "setup",
+        label: "Run setup wizard",
+        command: `fizzy-symphony setup --config ${app.configPath}`,
+        enabled: false,
+        mutates: true,
+        disabledReason: "Guidance only; run this command in your shell."
+      }
+    ];
+  }
+  return [
+    {
+      id: "start",
+      label: mode === "OFFLINE"
+        ? "Start daemon"
+        : "Start daemon for demo data",
+      command: `fizzy-symphony start --config ${app.configPath}`,
+      enabled: false,
+      mutates: true,
+      disabledReason: "Guidance only; run this command in your shell."
+    }
+  ];
+}
+
+function settingsSummary(mode: CockpitMode, app: CockpitApp, status: SymphonyStatus) {
+  const workspaceCount = status.worktrees.length;
+  return {
+    configPath: app.configPath,
+    source: app.source,
+    mode,
+    endpoint: app.endpoint,
+    runnerStatus: status.readiness.runnerStatus,
+    readiness: status.readiness.state,
+    readinessBlockers: status.readiness.blockers.length,
+    workspaceCount,
+    dirtyWorktrees: status.worktrees.filter((worktree) => worktree.dirty).length,
+    boardCount: status.boards.length,
+    routeCount: status.routes.length,
+    hasLiveEndpoint: Boolean(app.endpoint)
+  };
+}
+
+function advancedCommands(input: CockpitModelInput): CockpitAdvancedCommand[] {
+  const app = appShell(input.app);
+  return [
+    {
+      id: "setup",
+      key: "x",
+      label: "setup",
+      command: `fizzy-symphony setup --config ${app.configPath}`,
+      enabled: false,
+      mutates: true,
+      disabledReason: "Guidance only; run this command in your shell."
+    },
+    {
+      id: "start",
+      key: "y",
+      label: "start",
+      command: `fizzy-symphony start --config ${app.configPath}`,
+      enabled: false,
+      mutates: true,
+      disabledReason: "Guidance only; run this command in your shell."
+    },
+    {
+      id: "status",
+      key: "z",
+      label: "status",
+      command: `fizzy-symphony status --config ${app.configPath}`,
+      enabled: true,
+      mutates: false
+    },
+    {
+      id: "dashboard",
+      key: "q",
+      label: "dashboard",
+      command: app.endpoint ? `${app.endpoint}/dashboard` : `fizzy-symphony dashboard --config ${app.configPath}`,
+      enabled: Boolean(app.endpoint),
+      mutates: false,
+      disabledReason: app.endpoint ? undefined : "No live endpoint connected."
+    },
+    {
+      id: "capabilities",
+      key: "c",
+      label: "capabilities",
+      command: `fizzy-symphony capabilities --config ${app.configPath}`,
+      enabled: true,
+      mutates: false
+    },
+    {
+      id: "worktrees",
+      key: "t",
+      label: "worktrees",
+      command: `fizzy-symphony worktrees --config ${app.configPath}`,
+      enabled: true,
+      mutates: false
+    },
+    {
+      id: "doctor",
+      key: "D",
+      label: "doctor",
+      command: `fizzy-symphony doctor --goal --config ${app.configPath}`,
+      enabled: true,
+      mutates: false
+    },
+    {
+      id: "cockpit-fixture",
+      key: "f",
+      label: "cockpit fixture",
+      command: "fizzy-symphony cockpit --fixture src/v2/fixtures/ready.json --once",
+      enabled: true,
+      mutates: false
+    }
+  ];
+}
+
+function commandPaletteRows(
+  input: CockpitModelInput,
+  sections: CockpitSection[],
+  actions: CockpitAction[]
+): CockpitPaletteRow[] {
+  const rows: CockpitPaletteRow[] = sections.map((section) => ({
+    id: `section.${section.id}`,
+    key: section.key,
+    label: `Open ${section.label} section`,
+    section: section.id,
+    enabled: true,
+    mutates: false,
+    disabledReason: undefined
+  }));
+
+  for (const action of actions) {
+    rows.push({
+      id: `action.${action.id}`,
+      key: `A:${action.key ?? "?"}`,
+      label: action.label,
+      enabled: action.enabled,
+      disabledReason: action.disabledReason,
+      mutates: Boolean(action.commandType),
+      command: action.commandType
+    });
+  }
+
+  for (const command of advancedCommands(input)) {
+    rows.push({
+      id: `advanced.${command.id}`,
+      key: `V:${command.key}`,
+      label: `${command.label} command`,
+      enabled: command.enabled,
+      disabledReason: command.disabledReason,
+      mutates: command.mutates,
+      endpoint: command.command
+    });
+  }
+
+  return rows;
+}
+
 function activeRunSummaries(status: SymphonyStatus): CockpitRunSummary[] {
   const summaries: CockpitRunSummary[] = [];
   for (const run of [...status.runs.running, ...status.runs.queued]) {
@@ -249,6 +441,7 @@ function capabilitySummaries(capabilities: Capability[]): CapabilitySummary[] {
 
 interface ActionSpec {
   id: string;
+  commandType: OperatorCommandType;
   key: string;
   label: string;
   command: (selection?: CockpitSelection) => OperatorCommand | undefined;
@@ -257,18 +450,21 @@ interface ActionSpec {
 const ACTION_SPECS: ActionSpec[] = [
   {
     id: "dispatch.pause",
+    commandType: "dispatch.pause",
     key: "p",
     label: "Lock factory (pause dispatch)",
     command: () => ({ type: "dispatch.pause" })
   },
   {
     id: "dispatch.resume",
+    commandType: "dispatch.resume",
     key: "u",
     label: "Unlock factory (resume dispatch)",
     command: () => ({ type: "dispatch.resume" })
   },
   {
     id: "run.cancel",
+    commandType: "run.cancel",
     key: "c",
     label: "Cancel selected run",
     command: (selection) =>
@@ -278,6 +474,7 @@ const ACTION_SPECS: ActionSpec[] = [
   },
   {
     id: "session.stop",
+    commandType: "session.stop",
     key: "s",
     label: "Stop selected session",
     command: (selection) =>
@@ -287,6 +484,7 @@ const ACTION_SPECS: ActionSpec[] = [
   },
   {
     id: "card.rerun",
+    commandType: "card.rerun",
     key: "R",
     label: "Request rerun of selected card",
     command: (selection) =>
@@ -302,6 +500,7 @@ function buildActions(status: SymphonyStatus, selection?: CockpitSelection): Coc
     if (!command) {
       return {
         id: spec.id,
+        commandType: spec.commandType,
         key: spec.key,
         label: spec.label,
         enabled: false,
@@ -311,7 +510,7 @@ function buildActions(status: SymphonyStatus, selection?: CockpitSelection): Coc
     const availability = checkCommandAvailability(command, status);
     return {
       id: spec.id,
-      commandType: command.type,
+      commandType: spec.commandType,
       key: spec.key,
       label: spec.label,
       enabled: availability.available,
@@ -350,7 +549,15 @@ const HELP_KEYS: Array<{ key: string; description: string }> = [
   { key: "c", description: "cancel selected run (if available)" },
   { key: "s", description: "stop selected session (if available)" },
   { key: "R", description: "request rerun (if available)" },
-  { key: "m", description: "move selected card (if available)" }
+  { key: "m", description: "move selected card (if available)" },
+  { key: "1 / f", description: "factory section" },
+  { key: "2", description: "runs section" },
+  { key: "3 / w", description: "worktrees section" },
+  { key: "4 / d", description: "doctor section" },
+  { key: "5 / m", description: "manual section" },
+  { key: "6 / e", description: "events section" },
+  { key: "7 / S", description: "settings section" },
+  { key: "8", description: "advanced section" }
 ];
 
 export function createCockpitModel(input: CockpitModelInput): CockpitModel {
@@ -367,6 +574,11 @@ export function createCockpitModel(input: CockpitModelInput): CockpitModel {
   const lanes = buildLanes(status, input.filter);
   const selection = buildSelection(status, input.selectedId);
   const actions = buildActions(status, selection);
+  const sections = input.sections && input.sections.length > 0 ? input.sections : DEFAULT_SECTIONS;
+  const selectedSectionId = input.selectedSectionId ?? DEFAULT_SECTION_ID;
+  const paletteOpen = input.commandPaletteOpen ?? false;
+  const app = appShell(input.app);
+  const mode = app.mode;
 
   const dirtyWorktrees = status.worktrees.filter((worktree) => worktree.dirty).length;
 
@@ -390,6 +602,14 @@ export function createCockpitModel(input: CockpitModelInput): CockpitModel {
   };
 
   return {
+    app,
+    sections,
+    selectedSectionId,
+    nextActions: nextActions(mode, app),
+    settings: settingsSummary(mode, app, status),
+    commandPaletteOpen: paletteOpen,
+    commandPalette: commandPaletteRows(input, sections, actions),
+    advancedCommands: advancedCommands(input),
     header,
     factoryState,
     lanes,

--- a/src/v2/cockpit/renderer.ts
+++ b/src/v2/cockpit/renderer.ts
@@ -29,46 +29,122 @@ function fmtCounts(counts: CockpitModel["header"]["counts"]): string {
   ].join("  ");
 }
 
-export function renderCockpitText(model: CockpitModel): string {
+function renderSectionTabs(model: CockpitModel): string[] {
+  return [
+    hr("SECTIONS"),
+    model.sections
+      .map((section) =>
+        `${section.id === model.selectedSectionId ? ">" : " "} ${section.key}: ${section.label}`
+      )
+      .join(" | ")
+  ];
+}
+
+function renderSelectedSection(model: CockpitModel): string[] {
+  const sectionId = model.selectedSectionId;
   const lines: string[] = [];
-  const header = model.header;
+  const sectionLabel = model.sections.find((entry) => entry.id === sectionId)?.label ?? sectionId;
+  lines.push(hr(`SECTION: ${sectionLabel}`));
 
-  lines.push(hr("FIZZY-SYMPHONY COCKPIT (v2 spike)"));
-  lines.push(
-    `instance: ${header.instanceId}${header.instanceLabel ? ` (${header.instanceLabel})` : ""}` +
-      `   endpoint: ${header.endpoint ?? "—"}`
-  );
-  lines.push(
-    `readiness: ${header.readiness}   factory: ${FACTORY_STATE_LABELS[model.factoryState]}` +
-      `   runner: ${header.runnerStatus ?? "unknown"}`
-  );
-  lines.push(`updated: ${header.lastUpdatedAt}`);
-  lines.push(fmtCounts(header.counts));
-
-  lines.push("");
-  lines.push(hr("BOARD / FACTORY LANES"));
-  if (model.lanes.length === 0) {
-    lines.push("  (no routes)");
-  }
-  for (const lane of model.lanes) {
-    const laneState = lane.enabled ? "" : `  [disabled: ${lane.disabledReason ?? "unknown"}]`;
-    lines.push(`▣ ${lane.title}  «${lane.factoryLine}»  [route ${lane.routeId}]${laneState}`);
-    if (lane.cards.length === 0) {
-      lines.push("    (no cards)");
+  if (sectionId === "factory") {
+    lines.push(hr("FACTORY LANES"));
+    if (model.lanes.length === 0) {
+      lines.push("  (no routes)");
     }
-    for (const card of lane.cards) {
-      const hazard = card.hazard ? " ⚠" : "";
-      const num = card.number !== undefined ? `#${card.number} ` : "";
+    for (const lane of model.lanes) {
+      const laneState = lane.enabled ? "" : `  [disabled: ${lane.disabledReason ?? "unknown"}]`;
+      lines.push(`▣ ${lane.title}  «${lane.factoryLine}»  [route ${lane.routeId}]${laneState}`);
+      if (lane.cards.length === 0) lines.push("  (no cards)");
+      for (const card of lane.cards) {
+        const hazard = card.hazard ? " ⚠" : "";
+        const num = card.number !== undefined ? `#${card.number} ` : "";
+        lines.push(
+          `    • ${card.themeLabel}: ${num}${card.title} [${card.state}]${hazard}` +
+            `  (card ${card.id}${card.runId ? `, run ${card.runId}` : ""})`
+        );
+        if (card.attention) lines.push(`        attention: ${card.attention}`);
+      }
+    }
+  }
+
+  if (sectionId === "runs") {
+    lines.push(hr("RUNS"));
+    if (model.panels.activeRuns.length === 0) lines.push("  (none)");
+    for (const run of model.panels.activeRuns) {
+      const stall = run.stalled ? " [STALLED]" : "";
+      const err = run.error ? `  err=${run.error.code}: ${run.error.message}` : "";
       lines.push(
-        `    • ${card.themeLabel}: ${num}${card.title} [${card.state}]${hazard}` +
-          `  (card ${card.id}${card.runId ? `, run ${card.runId}` : ""})`
+        `  ${run.themeLabel}: run ${run.id} [${run.state}]${stall}` +
+          `${run.cardNumber !== undefined ? ` card #${run.cardNumber}` : ""}${err}`
       );
-      if (card.attention) lines.push(`        attention: ${card.attention}`);
     }
   }
 
+  if (sectionId === "worktrees") {
+    lines.push(hr("WORKTREES"));
+    if (model.panels.worktrees.length === 0) lines.push("  (no worktrees)");
+    for (const worktree of model.panels.worktrees) {
+      const flags = [worktree.dirty ? "dirty" : null, worktree.preserved ? "preserved" : null]
+        .filter(Boolean)
+        .join(",") || "clean";
+      lines.push(`  ${worktree.themeLabel}: ${worktree.workspaceKey} [${flags}] ${worktree.path}`);
+      if (worktree.recommendedAction) lines.push(`      action: ${worktree.recommendedAction}`);
+    }
+  }
+
+  if (sectionId === "doctor") {
+    lines.push(hr("DOCTOR"));
+    lines.push(`goalClosable=${model.panels.doctor.goalClosable}  ${model.panels.doctor.themeLabel}`);
+    for (const blocker of model.panels.doctor.blockers) {
+      lines.push(`  ${blocker.code}: ${blocker.message}`);
+    }
+    if (model.panels.doctor.blockers.length === 0) {
+      lines.push("  no doctor blockers");
+    }
+  }
+
+  if (sectionId === "manual") {
+    lines.push(hr("FACTORY MANUAL"));
+    lines.push(model.help.manualTitle);
+  }
+
+  if (sectionId === "events") {
+    lines.push(hr("EVENTS"));
+    if (model.panels.events.length === 0) lines.push("  (no events)");
+    for (const event of model.panels.events.slice(0, 12)) {
+      lines.push(`  [${event.severity}] ${event.themeLabel}: ${event.message}  (${event.at})`);
+    }
+  }
+
+  if (sectionId === "settings") {
+    lines.push(hr("SETTINGS"));
+    lines.push(`source: ${model.settings.source}`);
+    lines.push(`configPath: ${model.settings.configPath}`);
+    lines.push(`mode: ${model.settings.mode}`);
+    lines.push(`endpoint: ${model.settings.endpoint ?? "—"}`);
+    lines.push(`runner: ${model.settings.runnerStatus ?? "unknown"}`);
+    lines.push(`readiness: ${model.settings.readiness}`);
+    lines.push(`blocks: ${model.settings.readinessBlockers}`);
+    lines.push(`workspace: total=${model.settings.workspaceCount}  dirty=${model.settings.dirtyWorktrees}`);
+    lines.push(`boards=${model.settings.boardCount}  routes=${model.settings.routeCount}`);
+    lines.push(`hasLiveEndpoint=${model.settings.hasLiveEndpoint}`);
+  }
+
+  if (sectionId === "advanced") {
+    lines.push(hr("ADVANCED COMMANDS"));
+    for (const command of model.advancedCommands) {
+      const state = command.enabled ? "enabled" : `disabled: ${command.disabledReason ?? "n/a"}`;
+      const mutates = command.mutates ? "mutates" : "read-only";
+      lines.push(`  [${command.key}] ${command.label}: ${command.command} (${state}, ${mutates})`);
+    }
+  }
+
+  return lines;
+}
+
+function renderLegacySummary(model: CockpitModel): string[] {
+  const lines: string[] = [];
   if (model.selected) {
-    lines.push("");
     lines.push(hr("SELECTED DETAIL (raw truth)"));
     lines.push(`kind: ${model.selected.kind}   theme: ${model.selected.themeLabel ?? "—"}`);
     for (const [key, value] of Object.entries(model.selected.raw)) {
@@ -78,9 +154,9 @@ export function renderCockpitText(model: CockpitModel): string {
     if (model.selected.recommendedAction) {
       lines.push(`  recommendedAction: ${model.selected.recommendedAction}`);
     }
+    lines.push("");
   }
 
-  lines.push("");
   lines.push(hr("ACTIVE RUNS"));
   if (model.panels.activeRuns.length === 0) lines.push("  (none)");
   for (const run of model.panels.activeRuns) {
@@ -112,18 +188,83 @@ export function renderCockpitText(model: CockpitModel): string {
     lines.push(`  [${event.severity}] ${event.themeLabel}: ${event.message}  (${event.at})`);
   }
 
-  lines.push("");
-  lines.push(hr("ACTIONS"));
+  return lines;
+}
+
+function renderActions(model: CockpitModel): string[] {
+  const lines: string[] = [hr("ACTIONS")];
   for (const action of model.actions) {
-    const state = action.enabled
-      ? "enabled"
-      : `disabled: ${action.disabledReason ?? "unavailable"}`;
+    const state = action.enabled ? "enabled" : `disabled: ${action.disabledReason ?? "unavailable"}`;
     lines.push(`  [${action.key ?? "?"}] ${action.label} — ${state}`);
   }
+  return lines;
+}
+
+function renderFooter(model: CockpitModel): string[] {
+  return [
+    hr("FOOTER / KEYS"),
+    model.help.keys.map((entry) => `${entry.key}:${entry.description}`).join("   ")
+  ];
+}
+
+function renderCommandPalette(model: CockpitModel): string[] {
+  if (!model.commandPaletteOpen) return [];
+  const lines: string[] = [hr("COMMAND PALETTE")];
+  for (const row of model.commandPalette) {
+    const state = row.enabled ? "enabled" : `disabled: ${row.disabledReason ?? "unavailable"}`;
+    const mutates = row.mutates ? "mutates" : "read-only";
+    const backing = row.endpoint ?? row.command ?? row.section;
+    lines.push(`  [${row.key}] ${row.label} — ${state}, ${mutates}${backing ? ` (${backing})` : ""}`);
+  }
+  return lines;
+}
+
+function renderNextActions(model: CockpitModel): string[] {
+  if (model.nextActions.length === 0) return [];
+  const lines: string[] = [hr("NEXT ACTIONS")];
+  for (const action of model.nextActions) {
+    const state = action.enabled ? "enabled" : `disabled: ${action.disabledReason ?? "n/a"}`;
+    lines.push(
+      `  ${action.label}: ${action.command} (${state}, ${action.mutates ? "mutates" : "read-only"})`
+    );
+  }
+  return lines;
+}
+
+export function renderCockpitText(model: CockpitModel): string {
+  const lines: string[] = [];
+  const header = model.header;
+
+  lines.push(hr("FIZZY-SYMPHONY COCKPIT (v2 spike)"));
+  lines.push(`Mode: ${model.app.mode}`);
+  lines.push(`Source: ${model.app.source}`);
+  lines.push(`Endpoint: ${model.app.endpoint ?? "—"}`);
+  lines.push(`Config: ${model.app.configPath}`);
+  lines.push(
+    `instance: ${header.instanceId}${header.instanceLabel ? ` (${header.instanceLabel})` : ""}` +
+      ``
+  );
+  lines.push(
+    `readiness=${header.readiness} factory=${FACTORY_STATE_LABELS[model.factoryState]}` +
+      ` runner=${header.runnerStatus ?? "unknown"}`
+  );
+  lines.push(`updated: ${header.lastUpdatedAt}`);
+  lines.push(fmtCounts(header.counts));
 
   lines.push("");
-  lines.push(hr("FOOTER / KEYS"));
-  lines.push(model.help.keys.map((entry) => `${entry.key}:${entry.description}`).join("   "));
+  lines.push(...renderSectionTabs(model));
+  lines.push("");
+  lines.push(...renderNextActions(model));
+  lines.push("");
+  lines.push(...renderSelectedSection(model));
+  lines.push("");
+  lines.push(...renderLegacySummary(model));
+  lines.push("");
+  lines.push(...renderActions(model));
+  lines.push("");
+  lines.push(...renderFooter(model));
+  lines.push("");
+  lines.push(...renderCommandPalette(model));
 
   return lines.join("\n");
 }

--- a/src/v2/core/types.ts
+++ b/src/v2/core/types.ts
@@ -300,6 +300,68 @@ export interface CommandResult {
 // ---------------------------------------------------------------------------
 
 export type FactoryState = "open" | "running" | "blocked" | "locked" | "unknown";
+export type CockpitMode = "SETUP" | "OFFLINE" | "LIVE" | "DEMO";
+export type CockpitSectionId = "factory" | "runs" | "worktrees" | "doctor" | "manual" | "events" | "settings" | "advanced";
+
+export interface CockpitApp {
+  mode: CockpitMode;
+  source: string;
+  configPath: string;
+  endpoint?: string | null;
+}
+
+export interface CockpitSection {
+  id: CockpitSectionId;
+  label: string;
+  key: string;
+  shortcutHint?: string;
+}
+
+export interface CockpitNextAction {
+  id: string;
+  label: string;
+  command: string;
+  enabled: boolean;
+  mutates: boolean;
+  disabledReason?: string;
+}
+
+export interface CockpitSettingsSummary {
+  configPath: string;
+  source: string;
+  mode: CockpitMode;
+  endpoint?: string | null;
+  runnerStatus?: string;
+  readiness: ReadinessState;
+  readinessBlockers: number;
+  workspaceCount: number;
+  dirtyWorktrees: number;
+  boardCount: number;
+  routeCount: number;
+  hasLiveEndpoint: boolean;
+}
+
+export interface CockpitAdvancedCommand {
+  id: string;
+  key: string;
+  label: string;
+  command: string;
+  enabled: boolean;
+  mutates: boolean;
+  disabledReason?: string;
+}
+
+export interface CockpitPaletteRow {
+  id: string;
+  key: string;
+  label: string;
+  section?: CockpitSectionId;
+  enabled: boolean;
+  disabledReason?: string;
+  mutates: boolean;
+  command?: OperatorCommandType;
+  endpoint?: string;
+}
 
 export interface CockpitHeader {
   instanceId: string;
@@ -408,6 +470,14 @@ export interface CockpitHelp {
 }
 
 export interface CockpitModel {
+  app: CockpitApp;
+  sections: CockpitSection[];
+  selectedSectionId: CockpitSectionId;
+  nextActions: CockpitNextAction[];
+  settings: CockpitSettingsSummary;
+  commandPaletteOpen: boolean;
+  commandPalette: CockpitPaletteRow[];
+  advancedCommands: CockpitAdvancedCommand[];
   header: CockpitHeader;
   factoryState: FactoryState;
   lanes: CockpitLane[];
@@ -429,6 +499,10 @@ export interface CockpitModelInput {
   capabilities?: Capability[];
   selectedId?: string;
   filter?: string;
+  app?: CockpitApp;
+  sections?: CockpitSection[];
+  selectedSectionId?: CockpitSectionId;
+  commandPaletteOpen?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/v2/daemon/status-bridge.ts
+++ b/src/v2/daemon/status-bridge.ts
@@ -137,8 +137,10 @@ function projectRoute(snapshot: Record<string, any>) {
     goldenCardNumber: route.golden_card_number ?? route.goldenCardNumber,
     backend: route.backend,
     model: route.model,
-    enabled: runnerStatus !== "unavailable",
-    disabledReason: runnerStatus === "unavailable" ? "Runner unavailable" : undefined
+    enabled: route.enabled === undefined ? runnerStatus !== "unavailable" : Boolean(route.enabled),
+    disabledReason: route.enabled === false
+      ? route.disabledReason ?? "Route disabled"
+      : runnerStatus === "unavailable" ? "Runner unavailable" : undefined
   });
 }
 

--- a/src/validation.js
+++ b/src/validation.js
@@ -8,6 +8,14 @@ const AGENT_INSTRUCTIONS = "agent-instructions";
 const AGENT_BOARD = "agent-board";
 const SUPPORTED_SDK_RUNNERS = [];
 
+const KNOWN_BACKEND_TAGS = ["claude", "codex", "opencode", "anthropic", "openai", "command"];
+const MANAGED_TAG_FAMILIES = Object.freeze({
+  "agent-instructions": "scope",
+  "close-on-complete": "completion",
+  "comment-once": "completion",
+  "no-repeat": "completion"
+});
+
 const defaultAllowedCardOverrides = {
   backend: false,
   model: false,
@@ -122,17 +130,9 @@ export function parseGoldenTicketRoute(board, card, options = {}) {
   const sourceColumnId = getColumnId(card);
   const sourceColumn = findColumn(board, sourceColumnId);
 
-  const backend = parseSingleFamily(tags, "backend", (tag) => {
-    if (tag === "codex" || tag === "backend-codex") return "codex";
-    if (tag.startsWith("backend-")) {
-      throw new FizzySymphonyError("INVALID_BACKEND_TAG", "Only Codex backend tags are valid for MVP routes.", {
-        board_id: board.id,
-        card_id: card.id,
-        tag
-      });
-    }
-    return null;
-  }) ?? options.defaults?.backend ?? "codex";
+  const backend = parseSingleFamily(tags, "backend", (tag) => parseBackendTag(tag, board, card)) ??
+    parseDefaultBackend(options.defaults?.backend, board, card) ??
+    "codex";
 
   const model = parseSingleFamily(tags, "model", (tag) => tagValue(tag, "model-")) ?? options.defaults?.model ?? "";
   const workspace = parseSingleFamily(tags, "workspace", (tag) => tagValue(tag, "workspace-")) ?? options.defaults?.workspace ?? "app";
@@ -154,6 +154,10 @@ export function parseGoldenTicketRoute(board, card, options = {}) {
     source_column_name: sourceColumn?.name ?? sourceColumnId,
     golden_card_id: card.id,
     backend,
+    enabled: isExecutableBackend(backend),
+    disabledReason: isExecutableBackend(backend)
+      ? undefined
+      : `Execution for backend ${backend} is not wired yet.`,
     model,
     workspace,
     persona,
@@ -821,6 +825,37 @@ function validateCompletionGraph(routes) {
   }
 }
 
+function parseBackendTag(tag, board, card) {
+  if (KNOWN_BACKEND_TAGS.includes(tag)) return tag;
+  if (!tag.startsWith("backend-")) return null;
+
+  const alias = tagValue(tag, "backend-");
+  if (alias && KNOWN_BACKEND_TAGS.includes(alias)) return alias;
+
+  throw new FizzySymphonyError("INVALID_BACKEND_TAG", "Backend tag is not one of the supported route backends.", {
+    board_id: board.id,
+    card_id: card.id,
+    tag
+  });
+}
+
+function parseDefaultBackend(value, board, card) {
+  if (!value) return undefined;
+  const normalized = normalizeTag(value);
+  if (KNOWN_BACKEND_TAGS.includes(normalized)) return normalized;
+  const backendAlias = tagValue(normalized, "backend-");
+  if (backendAlias && KNOWN_BACKEND_TAGS.includes(backendAlias)) return backendAlias;
+  throw new FizzySymphonyError("INVALID_BACKEND_TAG", "Default route backend is not one of the supported route backends.", {
+    board_id: board.id,
+    card_id: card.id,
+    tag: value
+  });
+}
+
+function isExecutableBackend(backend = "") {
+  return backend === "codex";
+}
+
 function parseSingleFamily(tags, family, parser) {
   const values = new Map();
   for (const tag of tags) {
@@ -841,8 +876,8 @@ function parseSingleFamily(tags, family, parser) {
 
 function rejectUnknownManagedTags(tags, board, card, options) {
   const unknown = tags.filter((tag) => {
+    if (Object.hasOwn(managedTagFamilies(), tag)) return false;
     if (tag === AGENT_INSTRUCTIONS || tag === AGENT_BOARD || tag === "agent-rerun") return false;
-    if (tag === "codex" || tag === "backend-codex") return false;
     if (tag === "close-on-complete" || tag === "comment-once" || tag === "no-repeat") return false;
     if (/^(model|workspace|persona)-[^-].*/u.test(tag)) return false;
     if (/^priority-[1-5]$/u.test(tag)) return false;
@@ -863,12 +898,8 @@ function rejectUnknownManagedTags(tags, board, card, options) {
 
 function managedTagFamilies() {
   return {
-    "agent-instructions": "scope",
-    "backend-codex": "backend",
-    codex: "backend",
-    "close-on-complete": "completion",
-    "comment-once": "completion",
-    "no-repeat": "completion"
+    ...Object.fromEntries(KNOWN_BACKEND_TAGS.map((tag) => [[tag, "backend"], [`backend-${tag}`, "backend"]] ).flat()),
+    ...MANAGED_TAG_FAMILIES
   };
 }
 
@@ -894,7 +925,10 @@ function routeOptionsFromConfig(config) {
 
 function routeOptionsFromBoardEntry(board, config) {
   return {
-    defaults: board?.defaults,
+    defaults: {
+      backend: config.agent?.default_backend,
+      ...(board?.defaults ?? {})
+    },
     allowed_card_overrides: board?.defaults?.allowed_card_overrides ?? defaultAllowedCardOverrides,
     unknownManagedTagPolicy: board?.defaults?.unknown_managed_tag_policy,
     rerun_policy: config.routing?.rerun

--- a/test/cli-production-clients.test.js
+++ b/test/cli-production-clients.test.js
@@ -575,6 +575,7 @@ test("public help exits successfully", async () => {
 
     assert.equal(result.exitCode, 0, result.stderr);
     assert.match(result.stdout, /Usage:/u);
+    assert.match(result.stdout, /fizzy-symphony \[--config path\]/u);
     assert.match(result.stdout, /--max-agents n/u);
     assert.match(result.stdout, /--reasoning-effort level/u);
     assert.doesNotMatch(result.stdout, /fizzy-symphony init/u);
@@ -671,32 +672,68 @@ test("implicit setup friendly errors are premium plain text under NO_COLOR and C
   assert.doesNotMatch(result.stderr, /\x1b\[/u);
 });
 
-test("bare command opens dashboard when config exists", async () => {
+test("bare command opens cockpit LIVE when config exists", async () => {
   const dir = await setupWorkspace("fizzy-symphony-cli-bare-dashboard-");
   const configPath = await writeConfig(dir);
+  const requested = [];
 
   const result = await runCli(["--config", configPath, "--endpoint", "http://127.0.0.1:4567", "--once"], {
     env: {},
-    fetch: async () => ({
-      ok: true,
-      json: async () => ({
-        instance: { id: "instance-a" },
-        readiness: { ready: true },
-        runner_health: { status: "ready", kind: "cli_app_server" },
-        watched_boards: [],
-        routes: [],
-        active_runs: [],
-        claims: [],
-        workpads: [],
-        recent_failures: [],
-        recent_completions: [],
-        validation: { warnings: [], errors: [] }
-      })
-    })
+    fetch: async (url) => {
+      requested.push(String(url));
+      return {
+        ok: true,
+        json: async () => String(url).endsWith("/v2/events")
+          ? { events: [] }
+          : {
+              instance: { id: "instance-a", endpoint: "http://127.0.0.1:4567" },
+              readiness: { state: "ready", ready: true, blockers: [], runnerStatus: "ready" },
+              boards: [],
+              routes: [],
+              cards: [],
+              runs: { queued: [], running: [], completed: [], failed: [], cancelled: [], preempted: [] },
+              claims: [],
+              worktrees: [],
+              retryQueue: [],
+              capacityRefusals: [],
+              doctor: { goalClosable: true, blockers: [] },
+              warnings: [],
+              recentEvents: [],
+              lastUpdatedAt: "2026-05-31T00:00:00.000Z"
+            }
+      };
+    }
   });
 
   assert.equal(result.exitCode, 0, result.stderr);
-  assert.match(result.stdout, /fizzy-symphony dashboard/u);
+  assert.deepEqual(requested, [
+    "http://127.0.0.1:4567/v2/status",
+    "http://127.0.0.1:4567/v2/events"
+  ]);
+  assert.match(result.stdout, /Mode: LIVE/u);
+  assert.match(result.stdout, /FIZZY-SYMPHONY COCKPIT/u);
+});
+
+test("bare command with missing config enters cockpit SETUP without constructing clients", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-cli-bare-setup-"));
+  const result = await runCli(["--config", join(dir, ".fizzy-symphony", "config.yml"), "--once"], {
+    env: {},
+    clientFactories: {
+      createFizzyClient() {
+        throw new Error("bare setup cockpit should not construct Fizzy clients");
+      },
+      createRunner() {
+        throw new Error("bare setup cockpit should not construct runner clients");
+      }
+    },
+    fetch: async () => {
+      throw new Error("bare setup cockpit should not fetch without config");
+    }
+  });
+
+  assert.equal(result.exitCode, 0, result.stderr);
+  assert.match(result.stdout, /Mode: SETUP/u);
+  assert.match(result.stdout, /fizzy-symphony setup/u);
 });
 
 test("bare command rejects unknown leading flags instead of entering setup", async () => {

--- a/test/daemon.test.js
+++ b/test/daemon.test.js
@@ -339,6 +339,8 @@ test("daemon serves v2 status for live cockpit and capabilities discovery", asyn
     let stdout = "";
     let stderr = "";
     const exitCode = await runCockpitCommand([
+      "--config",
+      configPath,
       "--registry-dir",
       daemon.config.server.registry_dir,
       "--no-default-endpoint",

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -102,6 +102,19 @@ test("routeCard ignores cards that are not on a watched board or routed column",
   );
 });
 
+test("routeCard ignores disabled routes before dispatch", () => {
+  const decision = routeCard({
+    board: board(),
+    card: card(),
+    routes: [route({ enabled: false, disabledReason: "Execution for backend claude is not wired yet." })],
+    config: config()
+  });
+
+  assert.equal(decision.action, "ignore");
+  assert.equal(decision.reason, "route-disabled");
+  assert.equal(decision.route.disabledReason, "Execution for backend claude is not wired yet.");
+});
+
 test("routeCard ignores closed and postponed cards unless postponed dispatch is allowed", () => {
   assert.equal(
     routeCard({

--- a/test/v2/cockpit-cli.test.js
+++ b/test/v2/cockpit-cli.test.js
@@ -30,29 +30,144 @@ test("cockpit --once prints a static frame (non-TTY safe)", async () => {
   const { io, out } = bufferIo({ stdoutIsTTY: false });
   const code = await runCockpitCommand(["--fixture", join(FIXTURE_DIR, "running-one-card.json"), "--once"], io);
   assert.equal(code, 0);
+  assert.match(out(), /Mode: DEMO/);
   assert.match(out(), /FIZZY-SYMPHONY COCKPIT/);
   assert.match(out(), /Machine in motion/);
   assert.match(out(), /run_426/);
 });
 
-test("cockpit --once works from the packaged default fixture", async () => {
+test("cockpit --fixture packaged ready data stays DEMO", async () => {
   assert.equal(existsSync(PACKAGED_READY_FIXTURE), true);
   const { io, out } = bufferIo({
     stdoutIsTTY: false,
     fetch: async () => ({ ok: false, status: 404 })
   });
-  const code = await runCockpitCommand(["--once"], io);
+  const code = await runCockpitCommand(["--fixture", PACKAGED_READY_FIXTURE, "--once"], io);
   assert.equal(code, 0);
+  assert.match(out(), /Mode: DEMO/);
   assert.match(out(), /Factory open/);
 });
 
-test("cockpit with no explicit source discovers a live v2 daemon from the registry", async () => {
+test("cockpit without config enters setup without external clients", async () => {
   const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-v2-cockpit-"));
+  const requested = [];
+  const { io, out } = bufferIo({
+    stdoutIsTTY: false,
+    fetch: async (url) => {
+      requested.push(String(url));
+      return { ok: true, json: async () => ({}) };
+    }
+  });
+
+  const code = await runCockpitCommand(["--config", join(dir, "config.yml"), "--once"], io);
+  assert.equal(code, 0);
+  assert.equal(requested.length, 0);
+  assert.match(out(), /Mode: SETUP/);
+  assert.match(out(), /setup/);
+});
+
+test("cockpit with config exists but no daemon/default disabled enters OFFLINE", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-v2-cockpit-offline-"));
+  const configPath = join(dir, "config.json");
+  await writeFile(configPath, `${JSON.stringify({
+    server: { registry_dir: dir, host: "127.0.0.1", port: 4567 }
+  })}\n`, "utf8");
+  const { io, out } = bufferIo({
+    stdoutIsTTY: false
+  });
+  const code = await runCockpitCommand([
+    "--config",
+    configPath,
+    "--registry-dir",
+    dir,
+    "--no-default-endpoint",
+    "--once"
+  ], io);
+  assert.equal(code, 0);
+  assert.match(out(), /Mode: OFFLINE/);
+  assert.match(out(), /start.*daemon/i);
+});
+
+test("cockpit with config can reach LIVE through default endpoint fallback without secrets", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-v2-cockpit-default-live-"));
+  const configPath = join(dir, "config.json");
+  await writeFile(configPath, `${JSON.stringify({
+    server: { registry_dir: join(dir, "empty-registry"), host: "127.0.0.1", port: 4567 }
+  })}\n`, "utf8");
+  const bundle = JSON.parse(await readFile(join(FIXTURE_DIR, "running-one-card.json"), "utf8"));
+  const requested = [];
+  const { io, out } = bufferIo({
+    stdoutIsTTY: false,
+    fetch: async (url) => {
+      requested.push(String(url));
+      return {
+        ok: true,
+        json: async () => String(url).endsWith("/v2/events") ? { events: bundle.events ?? [] } : bundle.status
+      };
+    }
+  });
+
+  const code = await runCockpitCommand(["--config", configPath, "--once"], io);
+
+  assert.equal(code, 0);
+  assert.deepEqual(requested, [
+    "http://127.0.0.1:4567/v2/status",
+    "http://127.0.0.1:4567/v2/events"
+  ]);
+  assert.match(out(), /Mode: LIVE/);
+  assert.match(out(), /run_426/);
+});
+
+test("cockpit with config enters OFFLINE when default endpoint is unreachable", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-v2-cockpit-default-offline-"));
+  const configPath = join(dir, "config.json");
+  await writeFile(configPath, `${JSON.stringify({
+    server: { registry_dir: join(dir, "empty-registry"), host: "127.0.0.1", port: 4567 }
+  })}\n`, "utf8");
+  const requested = [];
+  const { io, out } = bufferIo({
+    stdoutIsTTY: false,
+    fetch: async (url) => {
+      requested.push(String(url));
+      return { ok: false, status: 503, json: async () => ({}) };
+    }
+  });
+
+  const code = await runCockpitCommand(["--config", configPath, "--once"], io);
+
+  assert.equal(code, 0);
+  assert.deepEqual(requested, ["http://127.0.0.1:4567/v2/status"]);
+  assert.match(out(), /Mode: OFFLINE/);
+  assert.match(out(), /start.*daemon/i);
+});
+
+test("cockpit --endpoint strict failure exits nonzero and does not fall back", async () => {
+  const requested = [];
+  const { io, err } = bufferIo({
+    stdoutIsTTY: false,
+    fetch: async (url) => {
+      requested.push(String(url));
+      return { ok: false, status: 503, json: async () => ({}) };
+    }
+  });
+
+  const code = await runCockpitCommand(["--endpoint", "http://127.0.0.1:49203", "--once"], io);
+  assert.equal(code, 1);
+  assert.match(err(), /failed to load source/);
+  assert.deepEqual(requested, ["http://127.0.0.1:49203/v2/status"]);
+});
+
+test("cockpit with config discovers a live v2 daemon from the registry", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fizzy-symphony-v2-cockpit-"));
+  const configPath = join(dir, "config.json");
   const endpoint = "http://127.0.0.1:49177";
+  const now = new Date().toISOString();
+  await writeFile(configPath, `${JSON.stringify({ server: { registry_dir: dir } })}\n`, "utf8");
   await writeFile(join(dir, "instance-a.json"), `${JSON.stringify({
     instance_id: "instance-a",
     endpoint: { base_url: endpoint },
-    updated_at: "2026-04-29T12:00:00.000Z"
+    heartbeat_at: now,
+    updated_at: now
   })}\n`, "utf8");
   const bundle = JSON.parse(await readFile(join(FIXTURE_DIR, "running-one-card.json"), "utf8"));
   const requested = [];
@@ -67,10 +182,18 @@ test("cockpit with no explicit source discovers a live v2 daemon from the regist
     }
   });
 
-  const code = await runCockpitCommand(["--registry-dir", dir, "--no-default-endpoint", "--once"], io);
+  const code = await runCockpitCommand([
+    "--config",
+    configPath,
+    "--registry-dir",
+    dir,
+    "--no-default-endpoint",
+    "--once"
+  ], io);
 
   assert.equal(code, 0);
   assert.deepEqual(requested, [`${endpoint}/v2/status`, `${endpoint}/v2/events`]);
+  assert.match(out(), /Mode: LIVE/);
   assert.match(out(), /run_426/);
   assert.equal(err(), "");
 });
@@ -80,16 +203,19 @@ test("cockpit falls back to static text in non-TTY without --once", async () => 
   const code = await runCockpitCommand(["--fixture", join(FIXTURE_DIR, "blocked-runner.json")], io);
   assert.equal(code, 0);
   assert.match(err(), /non-TTY detected/);
+  assert.match(out(), /Mode: DEMO/);
   assert.match(out(), /Factory cannot close|blocked/);
 });
 
-test("cockpit --json emits the cockpit model", async () => {
+test("cockpit --json emits a wrapped response with mode", async () => {
   const { io, out } = bufferIo({ stdoutIsTTY: false });
   const code = await runCockpitCommand(["--fixture", join(FIXTURE_DIR, "dirty-worktree.json"), "--json"], io);
   assert.equal(code, 0);
-  const model = JSON.parse(out());
-  assert.ok(model.header);
-  assert.ok(model.panels.worktrees.some((w) => w.dirty));
+  const payload = JSON.parse(out());
+  assert.equal(payload.app, "cockpit");
+  assert.equal(payload.mode, "DEMO");
+  assert.ok(payload.model.header);
+  assert.ok(payload.model.panels.worktrees.some((w) => w.dirty));
 });
 
 test("cockpit reports a clear error for a missing fixture", async () => {

--- a/test/v2/cockpit-model.test.js
+++ b/test/v2/cockpit-model.test.js
@@ -36,9 +36,46 @@ test("cockpit model is pure: frozen input does not throw and is not mutated", ()
 test("ready fixture renders factory open with no active runs", () => {
   const { status, events } = loadFixture("ready.json");
   const model = createCockpitModel({ status, events });
+  assert.equal(model.app.mode, "DEMO");
+  assert.equal(model.app.configPath, process.cwd());
+  assert.equal(model.sections.map((section) => section.id).join(","), "factory,runs,worktrees,doctor,manual,events,settings,advanced");
+  assert.equal(model.selectedSectionId, "factory");
+  assert.equal(model.commandPaletteOpen, false);
   assert.equal(model.factoryState, "open");
   assert.equal(model.header.counts.running, 0);
   assert.equal(model.panels.activeRuns.length, 0);
+});
+
+test("next actions and app metadata change with mode", () => {
+  const { status } = loadFixture("ready.json");
+  const setupMode = createCockpitModel({
+    status,
+    app: { mode: "SETUP", source: "config missing", configPath: "/tmp/fizzy-symphony/config.yml" }
+  });
+  assert.equal(setupMode.nextActions.length, 1);
+  assert.equal(setupMode.nextActions[0].command, "fizzy-symphony setup --config /tmp/fizzy-symphony/config.yml");
+  assert.equal(setupMode.nextActions[0].enabled, false);
+  assert.match(setupMode.nextActions[0].disabledReason, /Guidance only/u);
+
+  const offlineMode = createCockpitModel({
+    status,
+    app: { mode: "OFFLINE", source: "config", configPath: "/tmp/fizzy-symphony/config.yml" }
+  });
+  assert.equal(offlineMode.nextActions.length, 1);
+  assert.equal(offlineMode.nextActions[0].mutates, true);
+  assert.equal(offlineMode.nextActions[0].enabled, false);
+  assert.ok(offlineMode.advancedCommands.some((command) =>
+    command.id === "dashboard" &&
+    command.command === "fizzy-symphony dashboard --config /tmp/fizzy-symphony/config.yml" &&
+    command.enabled === false
+  ));
+
+  const demoMode = createCockpitModel({
+    status,
+    app: { mode: "DEMO", source: "fixture", configPath: "/tmp/fizzy-symphony/config.yml" }
+  });
+  assert.equal(demoMode.nextActions.length, 1);
+  assert.equal(demoMode.nextActions[0].enabled, false);
 });
 
 test("running fixture surfaces a machine in motion", () => {
@@ -99,7 +136,11 @@ test("actions reflect enabled/disabled with reasons", () => {
   const model = createCockpitModel({ status });
   const cancel = model.actions.find((a) => a.id === "run.cancel");
   assert.equal(cancel.enabled, false);
+  assert.equal(cancel.commandType, "run.cancel");
   assert.equal(cancel.disabledReason, "No run selected");
+  const cancelPaletteRow = model.commandPalette.find((row) => row.id === "action.run.cancel");
+  assert.equal(cancelPaletteRow.enabled, false);
+  assert.equal(cancelPaletteRow.mutates, true);
 
   const running = loadFixture("running-one-card.json");
   const runModel = createCockpitModel({ status: running.status, selectedId: "run_426" });
@@ -122,4 +163,6 @@ test("help is generated from capabilities, not hardcoded", () => {
   const model = createCockpitModel({ status });
   assert.ok(model.help.capabilities.length > 0);
   assert.ok(model.help.keys.some((k) => k.key === "?"));
+  assert.ok(model.commandPalette.some((row) => row.section === "factory"));
+  assert.ok(model.commandPalette.some((row) => row.id.startsWith("action.")));
 });

--- a/test/v2/interactive.test.js
+++ b/test/v2/interactive.test.js
@@ -31,7 +31,19 @@ function fakeTerminal() {
 test("interactive cockpit submits a typed command via keypress (dry-run)", async () => {
   const runtime = loadRuntime("running-one-card.json");
   const term = fakeTerminal();
-  const session = await startInteractiveCockpit({ runtime, terminalFactory: async () => term });
+  const session = await startInteractiveCockpit({
+    runtime,
+    app: {
+      mode: "LIVE",
+      source: "http://127.0.0.1:4510/status",
+      configPath: "/tmp/fizzy-symphony/config.yml",
+      endpoint: "http://127.0.0.1:4510"
+    },
+    terminalFactory: async () => term
+  });
+  assert.equal(session.currentModel().selectedSectionId, "factory");
+  assert.equal(session.currentModel().app.mode, "LIVE");
+  assert.equal(session.currentModel().app.endpoint, "http://127.0.0.1:4510");
 
   // selectable order: card_golden, card_426, run_426, ws_426. Move to card_426.
   session.handleKey("DOWN");
@@ -42,8 +54,64 @@ test("interactive cockpit submits a typed command via keypress (dry-run)", async
   const lastFrame = term.frames.at(-1);
   assert.match(lastFrame, /DRY-RUN/);
 
+  session.handleKey("2");
+  assert.equal(session.currentModel().selectedSectionId, "runs");
+
+  session.handleKey("3");
+  assert.equal(session.currentModel().selectedSectionId, "worktrees");
+
+  session.handleKey("a");
+  assert.equal(session.currentModel().selectedSectionId, "worktrees");
+  assert.match(term.frames.at(-1), /Actions/);
+
+  session.handleKey("8");
+  assert.equal(session.currentModel().selectedSectionId, "advanced");
+
+  session.handleKey("CTRL_P");
+  assert.equal(session.currentModel().commandPaletteOpen, true);
+  session.handleKey("CTRL_P");
+  assert.equal(session.currentModel().commandPaletteOpen, false);
+
   const events = runtime.getEvents(10);
   assert.ok(events.some((e) => e.type === "command.dry-run.run.cancel"));
+
+  session.handleKey("q");
+  await session.done;
+});
+
+test("interactive command palette dispatches sections, actions, and command hints", async () => {
+  const runtime = loadRuntime("running-one-card.json");
+  const term = fakeTerminal();
+  const session = await startInteractiveCockpit({
+    runtime,
+    app: { mode: "OFFLINE", source: "config", configPath: "/tmp/fizzy-symphony/config.yml" },
+    terminalFactory: async () => term
+  });
+
+  session.handleKey("DOWN"); // card_426 has run/session ids for action commands.
+
+  session.handleKey("CTRL_P");
+  session.handleKey("2");
+  assert.equal(session.currentModel().selectedSectionId, "runs");
+  assert.equal(session.currentModel().commandPaletteOpen, false);
+
+  session.handleKey("CTRL_P");
+  session.handleKey("A");
+  session.handleKey("c");
+  assert.equal(session.currentModel().commandPaletteOpen, false);
+  assert.match(term.frames.at(-1), /DRY-RUN/);
+  assert.ok(runtime.getEvents(10).some((event) => event.type === "command.dry-run.run.cancel"));
+
+  session.handleKey("CTRL_P");
+  session.handleKey("V");
+  session.handleKey("q");
+  assert.equal(session.currentModel().commandPaletteOpen, false);
+  assert.match(term.frames.at(-1), /dashboard disabled: No live endpoint connected\./);
+
+  session.handleKey("CTRL_P");
+  session.handleKey("V:D");
+  assert.equal(session.currentModel().commandPaletteOpen, false);
+  assert.match(term.frames.at(-1), /doctor: fizzy-symphony doctor --goal --config/);
 
   session.handleKey("q");
   await session.done;

--- a/test/v2/status-bridge.test.js
+++ b/test/v2/status-bridge.test.js
@@ -73,3 +73,27 @@ test("projectV1StatusToV2 maps the live daemon snapshot into cockpit status", ()
   assert.equal(status.doctor.goalClosable, false);
   assert.ok(status.recentEvents.some((event) => event.type === "v1.recent_failure"));
 });
+
+test("projectV1StatusToV2 preserves route disabled reasons from non-codex backends", () => {
+  const status = projectV1StatusToV2({
+    instance: { id: "instance-a" },
+    readiness: { ready: true, blockers: [] },
+    runner_health: { status: "ready", kind: "cli_app_server" },
+    watched_boards: [{ id: "board_1", label: "Agents" }],
+    routes: [{
+      id: "route_claude",
+      board_id: "board_1",
+      source_column_id: "col_ready",
+      source_column_name: "Ready for Agents",
+      golden_card_id: "golden_1",
+      backend: "claude",
+      enabled: false,
+      disabledReason: "Execution for backend claude is not wired yet."
+    }],
+    runs: { queued: [], running: [], completed: [], failed: [], cancelled: [], preempted: [] }
+  });
+
+  assert.equal(status.routes[0].enabled, false);
+  assert.equal(status.routes[0].backend, "claude");
+  assert.equal(status.routes[0].disabledReason, "Execution for backend claude is not wired yet.");
+});

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -437,8 +437,103 @@ test("discoverGoldenTicketRoutes parses aliases and produces stable IDs and fing
   assert.equal(routesA[0].workspace, "app");
   assert.equal(routesA[0].completion.policy, "move_to_column");
   assert.equal(routesA[0].completion.target_column_id, "col_done");
+  assert.equal(routesA[0].enabled, true);
   assert.equal(routesA[0].fingerprint, routesB[0].fingerprint);
   assert.match(routesA[0].fingerprint, /^sha256:[a-f0-9]{64}$/);
+});
+
+test("discoverGoldenTicketRoutes maps bare #claude and #backend-claude as backend aliases", () => {
+  const routesByBareTag = discoverGoldenTicketRoutes([board({
+    cards: [{ id: "golden_ready", title: "Ready Route", golden: true, column_id: "col_ready", tags: ["agent-instructions", "claude", "move-to-done"] }]
+  })]);
+  assert.equal(routesByBareTag[0].backend, "claude");
+  assert.equal(routesByBareTag[0].enabled, false);
+  assert.match(routesByBareTag[0].disabledReason, /not wired yet/);
+
+  const routesByBackendTag = discoverGoldenTicketRoutes([board({
+    cards: [{ id: "golden_ready", title: "Ready Route", golden: true, column_id: "col_ready", tags: ["agent-instructions", "backend-claude", "move-to-done"] }]
+  })]);
+  assert.equal(routesByBackendTag[0].backend, "claude");
+  assert.equal(routesByBackendTag[0].enabled, false);
+  assert.match(routesByBackendTag[0].disabledReason, /not wired yet/);
+});
+
+test("discoverGoldenTicketRoutes uses configured default backend when no backend tag is present", () => {
+  const routes = discoverGoldenTicketRoutes([
+    board({
+      cards: [{ id: "golden_ready", title: "Ready Route", golden: true, column_id: "col_ready", tags: ["agent-instructions", "move-to-done"] }]
+    })
+  ], {
+    defaults: { backend: "claude", workspace: "app", persona: "repo-agent" }
+  });
+
+  assert.equal(routes[0].backend, "claude");
+  assert.equal(routes[0].enabled, false);
+  assert.match(routes[0].disabledReason, /not wired yet/);
+});
+
+test("validateStartup reports non-codex backend routes as disabled but still valid", async () => {
+  const { config } = await parsedConfig();
+
+  const report = await validateStartup({
+    config,
+    fizzy: fakeFizzy({
+      boards: [
+        board({
+          cards: [{
+            id: "golden_1",
+            title: "One",
+            golden: true,
+            column_id: "col_ready",
+            tags: ["agent-instructions", "backend-claude", "move-to-done"]
+          }]
+        })
+      ],
+      tags: [
+        { id: "tag_agent", name: "agent-instructions" },
+        { id: "tag_claude", name: "backend-claude" },
+        { id: "tag_done", name: "move-to-done" }
+      ]
+    }),
+    runner: fakeRunner()
+  });
+
+  assert.equal(report.ok, true);
+  assert.equal(report.routes[0].backend, "claude");
+  assert.equal(report.routes[0].enabled, false);
+  assert.equal(report.routes[0].disabledReason, "Execution for backend claude is not wired yet.");
+});
+
+test("validateStartup applies agent default backend when board defaults omit backend", async () => {
+  const { config } = await parsedConfig();
+  delete config.boards.entries[0].defaults.backend;
+  config.agent.default_backend = "claude";
+
+  const report = await validateStartup({
+    config,
+    fizzy: fakeFizzy({
+      boards: [
+        board({
+          cards: [{
+            id: "golden_1",
+            title: "One",
+            golden: true,
+            column_id: "col_ready",
+            tags: ["agent-instructions", "move-to-done"]
+          }]
+        })
+      ],
+      tags: [
+        { id: "tag_agent", name: "agent-instructions" },
+        { id: "tag_done", name: "move-to-done" }
+      ]
+    }),
+    runner: fakeRunner()
+  });
+
+  assert.equal(report.ok, true);
+  assert.equal(report.routes[0].backend, "claude");
+  assert.equal(report.routes[0].enabled, false);
 });
 
 test("discoverGoldenTicketRoutes rejects tag-only instruction cards and board-level tickets", () => {


### PR DESCRIPTION
## Summary
- Make bare `fizzy-symphony` launch the cockpit instead of the old dashboard flow.
- Add explicit cockpit app modes for `SETUP`, `OFFLINE`, `LIVE`, and `DEMO`, with no silent fixture fallback.
- Expand the cockpit model, renderer, and interactive shell with mode-aware sections, palette actions, and advanced commands.
- Update route parsing and validation to recognize known backend tags while disabling non-Codex routes for live dispatch in MVP.
- Refresh README, user guide, and v2 docs to reflect the new default operator surface and backend-tag contract.

## Testing
- `node --test test/cli-production-clients.test.js`
- `node --test test/v2/cockpit-cli.test.js`
- `node --test test/v2/cockpit-model.test.js`
- `node --test test/v2/interactive.test.js`
- `node --test test/v2/status-bridge.test.js`
- `node --test test/validation.test.js`
- `npm test`
- `npm run build`
- `git diff --check`