### PR TITLE
Add color-aware cockpit rendering and live filter input

### DIFF
--- a/bin/fizzy-symphony.js
+++ b/bin/fizzy-symphony.js
@@ -612,7 +612,9 @@ const BARE_ENTRY_VALUE_FLAGS = new Set([
 ]);
 const BARE_ENTRY_BOOLEAN_FLAGS = new Set([
   "--once",
-  "--no-default-endpoint"
+  "--no-default-endpoint",
+  "--color",
+  "--no-color"
 ]);
 
 function bareEntryArgsAllowed(args) {

--- a/src/v2/cli/cockpit.ts
+++ b/src/v2/cli/cockpit.ts
@@ -36,6 +36,10 @@ export async function runCockpitCommand(args: string[], io: CockpitIo): Promise<
   const wantJson = args.includes("--json");
   const wantOnce = args.includes("--once");
   const isTty = io.stdoutIsTTY ?? Boolean((io.stdout as { isTTY?: boolean }).isTTY);
+  const env = io.env ?? process.env;
+  const colorEnabled = resolveColor(args, env, isTty);
+  const width = Number((io.stdout as { columns?: number }).columns) || 100;
+  const renderOptions = { color: colorEnabled, width };
 
   const app = {
     mode,
@@ -61,18 +65,27 @@ export async function runCockpitCommand(args: string[], io: CockpitIo): Promise<
     if (!isTty && !wantOnce) {
       io.stderr.write(`cockpit: non-TTY detected, printing static frame (${source}).\n`);
     }
-    io.stdout.write(`${renderCockpitText(model)}\n`);
+    io.stdout.write(`${renderCockpitText(model, renderOptions)}\n`);
     return 0;
   }
 
   // Interactive TTY mode.
   try {
-    const session = await startInteractiveCockpit({ runtime, app });
+    const session = await startInteractiveCockpit({ runtime, app, color: colorEnabled, width });
     await session.done;
     return 0;
   } catch (error) {
     io.stderr.write(`cockpit: interactive renderer unavailable (${(error as Error).message}); static frame:\n`);
-    io.stdout.write(`${renderCockpitText(model)}\n`);
+    io.stdout.write(`${renderCockpitText(model, renderOptions)}\n`);
     return 0;
   }
+}
+
+// Color is opt-in and respects the usual terminal contracts: explicit
+// --color/--no-color override, otherwise enabled only for a real TTY with
+// NO_COLOR unset, CI unset, and TERM other than "dumb".
+function resolveColor(args: string[], env: Record<string, string | undefined>, isTty: boolean): boolean {
+  if (args.includes("--no-color")) return false;
+  if (args.includes("--color")) return true;
+  return isTty && env.NO_COLOR === undefined && env.CI === undefined && env.TERM !== "dumb";
 }

--- a/src/v2/cockpit/format.ts
+++ b/src/v2/cockpit/format.ts
@@ -1,0 +1,143 @@
+// Pure terminal formatting helpers for the cockpit text renderer.
+//
+// Raw ANSI truecolor (same palette family as src/terminal-renderer.js). No
+// dependencies. Color is strictly opt-in: when a Painter is disabled every
+// helper returns plain text, so non-TTY, NO_COLOR, CI, TERM=dumb, and
+// redirected output stay completely ANSI-free and deterministic.
+
+const RESET = "\x1b[0m";
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/gu;
+
+const PALETTE = {
+  faint: "38;2;100;116;139",
+  dim: "38;2;148;163;184",
+  blue: "38;2;96;165;250",
+  green: "38;2;34;197;94",
+  yellow: "38;2;250;204;21",
+  red: "38;2;248;113;113",
+  magenta: "38;2;244;114;182",
+  cyan: "38;2;34;211;238",
+  white: "38;2;226;232;240"
+} as const;
+
+export type Tone = keyof typeof PALETTE;
+
+export interface Painter {
+  readonly enabled: boolean;
+  tint(tone: Tone, text: string, bold?: boolean): string;
+  bold(text: string): string;
+  dim(text: string): string;
+  faint(text: string): string;
+}
+
+export function createPainter(enabled: boolean): Painter {
+  function wrap(code: string, text: string): string {
+    if (!enabled) return text;
+    return `\x1b[${code}m${text}${RESET}`;
+  }
+  return {
+    enabled,
+    tint: (tone, text, bold = false) => wrap(`${bold ? "1;" : ""}${PALETTE[tone]}`, text),
+    bold: (text) => wrap("1", text),
+    dim: (text) => wrap(PALETTE.dim, text),
+    faint: (text) => wrap(PALETTE.faint, text)
+  };
+}
+
+// Strip ANSI SGR sequences, leaving the visible text. Lets callers reason about
+// a line's printable content (e.g. detecting copyable command lines) regardless
+// of whether color is enabled.
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_PATTERN, "");
+}
+
+// Visible width of a string, ignoring ANSI SGR sequences. Box-drawing and the
+// theme glyphs used here are all single-width, so a code-point count is exact.
+export function visibleWidth(text: string): number {
+  return [...stripAnsi(text)].length;
+}
+
+export function padEndVisible(text: string, width: number): string {
+  const pad = width - visibleWidth(text);
+  return pad > 0 ? text + " ".repeat(pad) : text;
+}
+
+// Middle-truncate so both ends (e.g. a long path) stay legible.
+export function truncateMiddle(text: string, max: number): string {
+  if (max <= 1 || visibleWidth(text) <= max) return text;
+  const plain = stripAnsi(text);
+  const keep = max - 1;
+  const head = Math.ceil(keep / 2);
+  const tail = Math.floor(keep / 2);
+  return `${plain.slice(0, head)}…${tail > 0 ? plain.slice(plain.length - tail) : ""}`;
+}
+
+// ANSI-aware hard clamp: keep at most `width` visible columns, preserving SGR
+// escape sequences (they cost no width) and closing any open color so a
+// truncated colored line never leaks formatting. Used to guarantee header and
+// section-rail lines never overrun the frame at any terminal width.
+export function fitVisible(text: string, width: number): string {
+  if (width <= 0) return "";
+  if (visibleWidth(text) <= width) return text;
+  let out = "";
+  let count = 0;
+  let index = 0;
+  let sawAnsi = false;
+  while (index < text.length && count < width) {
+    if (text[index] === "\x1b") {
+      const match = /^\x1b\[[0-9;]*m/u.exec(text.slice(index));
+      if (match) {
+        out += match[0];
+        index += match[0].length;
+        sawAnsi = true;
+        continue;
+      }
+    }
+    const codePoint = [...text.slice(index)][0];
+    out += codePoint;
+    index += codePoint.length;
+    count += 1;
+  }
+  if (sawAnsi) out += RESET;
+  return out;
+}
+
+export function clampWidth(width: number | undefined): number {
+  const value = Number.isFinite(width) ? Math.floor(width as number) : 80;
+  return Math.max(36, Math.min(value, 160));
+}
+
+// A heavy top/bottom frame rule.
+export function frameRule(width: number, painter: Painter): string {
+  return painter.faint("═".repeat(width));
+}
+
+// A light section rule that carries a heading: " Heading ─────────────".
+export function headingRule(label: string, width: number, painter: Painter): string {
+  const head = ` ${painter.bold(label)} `;
+  const used = visibleWidth(head) + 1;
+  const dashes = Math.max(0, width - used);
+  return `${head}${painter.faint("─".repeat(dashes))}`;
+}
+
+// Left/right justified single line within width.
+export function justify(left: string, right: string, width: number): string {
+  const gap = width - visibleWidth(left) - visibleWidth(right);
+  if (gap < 1) return `${left} ${right}`;
+  return `${left}${" ".repeat(gap)}${right}`;
+}
+
+export const GLYPH = {
+  ok: "✓",
+  info: "◆",
+  warn: "▲",
+  err: "✗",
+  setup: "◇",
+  offline: "◌",
+  dot: "·",
+  sel: "▸",
+  bar: "▌",
+  lane: "▏",
+  bullet: "·",
+  prompt: "$"
+} as const;

--- a/src/v2/cockpit/interactive.ts
+++ b/src/v2/cockpit/interactive.ts
@@ -16,6 +16,10 @@ import type { CockpitAdvancedCommand, CockpitApp, CockpitModel, CockpitSectionId
 export interface InteractiveCockpitOptions {
   runtime: SymphonyRuntime;
   app?: CockpitApp;
+  // Render styling for the live frames. Color defaults to on (interactive mode
+  // only runs on a real TTY); width defaults to the terminal width.
+  color?: boolean;
+  width?: number;
   // Injected for tests; defaults to dynamically importing terminal-kit.
   terminalFactory?: () => Promise<TerminalLike>;
 }
@@ -29,6 +33,7 @@ export interface TerminalLike {
   grabInput(options: boolean | Record<string, unknown>): void;
   on(event: "key", handler: (name: string) => void): void;
   off?(event: "key", handler: (name: string) => void): void;
+  width?: number;
   (text: string): void;
 }
 
@@ -90,6 +95,11 @@ export async function startInteractiveCockpit(
 
   let selectedIndex = 0;
   let filter: string | undefined;
+  // While capturing, keystrokes edit `filterDraft` instead of triggering
+  // navigation/actions; the draft is applied to `filter` live as you type.
+  // Enter keeps the applied filter and exits capture; Esc clears it.
+  let filterCapturing = false;
+  let filterDraft = "";
   let statusLine = "Ready. Press ? for the Factory Manual, q to quit.";
   let selectedSectionId: CockpitSectionId = "factory";
   let commandPaletteOpen = false;
@@ -118,7 +128,11 @@ export async function startInteractiveCockpit(
   function draw(): void {
     term.clear();
     term.moveTo(1, 1);
-    term(renderCockpitText(model()));
+    const renderOptions = {
+      color: options.color ?? true,
+      width: options.width ?? term.width ?? 100
+    };
+    term(renderCockpitText(model(), renderOptions));
     term(`\n\n> ${statusLine}\n`);
   }
 
@@ -127,6 +141,13 @@ export async function startInteractiveCockpit(
     const action = current.actions.find((entry) => entry.id === actionId);
     if (!action) {
       statusLine = `Action ${actionId} not available in this build.`;
+      return;
+    }
+    // DEMO is fixture data, not a live daemon. Refuse to dispatch any mutating
+    // action — never enqueue a command, never emit a dry-run event. This is the
+    // behavioral half of DEMO honesty; the renderer is the visual half.
+    if (current.app.mode === "DEMO" && action.commandType) {
+      statusLine = `${action.label} disabled: fixture data (DEMO) — connect a live daemon to act.`;
       return;
     }
     if (!action.enabled || !action.commandType) {
@@ -172,6 +193,15 @@ export async function startInteractiveCockpit(
   }
 
   function handlePaletteKey(name: string): boolean {
+    // Esc dismisses the palette overlay (consistent with Esc clearing the
+    // filter overlay) rather than falling through to the global quit branch.
+    if (name === "ESCAPE") {
+      commandPaletteOpen = false;
+      palettePrefix = undefined;
+      statusLine = "Command palette closed.";
+      draw();
+      return true;
+    }
     const directPaletteKey = /^([AV]):(.+)$/u.exec(name);
     if (directPaletteKey) {
       dispatchPalette(directPaletteKey[1] === "A" ? "action" : "advanced", directPaletteKey[2]);
@@ -216,13 +246,70 @@ export async function startInteractiveCockpit(
     return false;
   }
 
+  // Live count of cards that survive the current filter, for the status line.
+  function filteredCardCount(): number {
+    return model().lanes.reduce((total, lane) => total + lane.cards.length, 0);
+  }
+
+  // Minimal filter input. While capturing, every key edits the draft (which is
+  // applied live so the lanes narrow as you type); Enter keeps it, Esc clears.
+  // This only touches the status line + the model's existing `filter` input, so
+  // the pure renderer and non-TTY output are unaffected.
+  function handleFilterKey(name: string): void {
+    // Ctrl-C always quits, even mid-filter — it is the universal escape hatch.
+    if (name === "CTRL_C") {
+      cleanup();
+      return;
+    }
+    if (name === "ENTER") {
+      filterCapturing = false;
+      filter = filterDraft.length > 0 ? filterDraft : undefined;
+      const count = filteredCardCount();
+      statusLine = filter
+        ? `filter "${filter}" — ${count} card${count === 1 ? "" : "s"} match. Press / to edit, Esc to clear.`
+        : "filter cleared.";
+      draw();
+      return;
+    }
+    if (name === "ESCAPE") {
+      filterCapturing = false;
+      filterDraft = "";
+      filter = undefined;
+      statusLine = "filter cleared.";
+      draw();
+      return;
+    }
+    if (name === "BACKSPACE") {
+      filterDraft = filterDraft.slice(0, -1);
+    } else if (name === "SPACE") {
+      filterDraft += " ";
+    } else if ([...name].length === 1) {
+      filterDraft += name;
+    }
+    // Apply the draft live so the visible card count reflects what you typed.
+    filter = filterDraft.length > 0 ? filterDraft : undefined;
+    statusLine = `filter: ${filterDraft}▏  (${filteredCardCount()} match · Enter to keep · Esc to clear)`;
+    draw();
+  }
+
   function handleKey(name: string): void {
+    if (filterCapturing) {
+      handleFilterKey(name);
+      return;
+    }
     const ids = selectableIds(runtime.getStatus());
     if (commandPaletteOpen && handlePaletteKey(name)) {
       return;
     }
     if (name === "q" || name === "ESCAPE" || name === "CTRL_C") {
       cleanup();
+      return;
+    }
+    if (name === "/" && !commandPaletteOpen) {
+      filterCapturing = true;
+      filterDraft = filter ?? "";
+      statusLine = `filter: ${filterDraft}▏  (type to narrow · Enter to keep · Esc to clear)`;
+      draw();
       return;
     }
     if (name === "CTRL_P") {

--- a/src/v2/cockpit/renderer.ts
+++ b/src/v2/cockpit/renderer.ts
@@ -1,280 +1,727 @@
 // Cockpit text renderer.
 //
-// renderCockpitText turns a CockpitModel into a static, plain-text cockpit.
-// It is pure (string in, string out) and is used for:
+// renderCockpitText turns a CockpitModel into a single, deliberate operator
+// cockpit screen. It is pure (model in, string out) and is used for:
 //   - non-TTY fallback
 //   - `cockpit --once`
-//   - the body of the interactive renderer's static frames
+//   - the body of the interactive renderer's live frames
 //
 // The interactive Terminal Kit renderer lives in ./interactive.ts and reuses
-// this text where helpful. Truth-first: raw IDs always accompany theme labels.
+// this text. Truth-first: raw IDs, paths, mode, endpoint, readiness and
+// disabled reasons always accompany the Wonka/factory flavor labels.
+//
+// Layout (one strong screen, no nested cards):
+//   header rail → attention strip → counts rail → section rail →
+//   primary section (mode-honest) → inspector (selection + actions + guidance)
+//   → command palette (when open) → footer.
 
-import { FACTORY_STATE_LABELS } from "./theme.ts";
-import type { CockpitModel } from "../core/types.ts";
+import {
+  GLYPH,
+  clampWidth,
+  createPainter,
+  fitVisible,
+  frameRule,
+  headingRule,
+  justify,
+  padEndVisible,
+  stripAnsi,
+  truncateMiddle,
+  visibleWidth,
+  type Painter,
+  type Tone
+} from "./format.ts";
+import { FACTORY_STATE_LABELS, worktreeThemeLabel } from "./theme.ts";
+import type {
+  CardRuntimeState,
+  CockpitMode,
+  CockpitModel,
+  RunState
+} from "../core/types.ts";
 
-function hr(label: string): string {
-  const line = "─".repeat(Math.max(0, 62 - label.length));
-  return `── ${label} ${line}`;
+export interface RenderOptions {
+  color?: boolean;
+  width?: number;
 }
 
-function fmtCounts(counts: CockpitModel["header"]["counts"]): string {
-  return [
-    `boards=${counts.boards}`,
-    `routes=${counts.routes}`,
-    `running=${counts.running}`,
-    `queued=${counts.queued}`,
-    `failed=${counts.failed}`,
-    `dirty=${counts.dirtyWorktrees}`,
-    `warn=${counts.warnings}`
-  ].join("  ");
+const MODE_TONE: Record<CockpitMode, Tone> = {
+  DEMO: "magenta",
+  LIVE: "green",
+  OFFLINE: "yellow",
+  SETUP: "cyan"
+};
+
+function stateTone(state: CardRuntimeState | RunState): Tone {
+  switch (state) {
+    case "running":
+      return "blue";
+    case "queued":
+      return "cyan";
+    case "completed":
+      return "green";
+    case "failed":
+    case "blocked":
+      return "red";
+    case "preempted":
+      return "yellow";
+    default:
+      return "dim";
+  }
 }
 
-function renderSectionTabs(model: CockpitModel): string[] {
+// Honest, mode-aware status for a live operator action (one with a commandType).
+// A fixture is not a daemon and SETUP/OFFLINE have no reachable daemon, so a
+// mutating action can never read a live "ready" in those modes — it reads as a
+// disabled state with an explicit reason. DEMO is doubly enforced: the
+// interactive layer also refuses to dispatch (see interactive.ts submit()), so
+// fixture data can never masquerade as a fire-ready live mutation.
+function operatorActionStatus(
+  mode: CockpitMode,
+  enabled: boolean,
+  mutating: boolean,
+  disabledReason: string | undefined,
+  c: Painter
+): string {
+  if (mutating) {
+    if (mode === "DEMO") return c.tint("magenta", `demo ${GLYPH.dot} fixture data, not a live daemon`);
+    if (mode === "SETUP") return c.faint(`off ${GLYPH.dot} No daemon yet — run setup first.`);
+    if (mode === "OFFLINE") return c.faint(`off ${GLYPH.dot} Daemon offline — start it to act.`);
+  }
+  return enabled
+    ? c.tint("green", "ready")
+    : c.faint(`off ${GLYPH.dot} ${disabledReason ?? "unavailable"}`);
+}
+
+// ---------------------------------------------------------------------------
+// Header rail
+// ---------------------------------------------------------------------------
+
+function renderHeader(model: CockpitModel, c: Painter, width: number): string[] {
+  const mode = model.app.mode;
+  const badge = c.tint(MODE_TONE[mode], `[ ${mode} ]`, true);
+  const badgeWidth = visibleWidth(badge);
+
+  // Keep the mode badge whole (it is the most safety-critical glance); trim the
+  // wordmark first, then drop the subtitle, so the badge always survives.
+  let wordmark = `${c.bold("FIZZY-SYMPHONY")} ${c.faint(GLYPH.lane)} ${c.dim("operator cockpit")}`;
+  const wordmarkBudget = width - badgeWidth - 3;
+  if (visibleWidth(wordmark) > wordmarkBudget) {
+    wordmark = c.bold("FIZZY-SYMPHONY");
+    if (visibleWidth(wordmark) > wordmarkBudget) {
+      wordmark = fitVisible(wordmark, Math.max(3, wordmarkBudget));
+    }
+  }
+
+  const readiness = c.tint(
+    model.header.readiness === "ready" ? "green" : model.header.readiness === "unknown" ? "dim" : "yellow",
+    model.header.readiness
+  );
+  const factory = c.dim(FACTORY_STATE_LABELS[model.factoryState]);
+  const runner = `runner ${c.dim(model.header.runnerStatus ?? "unknown")}`;
+  const metaLeft = ` readiness ${readiness} ${c.faint(GLYPH.dot)} ${factory} ${c.faint(GLYPH.dot)} ${runner}`;
+
+  const connection = renderConnection(model, c, width);
+  const configPath = truncateMiddle(model.app.configPath, Math.max(10, width - 10));
+
   return [
-    hr("SECTIONS"),
-    model.sections
-      .map((section) =>
-        `${section.id === model.selectedSectionId ? ">" : " "} ${section.key}: ${section.label}`
-      )
-      .join(" | ")
+    frameRule(width, c),
+    fitVisible(justify(` ${wordmark}`, `${badge} `, width), width),
+    fitVisible(metaLeft, width),
+    fitVisible(` ${connection}`, width),
+    fitVisible(` ${c.faint("config")}  ${c.dim(configPath)}`, width),
+    frameRule(width, c)
   ];
 }
 
-function renderSelectedSection(model: CockpitModel): string[] {
-  const sectionId = model.selectedSectionId;
-  const lines: string[] = [];
-  const sectionLabel = model.sections.find((entry) => entry.id === sectionId)?.label ?? sectionId;
-  lines.push(hr(`SECTION: ${sectionLabel}`));
+// Mode-honest connection line. DEMO never claims a live daemon: it shows the
+// fixture source (app.source) so an embedded fixture endpoint is not mistaken
+// for a reachable daemon. LIVE shows the real endpoint; OFFLINE/SETUP say so.
+function renderConnection(model: CockpitModel, c: Painter, width: number): string {
+  switch (model.app.mode) {
+    case "LIVE": {
+      const endpoint = String(model.app.endpoint ?? model.header.endpoint ?? "connected");
+      const shown = truncateMiddle(endpoint, Math.max(12, width - 12));
+      return `daemon ${c.tint("green", "●")} ${c.dim(shown)}`;
+    }
+    case "DEMO": {
+      const prefix = `source ${c.tint("magenta", GLYPH.offline)} ${c.faint("(demo data)")} `;
+      const source = truncateMiddle(model.app.source, Math.max(8, width - 1 - visibleWidth(prefix)));
+      return `${prefix}${c.dim(source)}`;
+    }
+    case "OFFLINE": {
+      const source = truncateMiddle(model.app.source, Math.max(12, width - 22));
+      return `daemon ${c.tint("yellow", GLYPH.err)} ${c.tint("yellow", "offline")} ${c.faint(GLYPH.dot)} ${c.dim(source)}`;
+    }
+    case "SETUP":
+    default:
+      return `daemon ${c.faint(GLYPH.dot)} ${c.dim("not configured")}`;
+  }
+}
 
-  if (sectionId === "factory") {
-    lines.push(hr("FACTORY LANES"));
-    if (model.lanes.length === 0) {
-      lines.push("  (no routes)");
-    }
-    for (const lane of model.lanes) {
-      const laneState = lane.enabled ? "" : `  [disabled: ${lane.disabledReason ?? "unknown"}]`;
-      lines.push(`▣ ${lane.title}  «${lane.factoryLine}»  [route ${lane.routeId}]${laneState}`);
-      if (lane.cards.length === 0) lines.push("  (no cards)");
-      for (const card of lane.cards) {
-        const hazard = card.hazard ? " ⚠" : "";
-        const num = card.number !== undefined ? `#${card.number} ` : "";
-        lines.push(
-          `    • ${card.themeLabel}: ${num}${card.title} [${card.state}]${hazard}` +
-            `  (card ${card.id}${card.runId ? `, run ${card.runId}` : ""})`
-        );
-        if (card.attention) lines.push(`        attention: ${card.attention}`);
-      }
-    }
+// ---------------------------------------------------------------------------
+// Attention strip — the single highest-priority fact + next safe move.
+// ---------------------------------------------------------------------------
+
+interface Attention {
+  tone: Tone;
+  glyph: string;
+  text: string;
+}
+
+function computeAttention(model: CockpitModel): Attention {
+  const counts = model.header.counts;
+  const mode = model.app.mode;
+
+  if (mode === "SETUP") {
+    return {
+      tone: "cyan",
+      glyph: GLYPH.setup,
+      text: "Setup needed — no config yet. Run the setup wizard to wire boards, routes, and the runner."
+    };
+  }
+  if (mode === "OFFLINE") {
+    return {
+      tone: "yellow",
+      glyph: GLYPH.offline,
+      text: "Daemon offline — config found but no reachable daemon. Start the daemon to operate."
+    };
   }
 
-  if (sectionId === "runs") {
-    lines.push(hr("RUNS"));
-    if (model.panels.activeRuns.length === 0) lines.push("  (none)");
-    for (const run of model.panels.activeRuns) {
-      const stall = run.stalled ? " [STALLED]" : "";
-      const err = run.error ? `  err=${run.error.code}: ${run.error.message}` : "";
+  const cannotClose = model.factoryState === "blocked" || model.panels.doctor.goalClosable === false;
+  if (cannotClose) {
+    const n = model.panels.doctor.blockers.length;
+    const detail = n > 0 ? `${n} blocker${n === 1 ? "" : "s"}` : "runner unavailable";
+    return {
+      tone: "red",
+      glyph: GLYPH.err,
+      text: `Factory cannot close — ${detail}. Open Doctor (d).`
+    };
+  }
+
+  if (counts.failed > 0) {
+    const failed = model.panels.activeRuns.find((run) => run.state === "failed");
+    const code = failed?.error?.code ?? "FAILED";
+    return {
+      tone: "red",
+      glyph: GLYPH.err,
+      text: `${counts.failed} run${counts.failed === 1 ? "" : "s"} failed — ${code}. Open Runs (2).`
+    };
+  }
+
+  if (counts.dirtyWorktrees > 0) {
+    return {
+      tone: "yellow",
+      glyph: GLYPH.warn,
+      text: `${counts.dirtyWorktrees} worktree${counts.dirtyWorktrees === 1 ? "" : "s"} dirty — ${worktreeThemeLabel(true, false)}. Open Worktrees (w).`
+    };
+  }
+
+  if (model.factoryState === "locked") {
+    return {
+      tone: "yellow",
+      glyph: GLYPH.warn,
+      text: "Factory locked — dispatch paused. Resume (u) to dispatch again."
+    };
+  }
+
+  if (counts.warnings > 0) {
+    return {
+      tone: "yellow",
+      glyph: GLYPH.warn,
+      text: `${counts.warnings} warning${counts.warnings === 1 ? "" : "s"} active. Open Events (e).`
+    };
+  }
+
+  if (counts.running > 0 || counts.queued > 0) {
+    return {
+      tone: "blue",
+      glyph: GLYPH.info,
+      text: `${counts.running} machine${counts.running === 1 ? "" : "s"} in motion${counts.queued > 0 ? `, ${counts.queued} queued` : ""}. Factory humming.`
+    };
+  }
+
+  return {
+    tone: "green",
+    glyph: GLYPH.ok,
+    text: "Factory open — runner ready, nothing needs attention."
+  };
+}
+
+function renderAttention(model: CockpitModel, c: Painter, width: number): string[] {
+  const a = computeAttention(model);
+  const bar = c.tint(a.tone, GLYPH.bar);
+  const glyph = c.tint(a.tone, a.glyph, true);
+  return [fitVisible(`${bar} ${glyph} ${c.tint(a.tone, a.text, true)}`, width)];
+}
+
+// ---------------------------------------------------------------------------
+// Counts rail
+// ---------------------------------------------------------------------------
+
+function renderCounts(model: CockpitModel, c: Painter, width: number): string[] {
+  const k = model.header.counts;
+  const cell = (label: string, value: number, tone: Tone | null): string => {
+    const v = tone && value > 0 ? c.tint(tone, String(value), true) : c.bold(String(value));
+    return `${c.faint(label)} ${v}`;
+  };
+  const cells = [
+    cell("boards", k.boards, null),
+    cell("routes", k.routes, null),
+    cell("running", k.running, "blue"),
+    cell("queued", k.queued, "cyan"),
+    cell("failed", k.failed, "red"),
+    cell("dirty", k.dirtyWorktrees, "yellow"),
+    cell("warn", k.warnings, "yellow")
+  ];
+  return [fitVisible(` ${cells.join("   ")}`, width)];
+}
+
+// ---------------------------------------------------------------------------
+// Section rail (navigation)
+// ---------------------------------------------------------------------------
+
+function renderSectionRail(model: CockpitModel, c: Painter, width: number): string[] {
+  const tabs = model.sections.map((section) => {
+    const active = section.id === model.selectedSectionId;
+    const key = c.faint(section.key);
+    if (active) {
+      return `${c.tint("blue", GLYPH.sel, true)} ${c.tint("blue", section.label, true)} ${key}`;
+    }
+    return `${c.dim(section.label)} ${key}`;
+  });
+  return [fitVisible(` ${c.faint("sections")}  ${tabs.join(c.faint(`  ${GLYPH.dot} `))}`, width)];
+}
+
+// ---------------------------------------------------------------------------
+// Primary section
+// ---------------------------------------------------------------------------
+
+function renderPrimary(model: CockpitModel, c: Painter, width: number): string[] {
+  if (model.app.mode === "SETUP") return renderSetupScreen(model, c, width);
+  if (model.app.mode === "OFFLINE") return renderOfflineScreen(model, c, width);
+  return renderSection(model, c, width);
+}
+
+function renderSetupScreen(model: CockpitModel, c: Painter, width: number): string[] {
+  return [
+    headingRule("Getting started", width, c),
+    `   ${c.tint("cyan", "1", true)}  Run the setup wizard to create config and wire your runner.`,
+    `   ${c.tint("cyan", "2", true)}  Start the daemon, then re-open the cockpit to operate live.`,
+    `   ${c.dim("No boards, routes, or runs exist yet — nothing here is live.")}`,
+    `   ${c.faint("config target")}  ${c.dim(truncateMiddle(model.app.configPath, Math.max(10, width - 18)))}`
+  ];
+}
+
+function renderOfflineScreen(model: CockpitModel, c: Painter, width: number): string[] {
+  return [
+    headingRule("Daemon offline", width, c),
+    `   ${c.faint("config")}  ${c.dim(truncateMiddle(model.app.configPath, Math.max(10, width - 12)))}`,
+    `   ${c.dim("Boards, routes, runs, and worktrees stay hidden until a daemon is")}`,
+    `   ${c.dim("reachable. Live actions are unavailable while offline.")}`,
+    `   ${c.tint("yellow", "Start the daemon, then refresh (r).", true)}`
+  ];
+}
+
+function renderSection(model: CockpitModel, c: Painter, width: number): string[] {
+  switch (model.selectedSectionId) {
+    case "runs":
+      return renderRuns(model, c, width);
+    case "worktrees":
+      return renderWorktrees(model, c, width);
+    case "doctor":
+      return renderDoctor(model, c, width);
+    case "manual":
+      return renderManual(model, c, width);
+    case "events":
+      return renderEvents(model, c, width);
+    case "settings":
+      return renderSettings(model, c, width);
+    case "advanced":
+      return renderAdvanced(model, c, width);
+    case "factory":
+    default:
+      return renderFactory(model, c, width);
+  }
+}
+
+function renderFactory(model: CockpitModel, c: Painter, width: number): string[] {
+  const lines = [headingRule("Factory lanes", width, c)];
+  if (model.lanes.length === 0) {
+    lines.push(`   ${c.dim("(no routes configured)")}`);
+    return lines;
+  }
+  for (const lane of model.lanes) {
+    const meta = c.faint(`route ${lane.routeId} ${GLYPH.dot} board ${lane.boardId}`);
+    let title = c.tint("white", lane.title, true);
+    if (!lane.enabled) {
+      title += ` ${c.tint("red", `[disabled: ${lane.disabledReason ?? "unknown"}]`)}`;
+    }
+    lines.push(justify(`  ${title}`, `${meta} `, width));
+    if (lane.cards.length === 0) {
+      lines.push(`     ${c.dim("(no cards on this line)")}`);
+      continue;
+    }
+    for (const card of lane.cards) {
+      const num = card.number !== undefined ? `#${card.number}` : "—";
+      const hazard = card.hazard ? ` ${c.tint("red", "⚠", true)}` : "";
+      const state = c.tint(stateTone(card.state), card.state);
+      const ids = c.faint(`card ${card.id}${card.runId ? ` ${GLYPH.dot} run ${card.runId}` : ""}`);
       lines.push(
-        `  ${run.themeLabel}: run ${run.id} [${run.state}]${stall}` +
-          `${run.cardNumber !== undefined ? ` card #${run.cardNumber}` : ""}${err}`
+        `     ${c.faint(GLYPH.bullet)} ${c.bold(padEndVisible(num, 5))} ${card.title}${hazard}` +
+          `  ${state} ${c.faint(GLYPH.dot)} ${c.dim(card.themeLabel)}  ${ids}`
       );
+      if (card.attention) lines.push(`         ${c.tint("yellow", `attention: ${card.attention}`)}`);
     }
   }
-
-  if (sectionId === "worktrees") {
-    lines.push(hr("WORKTREES"));
-    if (model.panels.worktrees.length === 0) lines.push("  (no worktrees)");
-    for (const worktree of model.panels.worktrees) {
-      const flags = [worktree.dirty ? "dirty" : null, worktree.preserved ? "preserved" : null]
-        .filter(Boolean)
-        .join(",") || "clean";
-      lines.push(`  ${worktree.themeLabel}: ${worktree.workspaceKey} [${flags}] ${worktree.path}`);
-      if (worktree.recommendedAction) lines.push(`      action: ${worktree.recommendedAction}`);
-    }
-  }
-
-  if (sectionId === "doctor") {
-    lines.push(hr("DOCTOR"));
-    lines.push(`goalClosable=${model.panels.doctor.goalClosable}  ${model.panels.doctor.themeLabel}`);
-    for (const blocker of model.panels.doctor.blockers) {
-      lines.push(`  ${blocker.code}: ${blocker.message}`);
-    }
-    if (model.panels.doctor.blockers.length === 0) {
-      lines.push("  no doctor blockers");
-    }
-  }
-
-  if (sectionId === "manual") {
-    lines.push(hr("FACTORY MANUAL"));
-    lines.push(model.help.manualTitle);
-  }
-
-  if (sectionId === "events") {
-    lines.push(hr("EVENTS"));
-    if (model.panels.events.length === 0) lines.push("  (no events)");
-    for (const event of model.panels.events.slice(0, 12)) {
-      lines.push(`  [${event.severity}] ${event.themeLabel}: ${event.message}  (${event.at})`);
-    }
-  }
-
-  if (sectionId === "settings") {
-    lines.push(hr("SETTINGS"));
-    lines.push(`source: ${model.settings.source}`);
-    lines.push(`configPath: ${model.settings.configPath}`);
-    lines.push(`mode: ${model.settings.mode}`);
-    lines.push(`endpoint: ${model.settings.endpoint ?? "—"}`);
-    lines.push(`runner: ${model.settings.runnerStatus ?? "unknown"}`);
-    lines.push(`readiness: ${model.settings.readiness}`);
-    lines.push(`blocks: ${model.settings.readinessBlockers}`);
-    lines.push(`workspace: total=${model.settings.workspaceCount}  dirty=${model.settings.dirtyWorktrees}`);
-    lines.push(`boards=${model.settings.boardCount}  routes=${model.settings.routeCount}`);
-    lines.push(`hasLiveEndpoint=${model.settings.hasLiveEndpoint}`);
-  }
-
-  if (sectionId === "advanced") {
-    lines.push(hr("ADVANCED COMMANDS"));
-    for (const command of model.advancedCommands) {
-      const state = command.enabled ? "enabled" : `disabled: ${command.disabledReason ?? "n/a"}`;
-      const mutates = command.mutates ? "mutates" : "read-only";
-      lines.push(`  [${command.key}] ${command.label}: ${command.command} (${state}, ${mutates})`);
-    }
-  }
-
   return lines;
 }
 
-function renderLegacySummary(model: CockpitModel): string[] {
-  const lines: string[] = [];
-  if (model.selected) {
-    lines.push(hr("SELECTED DETAIL (raw truth)"));
-    lines.push(`kind: ${model.selected.kind}   theme: ${model.selected.themeLabel ?? "—"}`);
-    for (const [key, value] of Object.entries(model.selected.raw)) {
-      if (value === undefined || value === null) continue;
-      lines.push(`  ${key}: ${typeof value === "object" ? JSON.stringify(value) : String(value)}`);
-    }
-    if (model.selected.recommendedAction) {
-      lines.push(`  recommendedAction: ${model.selected.recommendedAction}`);
-    }
-    lines.push("");
+function renderRuns(model: CockpitModel, c: Painter, width: number): string[] {
+  const lines = [headingRule("Runs", width, c)];
+  if (model.panels.activeRuns.length === 0) {
+    lines.push(`   ${c.dim("(no active or queued runs)")}`);
+    return lines;
   }
-
-  lines.push(hr("ACTIVE RUNS"));
-  if (model.panels.activeRuns.length === 0) lines.push("  (none)");
   for (const run of model.panels.activeRuns) {
-    const stall = run.stalled ? " [STALLED]" : "";
-    const err = run.error ? `  err=${run.error.code}: ${run.error.message}` : "";
+    const state = c.tint(stateTone(run.state), run.state);
+    const stall = run.stalled ? ` ${c.tint("yellow", "[stalled]", true)}` : "";
+    const card = run.cardNumber !== undefined ? c.faint(`card #${run.cardNumber}`) : c.faint("card —");
     lines.push(
-      `  ${run.themeLabel}: run ${run.id} [${run.state}]${stall}` +
-        `${run.cardNumber !== undefined ? ` card #${run.cardNumber}` : ""}${err}`
+      `   ${c.faint(GLYPH.bullet)} ${c.bold(run.id)}  ${state}${stall}  ${card} ${c.faint(GLYPH.dot)} ${c.dim(run.themeLabel)}`
     );
+    if (run.error) lines.push(`       ${c.tint("red", `${run.error.code}: ${run.error.message}`)}`);
   }
+  return lines;
+}
 
-  lines.push("");
-  lines.push(hr("WORKTREES / DOCTOR"));
-  lines.push(`doctor: ${model.panels.doctor.themeLabel} (goalClosable=${model.panels.doctor.goalClosable})`);
-  for (const blocker of model.panels.doctor.blockers) {
-    lines.push(`  ✗ ${blocker.code}: ${blocker.message}${blocker.workspaceKey ? ` [${blocker.workspaceKey}]` : ""}`);
+function renderWorktrees(model: CockpitModel, c: Painter, width: number): string[] {
+  const lines = [headingRule("Worktrees", width, c)];
+  if (model.panels.worktrees.length === 0) {
+    lines.push(`   ${c.dim("(no worktrees)")}`);
+    return lines;
   }
-  if (model.panels.worktrees.length === 0) lines.push("  (no worktrees)");
   for (const wt of model.panels.worktrees) {
     const flags = [wt.dirty ? "dirty" : null, wt.preserved ? "preserved" : null].filter(Boolean).join(",") || "clean";
-    lines.push(`  ${wt.themeLabel}: ${wt.workspaceKey} [${flags}] ${wt.path}`);
-    if (wt.recommendedAction) lines.push(`      action: ${wt.recommendedAction}`);
-  }
-
-  lines.push("");
-  lines.push(hr("ACTIVITY"));
-  if (model.panels.events.length === 0) lines.push("  (no events)");
-  for (const event of model.panels.events.slice(0, 10)) {
-    lines.push(`  [${event.severity}] ${event.themeLabel}: ${event.message}  (${event.at})`);
-  }
-
-  return lines;
-}
-
-function renderActions(model: CockpitModel): string[] {
-  const lines: string[] = [hr("ACTIONS")];
-  for (const action of model.actions) {
-    const state = action.enabled ? "enabled" : `disabled: ${action.disabledReason ?? "unavailable"}`;
-    lines.push(`  [${action.key ?? "?"}] ${action.label} — ${state}`);
-  }
-  return lines;
-}
-
-function renderFooter(model: CockpitModel): string[] {
-  return [
-    hr("FOOTER / KEYS"),
-    model.help.keys.map((entry) => `${entry.key}:${entry.description}`).join("   ")
-  ];
-}
-
-function renderCommandPalette(model: CockpitModel): string[] {
-  if (!model.commandPaletteOpen) return [];
-  const lines: string[] = [hr("COMMAND PALETTE")];
-  for (const row of model.commandPalette) {
-    const state = row.enabled ? "enabled" : `disabled: ${row.disabledReason ?? "unavailable"}`;
-    const mutates = row.mutates ? "mutates" : "read-only";
-    const backing = row.endpoint ?? row.command ?? row.section;
-    lines.push(`  [${row.key}] ${row.label} — ${state}, ${mutates}${backing ? ` (${backing})` : ""}`);
-  }
-  return lines;
-}
-
-function renderNextActions(model: CockpitModel): string[] {
-  if (model.nextActions.length === 0) return [];
-  const lines: string[] = [hr("NEXT ACTIONS")];
-  for (const action of model.nextActions) {
-    const state = action.enabled ? "enabled" : `disabled: ${action.disabledReason ?? "n/a"}`;
+    const flagTone: Tone = wt.dirty ? "yellow" : wt.preserved ? "cyan" : "green";
     lines.push(
-      `  ${action.label}: ${action.command} (${state}, ${action.mutates ? "mutates" : "read-only"})`
+      `   ${c.faint(GLYPH.bullet)} ${c.bold(wt.workspaceKey)}  ${c.tint(flagTone, flags)} ${c.faint(GLYPH.dot)} ${c.dim(wt.themeLabel)}`
+    );
+    lines.push(`       ${c.faint(truncateMiddle(wt.path, Math.max(12, width - 7)))}`);
+    if (wt.recommendedAction) lines.push(`       ${c.tint("yellow", `action: ${wt.recommendedAction}`)}`);
+  }
+  return lines;
+}
+
+function renderDoctor(model: CockpitModel, c: Painter, width: number): string[] {
+  const doctor = model.panels.doctor;
+  const tone: Tone = doctor.goalClosable ? "green" : "red";
+  const lines = [
+    headingRule("Doctor", width, c),
+    `   ${c.tint(tone, doctor.themeLabel, true)} ${c.faint(`(goalClosable=${doctor.goalClosable})`)}`
+  ];
+  if (doctor.blockers.length === 0) {
+    lines.push(`   ${c.dim("no blockers")}`);
+    return lines;
+  }
+  for (const blocker of doctor.blockers) {
+    const where = blocker.workspaceKey ? c.faint(` [${blocker.workspaceKey}]`) : "";
+    lines.push(`   ${c.tint("red", GLYPH.err)} ${c.bold(blocker.code)}: ${blocker.message}${where}`);
+    if (blocker.recommendedAction) lines.push(`       ${c.tint("yellow", `action: ${blocker.recommendedAction}`)}`);
+  }
+  return lines;
+}
+
+function renderManual(model: CockpitModel, c: Painter, width: number): string[] {
+  const lines = [headingRule("Factory Manual", width, c), `   ${c.bold(model.help.manualTitle)}`];
+  for (const capability of model.help.capabilities.slice(0, 12)) {
+    const state = capability.enabled ? c.tint("green", "enabled") : c.faint(`disabled: ${capability.disabledReason ?? "n/a"}`);
+    lines.push(`   ${c.faint(`[${capability.category}]`)} ${c.dim(capability.id)} — ${capability.title}  ${state}`);
+  }
+  return lines;
+}
+
+function renderEvents(model: CockpitModel, c: Painter, width: number): string[] {
+  const lines = [headingRule("Events", width, c)];
+  if (model.panels.events.length === 0) {
+    lines.push(`   ${c.dim("(no events)")}`);
+    return lines;
+  }
+  // Severity carries a distinct glyph (not color alone) so info/warning/error
+  // stay distinguishable under NO_COLOR / monochrome terminals, matching the
+  // attention strip and doctor markers.
+  const mark = (sev: string): { tone: Tone; glyph: string } =>
+    sev === "error"
+      ? { tone: "red", glyph: GLYPH.err }
+      : sev === "warning"
+        ? { tone: "yellow", glyph: GLYPH.warn }
+        : { tone: "blue", glyph: GLYPH.info };
+  for (const event of model.panels.events.slice(0, 12)) {
+    const m = mark(event.severity);
+    lines.push(
+      `   ${c.tint(m.tone, m.glyph)} ${c.faint(event.at)}  ${c.dim(event.themeLabel)}  ${event.message}`
     );
   }
   return lines;
 }
 
-export function renderCockpitText(model: CockpitModel): string {
-  const lines: string[] = [];
-  const header = model.header;
-
-  lines.push(hr("FIZZY-SYMPHONY COCKPIT (v2 spike)"));
-  lines.push(`Mode: ${model.app.mode}`);
-  lines.push(`Source: ${model.app.source}`);
-  lines.push(`Endpoint: ${model.app.endpoint ?? "—"}`);
-  lines.push(`Config: ${model.app.configPath}`);
-  lines.push(
-    `instance: ${header.instanceId}${header.instanceLabel ? ` (${header.instanceLabel})` : ""}` +
-      ``
-  );
-  lines.push(
-    `readiness=${header.readiness} factory=${FACTORY_STATE_LABELS[model.factoryState]}` +
-      ` runner=${header.runnerStatus ?? "unknown"}`
-  );
-  lines.push(`updated: ${header.lastUpdatedAt}`);
-  lines.push(fmtCounts(header.counts));
-
-  lines.push("");
-  lines.push(...renderSectionTabs(model));
-  lines.push("");
-  lines.push(...renderNextActions(model));
-  lines.push("");
-  lines.push(...renderSelectedSection(model));
-  lines.push("");
-  lines.push(...renderLegacySummary(model));
-  lines.push("");
-  lines.push(...renderActions(model));
-  lines.push("");
-  lines.push(...renderFooter(model));
-  lines.push("");
-  lines.push(...renderCommandPalette(model));
-
-  return lines.join("\n");
+function renderSettings(model: CockpitModel, c: Painter, width: number): string[] {
+  const s = model.settings;
+  const rows: Array<[string, string]> = [
+    ["mode", s.mode],
+    ["source", s.source],
+    ["config", s.configPath],
+    ["endpoint", s.endpoint ? String(s.endpoint) : "—"],
+    ["readiness", `${s.readiness} (${s.readinessBlockers} blocker(s))`],
+    ["runner", s.runnerStatus ?? "unknown"],
+    ["boards / routes", `${s.boardCount} / ${s.routeCount}`],
+    ["worktrees", `${s.workspaceCount} total, ${s.dirtyWorktrees} dirty`],
+    ["live endpoint", String(s.hasLiveEndpoint)]
+  ];
+  const keyWidth = Math.max(...rows.map(([key]) => key.length));
+  const valueBudget = Math.max(12, width - 5 - keyWidth);
+  const lines = [headingRule("Settings", width, c)];
+  for (const [key, value] of rows) {
+    lines.push(`   ${c.faint(padEndVisible(key, keyWidth))}  ${c.dim(truncateMiddle(value, valueBudget))}`);
+  }
+  return lines;
 }
 
-export function renderCapabilitiesText(model: CockpitModel): string {
+function renderAdvanced(model: CockpitModel, c: Painter, width: number): string[] {
+  const lines = [headingRule("Advanced commands", width, c)];
+  for (const command of model.advancedCommands) {
+    const state = command.enabled
+      ? c.tint("green", "enabled")
+      : c.faint(`disabled: ${command.disabledReason ?? "n/a"}`);
+    const mutates = command.mutates ? c.tint("magenta", "↯ mutates") : c.faint("read-only");
+    lines.push(`   ${c.bold(`[${command.key}]`)} ${c.dim(command.label)}  ${mutates} ${c.faint(GLYPH.dot)} ${state}`);
+    lines.push(`       ${c.faint(`${GLYPH.prompt} ${command.command}`)}`);
+  }
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Inspector: selection raw truth + actions + guidance commands.
+// ---------------------------------------------------------------------------
+
+function renderInspector(model: CockpitModel, c: Painter, width: number): string[] {
   const lines: string[] = [];
-  lines.push(hr(model.help.manualTitle));
+  lines.push(...renderSelection(model, c, width));
+  lines.push("");
+  lines.push(...renderActions(model, c, width));
+  const guidance = renderGuidance(model, c, width);
+  if (guidance.length > 0) {
+    lines.push("");
+    lines.push(...guidance);
+  }
+  return lines;
+}
+
+function renderSelection(model: CockpitModel, c: Painter, width: number): string[] {
+  const selection = model.selected;
+  if (!selection || selection.kind === "none") {
+    return [
+      headingRule("Inspect", width, c),
+      `   ${c.dim("nothing selected — use ↑/↓ to choose a card, run, or worktree, then Enter.")}`
+    ];
+  }
+  const lines = [
+    headingRule("Inspect", width, c),
+    `   ${c.bold(truncateMiddle(`${selection.kind} ${selection.id ?? ""}`.trim(), Math.max(8, width - 4)))}  ${c.dim(selection.themeLabel ?? "")}`
+  ];
+  const entries = Object.entries(selection.raw).filter(([, value]) => value !== undefined && value !== null);
+  const keyWidth = Math.max(0, ...entries.map(([key]) => key.length));
+  // Raw values (paths, ids, error JSON) are the truth-first payload: keep both
+  // ends legible with a middle ellipsis rather than clipping the tail.
+  const valueBudget = Math.max(12, width - 5 - keyWidth);
+  for (const [key, value] of entries) {
+    const text = typeof value === "object" ? JSON.stringify(value) : String(value);
+    lines.push(`   ${c.faint(padEndVisible(key, keyWidth))}  ${c.dim(truncateMiddle(text, valueBudget))}`);
+  }
+  if (selection.recommendedAction) {
+    lines.push(`   ${c.tint("yellow", `recommendedAction: ${selection.recommendedAction}`)}`);
+  }
+  return lines;
+}
+
+function renderActions(model: CockpitModel, c: Painter, width: number): string[] {
+  const mode = model.app.mode;
+  const lines = [
+    headingRule("Actions", width, c),
+    `   ${c.faint(`${GLYPH.dot} ↯ marks actions that mutate live state`)}`
+  ];
+  for (const action of model.actions) {
+    const key = c.bold(`[${action.key ?? "?"}]`);
+    const mutating = Boolean(action.commandType);
+    const mutates = mutating ? c.tint("magenta", "↯") : " ";
+    // operatorActionStatus enforces mode honesty: mutating actions never read
+    // "ready" in DEMO/SETUP/OFFLINE — only LIVE can.
+    const status = operatorActionStatus(mode, action.enabled, mutating, action.disabledReason, c);
+    lines.push(fitVisible(`   ${key} ${mutates} ${padEndVisible(action.label, 34)} ${status}`, width));
+  }
+  return lines;
+}
+
+function renderGuidance(model: CockpitModel, c: Painter, width: number): string[] {
+  const mode = model.app.mode;
+  if (mode !== "SETUP" && mode !== "OFFLINE" && mode !== "DEMO") return [];
+
+  const rows: Array<{ label: string; command: string }> = model.nextActions.map((action) => ({
+    label: action.label,
+    command: action.command
+  }));
+
+  if (mode === "OFFLINE") {
+    for (const id of ["status", "doctor", "dashboard"]) {
+      const command = model.advancedCommands.find((entry) => entry.id === id);
+      if (command) rows.push({ label: command.label, command: command.command });
+    }
+  }
+
+  if (rows.length === 0) return [];
+
+  const lines = [
+    headingRule("Next in your shell", width, c),
+    `   ${c.faint("guidance only — these are not run for you")}`
+  ];
+  for (const row of rows) {
+    lines.push(`   ${c.tint("green", GLYPH.prompt)} ${c.dim(row.command)}`);
+    lines.push(`       ${c.faint(row.label)}`);
+  }
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Command palette
+// ---------------------------------------------------------------------------
+
+function renderCommandPalette(model: CockpitModel, c: Painter, width: number): string[] {
+  if (!model.commandPaletteOpen) return [];
+  const mode = model.app.mode;
+  const sections = model.commandPalette.filter((row) => row.section);
+  const actions = model.commandPalette.filter((row) => row.id.startsWith("action."));
+  const commands = model.commandPalette.filter((row) => row.id.startsWith("advanced."));
+
+  const lines = [
+    headingRule("Command palette", width, c),
+    // Legend: explain the prefix convention so the keys read as a real menu,
+    // not a printed list of codes. Kept short enough to survive an 80-col clamp.
+    fitVisible(
+      `   ${c.faint(`A:key action ${GLYPH.dot} V:key command ${GLYPH.dot} number/letter jumps ${GLYPH.dot} Esc closes`)}`,
+      width
+    )
+  ];
+
+  lines.push(
+    fitVisible(
+      `   ${c.faint("sections")}  ${sections
+        .map((row) => `${c.bold(`[${row.key}]`)} ${c.dim(row.label.replace(/^Open | section$/gu, ""))}`)
+        .join(c.faint(`  ${GLYPH.dot} `))}`,
+      width
+    )
+  );
+
+  const keyWidth = Math.max(0, ...[...actions, ...commands].map((row) => row.key.length));
+
+  lines.push(`   ${c.faint("actions")}`);
+  for (const row of actions) {
+    const status = operatorActionStatus(mode, row.enabled, row.mutates, row.disabledReason, c);
+    const meta = row.mutates ? c.tint("magenta", "↯") : c.faint("ro");
+    lines.push(
+      fitVisible(`     ${c.bold(padEndVisible(row.key, keyWidth))} ${meta} ${padEndVisible(row.label, 30)} ${status}`, width)
+    );
+  }
+
+  lines.push(`   ${c.faint("commands")}`);
+  for (const row of commands) {
+    // Advanced commands are shell-command hints, not live daemon actions, so
+    // their availability is their own (e.g. dashboard needs a live endpoint);
+    // mode honesty for live mutations does not apply here.
+    const status = row.enabled
+      ? c.tint("green", "ready")
+      : c.faint(`off ${GLYPH.dot} ${row.disabledReason ?? "unavailable"}`);
+    const meta = row.mutates ? c.tint("magenta", "↯") : c.faint("ro");
+    const backing = row.endpoint ?? row.command ?? "";
+    lines.push(
+      fitVisible(`     ${c.bold(padEndVisible(row.key, keyWidth))} ${meta} ${padEndVisible(row.label, 22)} ${status}`, width)
+    );
+    if (backing) {
+      lines.push(fitVisible(`         ${c.faint(truncateMiddle(String(backing), Math.max(12, width - 9)))}`, width));
+    }
+  }
+
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Footer
+// ---------------------------------------------------------------------------
+
+function renderFooter(c: Painter, width: number): string[] {
+  const hints = [
+    "↑↓ navigate",
+    "Enter inspect",
+    "/ filter",
+    "⌃P palette",
+    "? manual",
+    "r refresh",
+    "q quit"
+  ];
+  return [frameRule(width, c), ` ${c.dim(hints.join(c.faint(`  ${GLYPH.dot} `)))}`];
+}
+
+// ---------------------------------------------------------------------------
+// Top-level
+// ---------------------------------------------------------------------------
+
+// A copyable command line (its visible content begins with the "$ " prompt).
+// These are meant to be pasted into a shell, so they are exempt from the width
+// clamp: a middle ellipsis would corrupt the command. They wrap instead.
+function isCopyableCommand(line: string): boolean {
+  return stripAnsi(line).trimStart().startsWith(`${GLYPH.prompt} `);
+}
+
+// Final hard guarantee: no rendered line overruns the frame at any width. Long
+// in-cell content is already middle-truncated where it matters (paths, ids,
+// values); this catches everything else (lane cards, runs, events, doctor,
+// manual, footer) without each renderer having to clamp by hand. Copyable
+// command lines are preserved verbatim.
+function clampLines(lines: string[], width: number): string[] {
+  return lines.map((line) => (isCopyableCommand(line) ? line : fitVisible(line, width)));
+}
+
+export function renderCockpitText(model: CockpitModel, options: RenderOptions = {}): string {
+  const c = createPainter(options.color === true);
+  const width = clampWidth(options.width);
+
+  const lines: string[] = [];
+  lines.push(...renderHeader(model, c, width));
+  lines.push(...renderAttention(model, c, width));
+  lines.push(...renderCounts(model, c, width));
+  lines.push("");
+  lines.push(...renderSectionRail(model, c, width));
+  lines.push("");
+  lines.push(...renderPrimary(model, c, width));
+  lines.push("");
+  lines.push(...renderInspector(model, c, width));
+  const palette = renderCommandPalette(model, c, width);
+  if (palette.length > 0) {
+    lines.push("");
+    lines.push(...palette);
+  }
+  lines.push("");
+  lines.push(...renderFooter(c, width));
+
+  return clampLines(lines, width).join("\n");
+}
+
+export function renderCapabilitiesText(model: CockpitModel, options: RenderOptions = {}): string {
+  const c = createPainter(options.color === true);
+  const width = clampWidth(options.width);
+  const lines = [headingRule(model.help.manualTitle, width, c)];
   for (const capability of model.help.capabilities) {
-    const state = capability.enabled ? "enabled" : `disabled: ${capability.disabledReason ?? "n/a"}`;
-    lines.push(`  [${capability.category}] ${capability.id} — ${capability.title} (${state})`);
+    const state = capability.enabled
+      ? c.tint("green", "enabled")
+      : c.faint(`disabled: ${capability.disabledReason ?? "n/a"}`);
+    lines.push(`   ${c.faint(`[${capability.category}]`)} ${c.dim(capability.id)} — ${capability.title}  ${state}`);
   }
   return lines.join("\n");
 }

--- a/test/cli-production-clients.test.js
+++ b/test/cli-production-clients.test.js
@@ -710,8 +710,8 @@ test("bare command opens cockpit LIVE when config exists", async () => {
     "http://127.0.0.1:4567/v2/status",
     "http://127.0.0.1:4567/v2/events"
   ]);
-  assert.match(result.stdout, /Mode: LIVE/u);
-  assert.match(result.stdout, /FIZZY-SYMPHONY COCKPIT/u);
+  assert.match(result.stdout, /\[ LIVE \]/u);
+  assert.match(result.stdout, /FIZZY-SYMPHONY/u);
 });
 
 test("bare command with missing config enters cockpit SETUP without constructing clients", async () => {
@@ -732,7 +732,7 @@ test("bare command with missing config enters cockpit SETUP without constructing
   });
 
   assert.equal(result.exitCode, 0, result.stderr);
-  assert.match(result.stdout, /Mode: SETUP/u);
+  assert.match(result.stdout, /\[ SETUP \]/u);
   assert.match(result.stdout, /fizzy-symphony setup/u);
 });
 

--- a/test/daemon.test.js
+++ b/test/daemon.test.js
@@ -351,7 +351,7 @@ test("daemon serves v2 status for live cockpit and capabilities discovery", asyn
       stdoutIsTTY: false
     });
     assert.equal(exitCode, 0);
-    assert.match(stdout, /FIZZY-SYMPHONY COCKPIT/);
+    assert.match(stdout, /FIZZY-SYMPHONY/);
     assert.match(stdout, /board_1|Agents/);
     assert.equal(stderr, "");
 

--- a/test/v2/cockpit-cli.test.js
+++ b/test/v2/cockpit-cli.test.js
@@ -30,10 +30,12 @@ test("cockpit --once prints a static frame (non-TTY safe)", async () => {
   const { io, out } = bufferIo({ stdoutIsTTY: false });
   const code = await runCockpitCommand(["--fixture", join(FIXTURE_DIR, "running-one-card.json"), "--once"], io);
   assert.equal(code, 0);
-  assert.match(out(), /Mode: DEMO/);
-  assert.match(out(), /FIZZY-SYMPHONY COCKPIT/);
+  assert.match(out(), /\[ DEMO \]/);
+  assert.match(out(), /FIZZY-SYMPHONY/);
   assert.match(out(), /Machine in motion/);
   assert.match(out(), /run_426/);
+  // non-TTY output is ANSI-free by default
+  assert.doesNotMatch(out(), /\x1b\[/);
 });
 
 test("cockpit --fixture packaged ready data stays DEMO", async () => {
@@ -44,7 +46,7 @@ test("cockpit --fixture packaged ready data stays DEMO", async () => {
   });
   const code = await runCockpitCommand(["--fixture", PACKAGED_READY_FIXTURE, "--once"], io);
   assert.equal(code, 0);
-  assert.match(out(), /Mode: DEMO/);
+  assert.match(out(), /\[ DEMO \]/);
   assert.match(out(), /Factory open/);
 });
 
@@ -62,8 +64,9 @@ test("cockpit without config enters setup without external clients", async () =>
   const code = await runCockpitCommand(["--config", join(dir, "config.yml"), "--once"], io);
   assert.equal(code, 0);
   assert.equal(requested.length, 0);
-  assert.match(out(), /Mode: SETUP/);
-  assert.match(out(), /setup/);
+  assert.match(out(), /\[ SETUP \]/);
+  assert.match(out(), /Setup needed/);
+  assert.match(out(), /fizzy-symphony setup --config/);
 });
 
 test("cockpit with config exists but no daemon/default disabled enters OFFLINE", async () => {
@@ -84,7 +87,8 @@ test("cockpit with config exists but no daemon/default disabled enters OFFLINE",
     "--once"
   ], io);
   assert.equal(code, 0);
-  assert.match(out(), /Mode: OFFLINE/);
+  assert.match(out(), /\[ OFFLINE \]/);
+  assert.match(out(), /Daemon offline/);
   assert.match(out(), /start.*daemon/i);
 });
 
@@ -114,7 +118,7 @@ test("cockpit with config can reach LIVE through default endpoint fallback witho
     "http://127.0.0.1:4567/v2/status",
     "http://127.0.0.1:4567/v2/events"
   ]);
-  assert.match(out(), /Mode: LIVE/);
+  assert.match(out(), /\[ LIVE \]/);
   assert.match(out(), /run_426/);
 });
 
@@ -137,7 +141,7 @@ test("cockpit with config enters OFFLINE when default endpoint is unreachable", 
 
   assert.equal(code, 0);
   assert.deepEqual(requested, ["http://127.0.0.1:4567/v2/status"]);
-  assert.match(out(), /Mode: OFFLINE/);
+  assert.match(out(), /\[ OFFLINE \]/);
   assert.match(out(), /start.*daemon/i);
 });
 
@@ -193,7 +197,7 @@ test("cockpit with config discovers a live v2 daemon from the registry", async (
 
   assert.equal(code, 0);
   assert.deepEqual(requested, [`${endpoint}/v2/status`, `${endpoint}/v2/events`]);
-  assert.match(out(), /Mode: LIVE/);
+  assert.match(out(), /\[ LIVE \]/);
   assert.match(out(), /run_426/);
   assert.equal(err(), "");
 });
@@ -203,7 +207,7 @@ test("cockpit falls back to static text in non-TTY without --once", async () => 
   const code = await runCockpitCommand(["--fixture", join(FIXTURE_DIR, "blocked-runner.json")], io);
   assert.equal(code, 0);
   assert.match(err(), /non-TTY detected/);
-  assert.match(out(), /Mode: DEMO/);
+  assert.match(out(), /\[ DEMO \]/);
   assert.match(out(), /Factory cannot close|blocked/);
 });
 

--- a/test/v2/fixtures-render.test.js
+++ b/test/v2/fixtures-render.test.js
@@ -18,21 +18,224 @@ test("every fixture loads, normalizes, and renders without throwing", () => {
     const status = normalizeStatus(raw.status);
     const model = createCockpitModel({ status, events: raw.events ?? [] });
     const text = renderCockpitText(model);
-    assert.match(text, /FIZZY-SYMPHONY COCKPIT/, `fixture ${name} should render header`);
-    assert.match(text, /ACTIONS/, `fixture ${name} should render actions`);
+    assert.match(text, /FIZZY-SYMPHONY/, `fixture ${name} should render header`);
+    assert.match(text, /Actions/, `fixture ${name} should render actions`);
   }
 });
 
 test("hazard states are visually obvious in rendered text", () => {
   const dirty = JSON.parse(readFileSync(join(FIXTURE_DIR, "dirty-worktree.json"), "utf8"));
-  const dirtyModel = createCockpitModel({ status: normalizeStatus(dirty.status) });
+  const dirtyModel = createCockpitModel({ status: normalizeStatus(dirty.status), selectedSectionId: "worktrees" });
   assert.match(renderCockpitText(dirtyModel), /Spill \/ hazard/);
 
   const failed = JSON.parse(readFileSync(join(FIXTURE_DIR, "failed-run.json"), "utf8"));
-  const failedModel = createCockpitModel({ status: normalizeStatus(failed.status) });
+  const failedModel = createCockpitModel({ status: normalizeStatus(failed.status), selectedSectionId: "runs" });
   assert.match(renderCockpitText(failedModel), /Jammed machine|RUNNER_ERROR/);
 
   const blocked = JSON.parse(readFileSync(join(FIXTURE_DIR, "blocked-runner.json"), "utf8"));
-  const blockedModel = createCockpitModel({ status: normalizeStatus(blocked.status) });
+  const blockedModel = createCockpitModel({ status: normalizeStatus(blocked.status), selectedSectionId: "doctor" });
   assert.match(renderCockpitText(blockedModel), /Factory cannot close/);
+});
+
+test("attention strip surfaces the highest-priority hazard", () => {
+  const dirty = JSON.parse(readFileSync(join(FIXTURE_DIR, "dirty-worktree.json"), "utf8"));
+  const dirtyModel = createCockpitModel({ status: normalizeStatus(dirty.status) });
+  assert.match(renderCockpitText(dirtyModel), /Factory cannot close/);
+});
+
+test("non-TTY render is ANSI-free, color render emits truecolor escapes", () => {
+  const ready = JSON.parse(readFileSync(join(FIXTURE_DIR, "running-one-card.json"), "utf8"));
+  const model = createCockpitModel({ status: normalizeStatus(ready.status) });
+  assert.doesNotMatch(renderCockpitText(model), /\x1b\[/);
+  assert.match(renderCockpitText(model, { color: true }), /\x1b\[38;2;/);
+});
+
+test("width option scales the frame rule", () => {
+  const ready = JSON.parse(readFileSync(join(FIXTURE_DIR, "running-one-card.json"), "utf8"));
+  const model = createCockpitModel({ status: normalizeStatus(ready.status) });
+  const narrow = renderCockpitText(model, { width: 48 }).split("\n")[0];
+  const wide = renderCockpitText(model, { width: 120 }).split("\n")[0];
+  assert.equal(narrow.length, 48);
+  assert.equal(wide.length, 120);
+});
+
+const stripAnsi = (text) => text.replace(/\x1b\[[0-9;]*m/gu, "");
+const visibleWidth = (line) => [...stripAnsi(line)].length;
+
+test("header, attention, counts, and section rail never overrun width (40/80/120)", () => {
+  const ready = JSON.parse(readFileSync(join(FIXTURE_DIR, "running-one-card.json"), "utf8"));
+  const model = createCockpitModel({ status: normalizeStatus(ready.status), events: ready.events ?? [] });
+  for (const width of [40, 80, 120]) {
+    const lines = renderCockpitText(model, { width }).split("\n");
+    // Frame rules are exactly the requested width.
+    assert.equal(visibleWidth(lines[0]), width, `frame should equal width ${width}`);
+    // The critical glance region: header (6) + attention + counts + blank + rail.
+    const critical = lines.slice(0, 10);
+    for (const line of critical) {
+      assert.ok(
+        visibleWidth(line) <= width,
+        `line "${stripAnsi(line)}" (${visibleWidth(line)}) exceeds width ${width}`
+      );
+    }
+  }
+});
+
+test("DEMO shows the fixture source, never a fixture endpoint as a live daemon", () => {
+  const ready = JSON.parse(readFileSync(join(FIXTURE_DIR, "running-one-card.json"), "utf8"));
+  const model = createCockpitModel({
+    status: normalizeStatus(ready.status),
+    events: ready.events ?? [],
+    app: {
+      mode: "DEMO",
+      source: "fixture /abs/path/running-one-card.json",
+      configPath: "/abs/.fizzy-symphony/config.yml",
+      endpoint: "http://127.0.0.1:4567"
+    }
+  });
+  const text = stripAnsi(renderCockpitText(model));
+  assert.match(text, /\[ DEMO \]/);
+  assert.match(text, /source .*fixture/);
+  assert.match(text, /demo data/);
+  // The embedded endpoint must not be presented on a "daemon ●" live line.
+  assert.doesNotMatch(text, /daemon ● http:\/\/127\.0\.0\.1:4567/);
+});
+
+test("DEMO source line preserves the demo-data label with long fixture paths", () => {
+  const ready = JSON.parse(readFileSync(join(FIXTURE_DIR, "ready.json"), "utf8"));
+  const model = createCockpitModel({
+    status: normalizeStatus(ready.status),
+    app: {
+      mode: "DEMO",
+      source:
+        "fixture /var/home/kdlocpanda/second_brain/Resources/virtualization/docker/37signals/agent_stuff/fizzy-symphony/src/v2/fixtures/ready.json",
+      configPath: "/abs/.fizzy-symphony/config.yml"
+    }
+  });
+  const sourceLine = stripAnsi(renderCockpitText(model, { width: 100 }))
+    .split("\n")
+    .find((line) => line.includes("source"));
+  assert.ok(sourceLine, "expected a DEMO source line");
+  assert.match(sourceLine, /\(demo data\)/);
+  assert.ok(visibleWidth(sourceLine) <= 100, `source line exceeds width: ${sourceLine}`);
+});
+
+test("SETUP and OFFLINE never show live mutating actions as ready", () => {
+  const ready = JSON.parse(readFileSync(join(FIXTURE_DIR, "running-one-card.json"), "utf8"));
+  const status = normalizeStatus(ready.status);
+  for (const mode of ["SETUP", "OFFLINE"]) {
+    const model = createCockpitModel({
+      status,
+      app: { mode, source: `config /abs/config.yml`, configPath: "/abs/config.yml", endpoint: undefined }
+    });
+    const text = stripAnsi(renderCockpitText(model));
+    const actionsBlock = text.slice(text.indexOf(" Actions "));
+    // Every mutating action line (marked ↯) must read "off ·", never "ready".
+    for (const line of actionsBlock.split("\n")) {
+      if (line.includes("↯") && /\[[a-zA-Z]\]/.test(line)) {
+        assert.match(line, /off ·/, `${mode}: mutating action should be disabled: ${line}`);
+        assert.doesNotMatch(line, /\bready\b/, `${mode}: mutating action must not be ready: ${line}`);
+      }
+    }
+    // Guidance-only shell commands remain visible.
+    assert.match(text, /Next in your shell/);
+  }
+});
+
+test("DEMO marks mutating actions as demo data, never live-ready", () => {
+  // A fixture is not a daemon, so a mutating action in DEMO must read "demo"
+  // (fixture data) and never the live-ready "ready" — in actions and palette.
+  const ready = JSON.parse(readFileSync(join(FIXTURE_DIR, "running-one-card.json"), "utf8"));
+  const model = createCockpitModel({
+    status: normalizeStatus(ready.status),
+    selectedId: "card_426", // gives run.cancel/session.stop a valid live target
+    commandPaletteOpen: true,
+    app: { mode: "DEMO", source: "fixture running-one-card.json", configPath: "/abs/config.yml" }
+  });
+  const text = stripAnsi(renderCockpitText(model));
+  for (const line of text.split("\n")) {
+    // mutating action rows are marked ↯ and carry an action key like [c] or A:c
+    if (line.includes("↯") && /(\[[a-zA-Z]\]|A:[a-zA-Z])/.test(line)) {
+      assert.match(line, /demo ·/, `DEMO mutating action should read demo: ${line}`);
+      assert.doesNotMatch(line, /\bready\b/, `DEMO mutating action must not be ready: ${line}`);
+    }
+  }
+});
+
+test("command palette explains its prefix convention", () => {
+  const ready = JSON.parse(readFileSync(join(FIXTURE_DIR, "ready.json"), "utf8"));
+  const model = createCockpitModel({
+    status: normalizeStatus(ready.status),
+    commandPaletteOpen: true
+  });
+  const text = stripAnsi(renderCockpitText(model));
+  assert.match(text, /A:key action/);
+  assert.match(text, /V:key command/);
+  assert.match(text, /Esc closes/);
+});
+
+test("event severity is distinguishable without color (no color-only semantics)", () => {
+  // info/warning/error must carry a distinct glyph, not just a tint, so the
+  // distinction survives NO_COLOR / monochrome terminals.
+  const wh = JSON.parse(readFileSync(join(FIXTURE_DIR, "webhook-error.json"), "utf8"));
+  const model = createCockpitModel({
+    status: normalizeStatus(wh.status),
+    events: wh.events ?? [],
+    selectedSectionId: "events"
+  });
+  const text = stripAnsi(renderCockpitText(model)); // color OFF
+  const eventsBlock = text.slice(text.indexOf(" Events "));
+  // error rows carry ✗, info rows carry ◆ — both present and different.
+  assert.match(eventsBlock, /✗/, "error severity needs a distinct glyph under no-color");
+  assert.match(eventsBlock, /◆/, "info severity needs a distinct glyph under no-color");
+});
+
+test("no rendered line overruns the frame at any width (copyable commands exempt)", () => {
+  // The width clamp is the final hard guarantee: at any width, every line fits
+  // the frame except copyable "$ <command>" lines, which must stay verbatim so
+  // an operator can paste them. Exercise every fixture, every section, palette
+  // open, with a selection (the densest, longest-content frames).
+  const sections = ["factory", "runs", "worktrees", "doctor", "manual", "events", "settings", "advanced"];
+  for (const name of fixtures) {
+    const raw = JSON.parse(readFileSync(join(FIXTURE_DIR, name), "utf8"));
+    const status = normalizeStatus(raw.status);
+    const selectedId = status.cards[0]?.id ?? status.worktrees[0]?.workspaceKey;
+    for (const width of [40, 56, 80, 120]) {
+      for (const selectedSectionId of sections) {
+        const model = createCockpitModel({
+          status,
+          events: raw.events ?? [],
+          selectedId,
+          selectedSectionId,
+          commandPaletteOpen: true
+        });
+        const lines = renderCockpitText(model, { width }).split("\n");
+        // Frame rules are exactly the requested width.
+        assert.equal(visibleWidth(lines[0]), width, `${name} @${width}: frame should equal width`);
+        for (const line of lines) {
+          const plain = stripAnsi(line);
+          const isCopyable = plain.trimStart().startsWith("$ ");
+          if (!isCopyable) {
+            assert.ok(
+              visibleWidth(line) <= width,
+              `${name} @${width} (${selectedSectionId}): "${plain}" (${visibleWidth(line)}) exceeds width`
+            );
+          }
+        }
+      }
+    }
+  }
+});
+
+test("copyable shell commands are preserved verbatim (not ellipsized)", () => {
+  // A long absolute config path would overrun 80 cols; the guidance command
+  // must keep the full path so it pastes correctly.
+  const ready = JSON.parse(readFileSync(join(FIXTURE_DIR, "ready.json"), "utf8"));
+  const longPath = "/very/long/absolute/path/to/some/deeply/nested/workspace/.fizzy-symphony/config.yml";
+  const model = createCockpitModel({
+    status: normalizeStatus(ready.status),
+    app: { mode: "OFFLINE", source: "config", configPath: longPath, endpoint: undefined }
+  });
+  const text = stripAnsi(renderCockpitText(model, { width: 80 }));
+  assert.match(text, new RegExp(`\\$ fizzy-symphony start --config ${longPath.replace(/[/.]/gu, "\\$&")}`));
+  assert.doesNotMatch(text, /fizzy-symphony start --config \S*…/);
 });

--- a/test/v2/interactive.test.js
+++ b/test/v2/interactive.test.js
@@ -135,3 +135,102 @@ test("interactive cockpit quits on ESCAPE", async () => {
   await session.done; // resolves
   assert.ok(true);
 });
+
+test("DEMO refuses to dispatch mutating actions (no command, no event)", async () => {
+  // A fixture is not a daemon: a mutating action in DEMO must be disabled
+  // behaviorally, not merely relabeled. The same fixture in LIVE still dry-runs.
+  const term = fakeTerminal();
+  const runtime = loadRuntime("running-one-card.json");
+  const session = await startInteractiveCockpit({
+    runtime,
+    app: { mode: "DEMO", source: "fixture running-one-card.json", configPath: "/x/config.yml" },
+    terminalFactory: async () => term
+  });
+  session.handleKey("DOWN"); // select card_426 (has runId/sessionId)
+  assert.equal(session.currentModel().selected.raw.runId, "run_426");
+
+  // Direct key and palette dispatch both route through submit(); neither acts.
+  session.handleKey("c"); // run.cancel
+  assert.match(term.frames.at(-1), /disabled/i);
+  assert.match(term.frames.at(-1), /fixture data \(DEMO\)/);
+
+  session.handleKey("CTRL_P");
+  session.handleKey("A");
+  session.handleKey("c");
+  assert.match(term.frames.at(-1), /disabled/i);
+
+  // Nothing was enqueued: no dry-run event was emitted for the cancel.
+  assert.ok(
+    !runtime.getEvents(20).some((event) => event.type === "command.dry-run.run.cancel"),
+    "DEMO must not produce a dry-run command event"
+  );
+
+  session.handleKey("q");
+  await session.done;
+});
+
+test("interactive / filter narrows lane cards live, Enter keeps, Esc clears", async () => {
+  const term = fakeTerminal();
+  const runtime = loadRuntime("running-multiple-cards.json");
+  const session = await startInteractiveCockpit({
+    runtime,
+    app: { mode: "LIVE", source: "x", configPath: "/x", endpoint: "http://127.0.0.1:4510" },
+    terminalFactory: async () => term
+  });
+  const cardCount = () => session.currentModel().lanes.flatMap((lane) => lane.cards).length;
+  const before = cardCount();
+  assert.ok(before > 1, "fixture should have several cards");
+
+  session.handleKey("/"); // enter capture
+  assert.match(term.frames.at(-1), /filter:/);
+  for (const ch of "cockpit") session.handleKey(ch); // selective term
+  const narrowed = cardCount();
+  assert.ok(narrowed < before, "typing should narrow the visible cards");
+  assert.match(term.frames.at(-1), new RegExp(`${narrowed} match`));
+
+  session.handleKey("BACKSPACE"); // edits the draft, stays in capture
+  assert.match(term.frames.at(-1), /filter: cockpi▏/u);
+
+  session.handleKey("ENTER"); // apply
+  assert.match(term.frames.at(-1), /filter "cockpi"/);
+  assert.ok(cardCount() < before, "applied filter persists");
+
+  session.handleKey("/"); // re-open, then cancel
+  session.handleKey("ESCAPE");
+  assert.equal(cardCount(), before, "Esc clears the filter");
+  // Esc in filter mode must NOT quit the session.
+  assert.equal(session.currentModel().selectedSectionId, "factory");
+
+  // Navigation works again after exiting filter mode.
+  session.handleKey("2");
+  assert.equal(session.currentModel().selectedSectionId, "runs");
+
+  session.handleKey("q");
+  await session.done;
+});
+
+test("Esc closes the command palette instead of quitting the session", async () => {
+  const term = fakeTerminal();
+  const runtime = loadRuntime("running-multiple-cards.json");
+  const session = await startInteractiveCockpit({ runtime, terminalFactory: async () => term });
+  session.handleKey("CTRL_P");
+  assert.equal(session.currentModel().commandPaletteOpen, true);
+  session.handleKey("ESCAPE"); // dismiss overlay, must NOT quit
+  assert.equal(session.currentModel().commandPaletteOpen, false);
+  assert.match(term.frames.at(-1), /Command palette closed/);
+  // Session is still alive: navigation works.
+  session.handleKey("2");
+  assert.equal(session.currentModel().selectedSectionId, "runs");
+  session.handleKey("q");
+  await session.done;
+});
+
+test("Ctrl-C quits even while the filter is capturing", async () => {
+  const term = fakeTerminal();
+  const runtime = loadRuntime("running-multiple-cards.json");
+  const session = await startInteractiveCockpit({ runtime, terminalFactory: async () => term });
+  session.handleKey("/"); // enter capture
+  session.handleKey("CTRL_C"); // universal escape hatch must still quit
+  await session.done; // resolves — otherwise this test hangs
+  assert.ok(true);
+});


### PR DESCRIPTION
## Summary
- Adds ANSI-aware cockpit rendering with optional color support, terminal-width handling, and consistent monochrome fallback.
- Reworks the cockpit layout into a more structured operator screen with stronger status, counts, section, and detail rails.
- Adds interactive `/` filter entry with live narrowing, Enter-to-keep, Esc-to-clear, and explicit status updates.
- Improves DEMO/LIVE/OFFLINE/SETUP honesty so fixture data and unavailable daemon states cannot present as actionable live state.
- Expands coverage across cockpit rendering, interactive behavior, CLI output, and production-client paths.

## Testing
- `Not run` automated tests in this turn.
- Existing/new test coverage includes cockpit CLI, interactive key handling, fixture rendering, daemon behavior, and production client checks.
- Suggested verification: run the focused cockpit test suite and a CLI smoke check in both TTY and non-TTY modes.